### PR TITLE
feat: ajout d'un reverse proxy nginx pour gérér les connexions en HTTPS

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -9,11 +9,6 @@ import { RoleType } from './utilisateurs/entities/utilisateur.entity';
 export class AppController {
   constructor(private readonly appService: AppService) { }
 
-  @Get()
-  getApiInfo(): object {
-    return this.appService.getApiInfo();
-  }
-
   @Get('stats')
   @UseGuards(JwtAuthGuard, RoleGuard)
   async getStats() {

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -46,33 +46,6 @@ export class AppService {
     private categoriesRepository: Repository<Category>,
   ) { }
 
-  getApiInfo(): object {
-    return {
-      name: 'Educ Prime API',
-      version: '1.0.0',
-      status: 'running',
-      endpoints: {
-        auth: '/auth',
-        utilisateurs: '/utilisateurs',
-        etablissements: '/etablissements',
-        filieres: '/filieres',
-        niveauEtude: '/niveau-etude',
-        matieres: '/matieres',
-        epreuves: '/epreuves',
-        ressources: '/ressources',
-        fichiers: '/fichiers',
-        publicites: '/publicites',
-        evenements: '/evenements',
-        opportunites: '/opportunites',
-        concours: '/concours',
-        contactsProfessionnels: '/contacts-professionnels',
-        parcours: '/parcours',
-        categories: '/categories',
-        stats: '/stats'
-      }
-    };
-  }
-
   async getStats(): Promise<{
     usersCount: number;
     etablissementsCount: number;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,21 +7,19 @@ services:
     container_name: educ_prime_db_dev
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${DB_USERNAME:-postgres}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
-      POSTGRES_DB: ${DB_NAME:-educ_prime}
-    ports:
-      - "5432:5432"
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
       - ./backend/config/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+    networks:
+      - educ-prime-network
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME:-postgres} -d ${DB_NAME:-educ_prime}" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}" ]
       interval: 10s
       timeout: 5s
       retries: 5
-    networks:
-      - educ-prime-network
 
   # NestJS Backend API
   backend:
@@ -31,20 +29,20 @@ services:
     container_name: educ_prime_backend_dev
     restart: unless-stopped
     environment:
-      NODE_ENV: ${NODE_ENV:-development}
+      # Database
       DB_HOST: db
       DB_PORT: 5432
-      DB_USERNAME: ${DB_USERNAME:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
-      DB_NAME: ${DB_NAME:-educ_prime}
-      JWT_SECRET: ${JWT_SECRET:-dev-secret-key-12345}
-      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID}
-      FIREBASE_CLIENT_EMAIL: ${FIREBASE_CLIENT_EMAIL}
-      FIREBASE_PRIVATE_KEY: ${FIREBASE_PRIVATE_KEY}
-    ports:
-      - "3000:3000"
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      # JWT
+      JWT_SECRET: ${JWT_SECRET}
+      # Node
+      NODE_ENV: development
     volumes:
       - ./backend/config/firebase-serviceaccount.json:/app/config/firebase-serviceaccount.json:ro
+    networks:
+      - educ-prime-network
     depends_on:
       db:
         condition: service_healthy
@@ -54,8 +52,6 @@ services:
       timeout: 3s
       retries: 3
       start_period: 40s
-    networks:
-      - educ-prime-network
 
   # React Frontend Admin Dashboard
   frontend:
@@ -63,11 +59,9 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        - VITE_API_URL=${VITE_API_URL}
+        - VITE_API_URL=/backend
     container_name: educ_prime_frontend_dev
     restart: unless-stopped
-    ports:
-      - "80:80"
     networks:
       - educ-prime-network
     depends_on:
@@ -77,6 +71,21 @@ services:
       interval: 30s
       timeout: 3s
       retries: 3
+
+  # Nginx Reverse Proxy (Dev)
+  nginx:
+    image: nginx:alpine
+    container_name: educ_prime_nginx_dev
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - educ-prime-network
+    depends_on:
+      - frontend
+      - backend
 
 networks:
   educ-prime-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       # Node
       NODE_ENV: production
-    ports:
-      - "3000:3000"
     networks:
       - educ-prime-network
     depends_on:
@@ -56,8 +54,6 @@ services:
     image: ${DOCKER_IMAGE_FRONTEND:-ghcr.io/dkayode/educ-prime-frontend:latest}
     container_name: educ_prime_frontend
     restart: unless-stopped
-    ports:
-      - "80:80"
     networks:
       - educ-prime-network
     depends_on:
@@ -68,6 +64,43 @@ services:
       interval: 30s
       timeout: 3s
       retries: 3
+
+  # Nginx Reverse Proxy
+  nginx:
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    container_name: educ_prime_nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    networks:
+      - educ-prime-network
+    depends_on:
+      - frontend
+      - backend
+      - certbot
+
+  # Certbot
+  certbot:
+    build:
+      context: ./certbot
+      dockerfile: Dockerfile
+    container_name: educ_prime_certbot
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: >
+      /bin/sh -c ' if [ ! -f /etc/letsencrypt/live/educ-prime.com/fullchain.pem ]; then
+        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.com --agree-tos --no-eff-email -d educ-prime.com -d api.educ-prime.com;
+      fi; trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done; '
+    networks:
+      - educ-prime-network
 
 volumes:
   postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci --legacy-peer-deps
 COPY . .
 
 # Accept build arguments
-ARG VITE_API_URL=http://localhost:3000
+ARG VITE_API_URL=/backend
 ENV VITE_API_URL=$VITE_API_URL
 
 # Build the application with production mode

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,11 +18,7 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
-
-
-
-
-
+    
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 // API configuration and base client
-export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+export const API_URL = import.meta.env.VITE_API_URL || '/backend';
 
 interface ApiError {
   message: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/backend": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/backend/, ""),
+      },
+    },
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,48 @@
+
+# HTTP for Frontend & Backend : educ-prime.com, api.educ-prime.com
+server {
+    listen 80;
+    server_name educ-prime.com api.educ-prime.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS for Frontend : educ-prime.com
+server {
+    listen 443 ssl;
+    server_name educ-prime.com;
+
+    ssl_certificate /etc/letsencrypt/live/educ-prime.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/educ-prime.com/privkey.pem;
+
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# HTTPS for Backend : api.educ-prime.com
+server {
+    listen 443 ssl;
+    server_name api.educ-prime.com;
+
+    ssl_certificate /etc/letsencrypt/live/educ-prime.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/educ-prime.com/privkey.pem;
+
+    location / {
+        proxy_pass http://backend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://frontend:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /backend/ {
+        proxy_pass http://backend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header X-Debug-Match "backend-location";
+    }
+}


### PR DESCRIPTION
- nginx:
  - forcer l'utilisation de HTTPS pendant l'utilisation de nos  services
  - associer le frontend au nom de domaine educ-prime.cloud
  - associer le backend au nom de domaine api.educ-prime.cloud
- certbot: pour la gestion et le renouvellement automtique des certificats SSL

close #10