### PR TITLE
fix(deploy): use docker compose v2 to avoid ContainerConfig crash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,17 @@ jobs:
             # Créer le fichier nginx.conf depuis le contenu du repo
             echo "$NGINX_CONTENT" | base64 -d > ./nginx/nginx.conf
 
+            # Use Docker Compose v2 (the Go plugin, invoked as `docker compose`).
+            # The legacy v1 Python binary (`docker-compose`, 1.29.2) crashes with
+            # `KeyError: 'ContainerConfig'` against modern Docker engines that
+            # stopped emitting that field. Install the plugin if it's missing.
+            if ! docker compose version >/dev/null 2>&1; then
+              echo "=== Installation du plugin docker compose v2"
+              apt-get update -qq
+              apt-get install -y -qq docker-compose-plugin
+            fi
+            COMPOSE="docker compose"
+
             # Bootstrap Let's Encrypt: si aucun certificat n'existe pour le
             # domaine, créer un certificat auto-signé temporaire pour que
             # nginx puisse démarrer. Sinon le challenge HTTP-01 est bloqué
@@ -103,14 +114,14 @@ jobs:
             fi
 
             # Arrêter les conteneurs applicatifs (laisser db, redis, certbot, nginx)
-            docker-compose stop backend frontend
-            docker-compose rm -f backend frontend
+            $COMPOSE stop backend frontend
+            $COMPOSE rm -f backend frontend
 
             # Pull les dernières images
-            docker-compose pull backend frontend redis
+            $COMPOSE pull backend frontend redis
 
             # Démarrer la pile (nginx avec dummy cert si nécessaire)
-            docker-compose up -d --remove-orphans
+            $COMPOSE up -d --remove-orphans
 
             # Si on a démarré avec un dummy cert, demander un vrai certificat
             # à Let's Encrypt via webroot (nginx est maintenant up sur le 80).
@@ -131,25 +142,25 @@ jobs:
                   -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN"
 
               # Recharger nginx avec le vrai certificat
-              docker-compose exec -T nginx nginx -s reload
+              $COMPOSE exec -T nginx nginx -s reload
             fi
 
             # Recharger nginx pour prendre en compte d'éventuels changements
             # de configuration. On ne fail pas si nginx n'est pas up — le
             # diagnostic ci-dessous montrera l'état réel.
-            docker-compose exec -T nginx nginx -s reload || true
+            $COMPOSE exec -T nginx nginx -s reload || true
 
             # Attendre un peu pour que les conteneurs démarrent
             sleep 10
 
             # Afficher l'état des conteneurs
-            docker-compose ps
+            $COMPOSE ps
 
             # Afficher les logs pour diagnostic
             echo "=== Backend logs ==="
-            docker-compose logs --tail=50 backend
+            $COMPOSE logs --tail=50 backend
             echo "=== Nginx logs ==="
-            docker-compose logs --tail=20 nginx
+            $COMPOSE logs --tail=20 nginx
 
       - name: Notify deployment status
         if: always()


### PR DESCRIPTION
The legacy `docker-compose` (Python v1, 1.29.2) crashes with `KeyError: 'ContainerConfig'` against modern Docker engines. Recent Docker versions stopped emitting that field on image inspect, but v1's `get_container_data_volumes` still tries to read it during container recreation — failing the deploy on every run when certbot gets rebuilt.

Switch all compose calls in the deploy script to `docker compose` (the Go plugin, v2), which doesn't depend on `ContainerConfig`. Install the plugin on the VPS first if it's missing — modern Ubuntu has it via `docker-compose-plugin`.