### PR TITLE
chore(deploy): drop dead per-host DB env vars from backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     container_name: edukia_backend
     restart: unless-stopped
     environment:
+      # Database — managed Postgres on Neon. Connection string carries
+      # credentials, host, db name, and sslmode=require; the previous
+      # DB_HOST / DB_PORT / DB_USERNAME / DB_PASSWORD / DB_NAME variables
+      # were leftovers from a local-db setup and are no longer read.
       DATABASE_URL: ${DATABASE_URL}
       # JWT
       JWT_SECRET: ${JWT_SECRET}


### PR DESCRIPTION
DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_NAME pointed at a `db` service that doesn't exist in this compose file (we use Neon, a managed Postgres reached via DATABASE_URL only). The vars were leftovers from a pre-Neon local-db setup — nothing in the backend code or workflows reads them, so they were just leaking unused secret values into the container env.

Verified by grepping src/ and .github/ for any reference to those five names: zero hits.