### PR TITLE
fix(deploy): bootstrap let's encrypt certs and clean up stale env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,10 @@ jobs:
           port: ${{ secrets.VPS_PORT || 22 }}
           envs: COMPOSE_CONTENT,NGINX_CONTENT
           script: |
-            DEPLOY_DIR=${{ '/root/edukia' }}
+            set -e
+            DEPLOY_DIR=/root/edukia
+            PRIMARY_DOMAIN=educ-prime.com
+            CERT_EMAIL=support@educ-prime.cloud
 
             # Créer le répertoire de déploiement
             mkdir -p "$DEPLOY_DIR/backend/config"
@@ -57,9 +60,6 @@ jobs:
 
             # Créer le fichier .env avec les secrets
             cat > .env << 'ENV_EOF'
-            DB_USERNAME=${{ secrets.DB_USERNAME }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
-            DB_NAME=${{ secrets.DB_NAME }}
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             JWT_SECRET=${{ secrets.JWT_SECRET }}
             FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
@@ -83,19 +83,61 @@ jobs:
             # Créer le fichier nginx.conf depuis le contenu du repo
             echo "$NGINX_CONTENT" | base64 -d > ./nginx/nginx.conf
 
-            # Arrêter les conteneurs
-            docker-compose stop backend frontend redis
-            docker-compose rm -f backend frontend redis
+            # Bootstrap Let's Encrypt: si aucun certificat n'existe pour le
+            # domaine, créer un certificat auto-signé temporaire pour que
+            # nginx puisse démarrer. Sinon le challenge HTTP-01 est bloqué
+            # par le fait que nginx refuse de démarrer sans certificat.
+            CERT_DIR="$DEPLOY_DIR/certbot/conf/live/$PRIMARY_DOMAIN"
+            BOOTSTRAP_NEEDED=0
+            if [ ! -s "$CERT_DIR/fullchain.pem" ]; then
+              echo "=== Aucun certificat trouvé pour $PRIMARY_DOMAIN — création d'un dummy"
+              mkdir -p "$CERT_DIR"
+              docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                --entrypoint openssl certbot/certbot \
+                req -x509 -nodes -newkey rsa:4096 -days 1 \
+                -keyout "/etc/letsencrypt/live/$PRIMARY_DOMAIN/privkey.pem" \
+                -out "/etc/letsencrypt/live/$PRIMARY_DOMAIN/fullchain.pem" \
+                -subj "/CN=localhost"
+              BOOTSTRAP_NEEDED=1
+            fi
+
+            # Arrêter les conteneurs applicatifs (laisser db, redis, certbot, nginx)
+            docker-compose stop backend frontend
+            docker-compose rm -f backend frontend
 
             # Pull les dernières images
             docker-compose pull backend frontend redis
 
-            # Démarrer les conteneurs
+            # Démarrer la pile (nginx avec dummy cert si nécessaire)
             docker-compose up -d --remove-orphans
 
+            # Si on a démarré avec un dummy cert, demander un vrai certificat
+            # à Let's Encrypt via webroot (nginx est maintenant up sur le 80).
+            if [ "$BOOTSTRAP_NEEDED" = "1" ]; then
+              echo "=== Suppression du dummy cert et émission du vrai certificat"
+              docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                --entrypoint sh certbot/certbot \
+                -c "rm -rf /etc/letsencrypt/live/$PRIMARY_DOMAIN /etc/letsencrypt/archive/$PRIMARY_DOMAIN /etc/letsencrypt/renewal/$PRIMARY_DOMAIN.conf"
 
-            # Recharger nginx
-            docker-compose exec nginx nginx -s reload
+              docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                -v "$DEPLOY_DIR/certbot/www:/var/www/certbot" \
+                certbot/certbot certonly --webroot \
+                  --webroot-path=/var/www/certbot \
+                  --email "$CERT_EMAIL" --agree-tos --no-eff-email \
+                  --rsa-key-size 4096 \
+                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN"
+
+              # Recharger nginx avec le vrai certificat
+              docker-compose exec -T nginx nginx -s reload
+            fi
+
+            # Recharger nginx pour prendre en compte d'éventuels changements
+            # de configuration. On ne fail pas si nginx n'est pas up — le
+            # diagnostic ci-dessous montrera l'état réel.
+            docker-compose exec -T nginx nginx -s reload || true
 
             # Attendre un peu pour que les conteneurs démarrent
             sleep 10
@@ -103,9 +145,11 @@ jobs:
             # Afficher l'état des conteneurs
             docker-compose ps
 
-            # Afficher les logs du backend pour diagnostic
+            # Afficher les logs pour diagnostic
             echo "=== Backend logs ==="
             docker-compose logs --tail=50 backend
+            echo "=== Nginx logs ==="
+            docker-compose logs --tail=20 nginx
 
       - name: Notify deployment status
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,6 @@
 version: '3.8'
 
 services:
-  # PostgreSQL Database
-  db:
-    image: postgres:15-alpine
-    container_name: educ_prime_db
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${DB_USERNAME}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ./backend/config/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
-    networks:
-      - educ-prime-network
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME}" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   # Redis for BullMQ Queue
   redis:
     image: redis:7-alpine
@@ -116,7 +96,7 @@ services:
   # Certbot
   certbot:
     image: certbot/certbot
-    container_name: educ_prime_certbot
+    container_name: edukia_certbot
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot


### PR DESCRIPTION
Three changes that combine to make a fresh-VPS deploy actually work:

1. Cert bootstrap (the headline fix). nginx refuses to start without the SSL cert files at /etc/letsencrypt/live/educ-prime.com/, but the certbot sidecar can't issue a cert without nginx running on port 80 to serve the ACME HTTP-01 challenge — classic deadlock.

   The deploy script now:
   - Detects whether a cert exists for $PRIMARY_DOMAIN.
   - If not, drops a 1-day self-signed dummy cert at the expected path so nginx starts.
   - Brings the stack up.
   - Removes the dummy cert files and runs `certbot certonly --webroot` once to get a real Let's Encrypt cert.
   - Reloads nginx. On subsequent deploys the certs already exist, the bootstrap is skipped, and the certbot sidecar handles renewals every 12h.

2. Drop DB_USERNAME / DB_PASSWORD / DB_NAME from the composed .env. The backend reads DATABASE_URL only (Neon), and the local db: postgres service was removed from docker-compose.yml — those three vars had nothing left consuming them.

3. The final `docker-compose exec nginx nginx -s reload` no longer tanks the deploy with `set -e` if nginx isn't running for some reason (`|| true`). Diagnostic logs include nginx alongside backend so failures are easier to triage from the run log.

Also: educ_prime_certbot → edukia_certbot to match the rest of the container naming.