### PR TITLE
feat(jobkia): add type_contrat to services and offres

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -471,6 +471,7 @@ model types {
 
 model services {
   id               Int                  @id @default(autoincrement())
+  type_contrat     String               @default("hybride") @db.VarChar(20)
   pays             String               @default("benin") @db.VarChar(50)
   titre            String               @db.VarChar(255)
   description      String               @db.Text
@@ -552,6 +553,7 @@ model competences {
 
 model offres {
   id               Int                  @id @default(autoincrement())
+  type_contrat     String               @default("hybride") @db.VarChar(20)
   titre            String               @db.VarChar(255)
   description      String               @db.Text
   type_id          Int

--- a/backend/src/common/enums/type-contrat.enum.ts
+++ b/backend/src/common/enums/type-contrat.enum.ts
@@ -1,0 +1,5 @@
+export enum TypeContratEnum {
+    PRESENTIEL = 'presentiel',
+    HYBRIDE = 'hybride',
+    REMOTE = 'remote',
+}

--- a/backend/src/offres/dto/offre.dto.ts
+++ b/backend/src/offres/dto/offre.dto.ts
@@ -1,6 +1,7 @@
 import { IsString, IsNotEmpty, IsNumber, IsOptional, IsArray, IsEnum } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ServiceStatusEnum } from '../../common/enums/service-status.enum';
+import { TypeContratEnum } from '../../common/enums/type-contrat.enum';
 
 export class CreateOffreDto {
     @ApiProperty({ description: 'Titre de l\'offre', example: 'Recherche développeur React' })
@@ -43,6 +44,11 @@ export class CreateOffreDto {
     @IsOptional()
     @IsString({ each: true })
     competences?: string[];
+
+    @ApiProperty({ description: 'Modalité de travail', enum: TypeContratEnum, example: TypeContratEnum.HYBRIDE })
+    @IsEnum(TypeContratEnum)
+    @IsNotEmpty()
+    type_contrat: TypeContratEnum;
 }
 
 export class UpdateOffreDto {
@@ -81,6 +87,11 @@ export class UpdateOffreDto {
     @IsOptional()
     @IsString({ each: true })
     competences?: string[];
+
+    @ApiPropertyOptional({ description: 'Modalité de travail', enum: TypeContratEnum })
+    @IsEnum(TypeContratEnum)
+    @IsOptional()
+    type_contrat?: TypeContratEnum;
 }
 
 export class UpdateOffreStatusDto {

--- a/backend/src/offres/entities/offre.entity.ts
+++ b/backend/src/offres/entities/offre.entity.ts
@@ -3,6 +3,7 @@ import { Type } from '../../types/entities/type.entity';
 import { Utilisateur } from '../../utilisateurs/entities/utilisateur.entity';
 import { Competence } from '../../competences/entities/competence.entity';
 import { ServiceStatusEnum } from '../../common/enums/service-status.enum';
+import { TypeContratEnum } from '../../common/enums/type-contrat.enum';
 
 export { ServiceStatusEnum };
 
@@ -40,6 +41,9 @@ export class Offre {
 
     @Column({ type: 'enum', enum: ServiceStatusEnum, default: ServiceStatusEnum.PENDING_APPROVAL })
     status: ServiceStatusEnum;
+
+    @Column({ type: 'varchar', length: 20, default: TypeContratEnum.HYBRIDE })
+    type_contrat: TypeContratEnum;
 
     @CreateDateColumn({ type: 'timestamptz' })
     created_at: Date;

--- a/backend/src/offres/offres.controller.ts
+++ b/backend/src/offres/offres.controller.ts
@@ -8,6 +8,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { TypeContratEnum } from '../common/enums/type-contrat.enum';
 
 @ApiTags('offres')
 @Controller('offres')
@@ -20,6 +21,7 @@ export class OffresController {
     @ApiQuery({ name: 'prixMin', required: false, type: Number })
     @ApiQuery({ name: 'prixMax', required: false, type: Number })
     @ApiQuery({ name: 'search', required: false })
+    @ApiQuery({ name: 'type_contrat', required: false, enum: TypeContratEnum })
     @ApiQuery({ name: 'page', required: false, type: Number })
     @ApiQuery({ name: 'limit', required: false, type: Number })
     findAll(
@@ -28,6 +30,7 @@ export class OffresController {
         @Query('prixMin') prixMin?: string,
         @Query('prixMax') prixMax?: string,
         @Query('search') search?: string,
+        @Query('type_contrat') type_contrat?: TypeContratEnum,
         @Query('page') page?: string,
         @Query('limit') limit?: string,
     ) {
@@ -36,6 +39,7 @@ export class OffresController {
             prixMin: prixMin ? parseFloat(prixMin) : undefined,
             prixMax: prixMax ? parseFloat(prixMax) : undefined,
             search,
+            type_contrat,
             page: page ? parseInt(page, 10) : 1,
             limit: limit ? parseInt(limit, 10) : 10,
         });

--- a/backend/src/offres/offres.service.ts
+++ b/backend/src/offres/offres.service.ts
@@ -13,12 +13,14 @@ import { Competence } from '../competences/entities/competence.entity';
 import { Utilisateur } from '../utilisateurs/entities/utilisateur.entity';
 import { Avis } from '../avis/entities/avis.entity';
 import { EntiteType } from '../common/enums/entite-type.enum';
+import { TypeContratEnum } from '../common/enums/type-contrat.enum';
 
 export interface OffreFilterDto {
     type?: string;
     prixMin?: number;
     prixMax?: number;
     search?: string;
+    type_contrat?: TypeContratEnum;
     page?: number;
     limit?: number;
 }
@@ -205,7 +207,7 @@ export class OffresService {
     }
 
     async findAll(pays: string, filters: OffreFilterDto) {
-        const { type, prixMin, prixMax, search, page = 1, limit = 10 } = filters;
+        const { type, prixMin, prixMax, search, type_contrat, page = 1, limit = 10 } = filters;
 
         const queryBuilder = this.offresRepository.createQueryBuilder('offre')
             .leftJoinAndSelect('offre.type', 'type')
@@ -215,6 +217,10 @@ export class OffresService {
 
         if (type) {
             queryBuilder.andWhere('type.slug = :type', { type });
+        }
+
+        if (type_contrat) {
+            queryBuilder.andWhere('offre.type_contrat = :type_contrat', { type_contrat });
         }
 
         if (prixMin !== undefined) {

--- a/backend/src/services/dto/service.dto.ts
+++ b/backend/src/services/dto/service.dto.ts
@@ -1,6 +1,7 @@
 import { IsString, IsNotEmpty, IsNumber, IsOptional, IsEnum } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ServiceStatusEnum } from '../../common/enums/service-status.enum';
+import { TypeContratEnum } from '../../common/enums/type-contrat.enum';
 
 export class CreateServiceDto {
     @ApiProperty({ description: 'Titre du service', example: 'Développement d\'une application web' })
@@ -47,6 +48,11 @@ export class CreateServiceDto {
     @IsString()
     @IsOptional()
     image_couverture?: string;
+
+    @ApiProperty({ description: 'Modalité de travail', enum: TypeContratEnum, example: TypeContratEnum.HYBRIDE })
+    @IsEnum(TypeContratEnum)
+    @IsNotEmpty()
+    type_contrat: TypeContratEnum;
 }
 
 export class UpdateServiceDto {
@@ -89,6 +95,11 @@ export class UpdateServiceDto {
     @IsString()
     @IsOptional()
     livrable?: string;
+
+    @ApiPropertyOptional({ description: 'Modalité de travail', enum: TypeContratEnum })
+    @IsEnum(TypeContratEnum)
+    @IsOptional()
+    type_contrat?: TypeContratEnum;
 }
 
 export class UpdateServiceStatusDto {

--- a/backend/src/services/entities/service.entity.ts
+++ b/backend/src/services/entities/service.entity.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateCol
 import { Type } from '../../types/entities/type.entity';
 import { Utilisateur } from '../../utilisateurs/entities/utilisateur.entity';
 import { ServiceStatusEnum } from '../../common/enums/service-status.enum';
+import { TypeContratEnum } from '../../common/enums/type-contrat.enum';
 
 @Entity('services')
 export class Service {
@@ -34,6 +35,9 @@ export class Service {
 
     @Column({ type: 'enum', enum: ServiceStatusEnum, default: ServiceStatusEnum.PENDING_APPROVAL })
     status: ServiceStatusEnum;
+
+    @Column({ type: 'varchar', length: 20, default: TypeContratEnum.HYBRIDE })
+    type_contrat: TypeContratEnum;
 
     @Column({ name: 'disponibilite', type: 'int', nullable: true })
     delai: number;

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -8,6 +8,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiResponse, ApiConsumes, ApiBody } from '@nestjs/swagger';
 import { ServiceStatusEnum } from '../common/enums/service-status.enum';
+import { TypeContratEnum } from '../common/enums/type-contrat.enum';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
 
 @ApiTags('services')
@@ -33,6 +34,7 @@ export class ServicesController {
     @ApiQuery({ name: 'tarifMin', required: false, type: Number })
     @ApiQuery({ name: 'tarifMax', required: false, type: Number })
     @ApiQuery({ name: 'search', required: false, type: String, description: 'Recherche dans titre et description' })
+    @ApiQuery({ name: 'type_contrat', required: false, enum: TypeContratEnum })
     @ApiQuery({ name: 'page', required: false, type: Number })
     @ApiQuery({ name: 'limit', required: false, type: Number })
     findAll(
@@ -42,6 +44,7 @@ export class ServicesController {
         @Query('tarifMin') tarifMin?: string,
         @Query('tarifMax') tarifMax?: string,
         @Query('search') search?: string,
+        @Query('type_contrat') type_contrat?: TypeContratEnum,
         @Query('page') page?: string,
         @Query('limit') limit?: string,
     ) {
@@ -51,6 +54,7 @@ export class ServicesController {
             tarifMin: tarifMin ? parseFloat(tarifMin) : undefined,
             tarifMax: tarifMax ? parseFloat(tarifMax) : undefined,
             search,
+            type_contrat,
             page: page ? parseInt(page) : 1,
             limit: limit ? parseInt(limit) : 10,
         });

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -12,6 +12,7 @@ import { CreateServiceDto, UpdateServiceDto } from './dto/service.dto';
 import { MailService } from '../mail/mail.service';
 import { FichiersService } from '../fichiers/fichiers.service';
 import { TypeFichier } from '../fichiers/entities/fichier.entity';
+import { TypeContratEnum } from '../common/enums/type-contrat.enum';
 
 export interface ServiceFilterDto {
     localisation?: string;
@@ -19,6 +20,7 @@ export interface ServiceFilterDto {
     tarifMin?: number;
     tarifMax?: number;
     search?: string;
+    type_contrat?: TypeContratEnum;
     page?: number;
     limit?: number;
 }
@@ -164,7 +166,7 @@ export class ServicesService {
     }
 
     async findAll(pays: string, filters: ServiceFilterDto) {
-        const { localisation, type, tarifMin, tarifMax, search, page = 1, limit = 10 } = filters;
+        const { localisation, type, tarifMin, tarifMax, search, type_contrat, page = 1, limit = 10 } = filters;
 
         const qb = this.servicesWithRelations()
             .where('service.pays = :pays', { pays })
@@ -175,6 +177,9 @@ export class ServicesService {
         }
         if (type) {
             qb.andWhere('type.slug = :typeSlug', { typeSlug: type });
+        }
+        if (type_contrat) {
+            qb.andWhere('service.type_contrat = :type_contrat', { type_contrat });
         }
         if (tarifMin !== undefined) {
             qb.andWhere('service.prix >= :tarifMin', { tarifMin });
@@ -244,7 +249,7 @@ export class ServicesService {
             throw new ForbiddenException("Vous n'êtes pas autorisé à modifier ce service.");
         }
 
-        const { titre, description, prix, localisation, type, type_id, delai, livrable } = updateServiceDto;
+        const { titre, description, prix, localisation, type, type_id, delai, livrable, type_contrat } = updateServiceDto;
 
         if (type || type_id) {
             let finalTypeId = type_id;
@@ -264,6 +269,7 @@ export class ServicesService {
         if (localisation !== undefined) service.localisation = localisation;
         if (delai !== undefined) service.delai = delai;
         if (livrable !== undefined) service.livrable = livrable;
+        if (type_contrat !== undefined) service.type_contrat = type_contrat;
         service.status = ServiceStatusEnum.PENDING_APPROVAL;
 
         return this.servicesRepository.save(service);

--- a/frontend/src/lib/services/offres.service.ts
+++ b/frontend/src/lib/services/offres.service.ts
@@ -1,5 +1,7 @@
 import { api } from '../api';
 
+export type TypeContrat = 'presentiel' | 'hybride' | 'remote';
+
 export interface OffreItem {
     id: number;
     titre: string;
@@ -8,6 +10,7 @@ export interface OffreItem {
     prix?: number;
     type_id: number;
     status: 'pending_approval' | 'declined' | 'approved' | 'active' | 'inactive';
+    type_contrat: TypeContrat;
     temps?: string | null;
     image_couverture?: string | null;
     created_at: string;

--- a/frontend/src/lib/services/services.service.ts
+++ b/frontend/src/lib/services/services.service.ts
@@ -1,4 +1,7 @@
 import { api } from '../api';
+import type { TypeContrat } from './offres.service';
+
+export type { TypeContrat };
 
 export interface ServiceItem {
     id: number;
@@ -9,6 +12,7 @@ export interface ServiceItem {
     prix?: number;
     type_id: number;
     status: 'pending_approval' | 'declined' | 'approved' | 'active' | 'inactive';
+    type_contrat: TypeContrat;
     delai?: number | null;
     created_at: string;
     updated_at: string;

--- a/frontend/src/pages/OffresAdmin.tsx
+++ b/frontend/src/pages/OffresAdmin.tsx
@@ -213,6 +213,7 @@ export default function OffresAdmin() {
                                         <TableHead>Titre</TableHead>
                                         <TableHead>Auteur</TableHead>
                                         <TableHead>Type</TableHead>
+                                        <TableHead>Modalité</TableHead>
                                         <TableHead>Prix</TableHead>
                                         <TableHead>Statut</TableHead>
                                         <TableHead>Date</TableHead>
@@ -222,7 +223,7 @@ export default function OffresAdmin() {
                                 <TableBody>
                                     {offres.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={7} className="text-center text-muted-foreground">
+                                            <TableCell colSpan={8} className="text-center text-muted-foreground">
                                                 Aucune offre trouvée.
                                             </TableCell>
                                         </TableRow>
@@ -237,6 +238,9 @@ export default function OffresAdmin() {
                                                 </TableCell>
                                                 <TableCell>
                                                     {offre.type?.nom || '-'}
+                                                </TableCell>
+                                                <TableCell className="capitalize text-muted-foreground">
+                                                    {offre.type_contrat || '-'}
                                                 </TableCell>
                                                 <TableCell>
                                                     {offre.prix ? `${offre.prix} FCFA` : '-'}

--- a/frontend/src/pages/ServicesAdmin.tsx
+++ b/frontend/src/pages/ServicesAdmin.tsx
@@ -213,6 +213,7 @@ export default function ServicesAdmin() {
                                         <TableHead>Titre</TableHead>
                                         <TableHead>Auteur</TableHead>
                                         <TableHead>Type</TableHead>
+                                        <TableHead>Modalité</TableHead>
                                         <TableHead>Prix</TableHead>
                                         <TableHead>Statut</TableHead>
                                         <TableHead>Date</TableHead>
@@ -222,7 +223,7 @@ export default function ServicesAdmin() {
                                 <TableBody>
                                     {services.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={7} className="text-center text-muted-foreground">
+                                            <TableCell colSpan={8} className="text-center text-muted-foreground">
                                                 Aucun service trouvé.
                                             </TableCell>
                                         </TableRow>
@@ -237,6 +238,9 @@ export default function ServicesAdmin() {
                                                 </TableCell>
                                                 <TableCell>
                                                     {service.type?.nom || '-'}
+                                                </TableCell>
+                                                <TableCell className="capitalize text-muted-foreground">
+                                                    {service.type_contrat || '-'}
                                                 </TableCell>
                                                 <TableCell>
                                                     {service.prix ? `${service.prix} FCFA` : '-'}


### PR DESCRIPTION
Required field with three values (presentiel | hybride | remote) on both JobKia entities. Existing rows backfill to 'hybride' — most permissive default that doesn't mislead either side: applicants can still show interest knowing the spec was never set, advertisers can sharpen later.

Backend
- New TypeContratEnum in src/common/enums.
- pays-style varchar(20) column on Offre + Service entities (default hybride), mirrored on the Prisma models for parity.
- DTOs: required on Create with @IsEnum, optional on Update.
- findAll filters on both modules accept ?type_contrat= as an extra predicate; ApiQuery surfaces the enum in Swagger.

Frontend
- TypeContrat type re-exported from offres.service so both modules share it. OffreItem / ServiceItem gain a typed type_contrat field.
- Admin tables (OffresAdmin, ServicesAdmin) render a Modalité column between Type and Prix.

Schema migration: edukia-db/005_add_type_contrat_to_jobkia.sql — apply before deploy. Idempotent.