### PR TITLE
fix(typeorm): register LikeUser, CommentaireUser, DesabonnementEmail

### DIFF
--- a/backend/src/comments-polymorphic/comments-polymorphic.module.ts
+++ b/backend/src/comments-polymorphic/comments-polymorphic.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentsPolymorphicService } from './comments-polymorphic.service';
 import { CommentsPolymorphicController } from './comments-polymorphic.controller';
 import { LikesPolymorphicModule } from '../likes-polymorphic/likes-polymorphic.module';
+import { CommentaireUser } from './entities/commentaire-user.entity';
 
 @Module({
-    imports: [LikesPolymorphicModule],
+    imports: [TypeOrmModule.forFeature([CommentaireUser]), LikesPolymorphicModule],
     controllers: [CommentsPolymorphicController],
     providers: [CommentsPolymorphicService],
 })

--- a/backend/src/likes-polymorphic/likes-polymorphic.module.ts
+++ b/backend/src/likes-polymorphic/likes-polymorphic.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { LikesPolymorphicService } from './likes-polymorphic.service';
 import { LikesPolymorphicController } from './likes-polymorphic.controller';
+import { LikeUser } from './entities/like-user.entity';
 
 @Module({
+    imports: [TypeOrmModule.forFeature([LikeUser])],
     controllers: [LikesPolymorphicController],
     providers: [LikesPolymorphicService],
     exports: [LikesPolymorphicService],

--- a/backend/src/notification-email/notification-email.module.ts
+++ b/backend/src/notification-email/notification-email.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { NotificationEmailController } from './notification-email.controller';
 import { NotificationEmailService } from './notification-email.service';
 import { MailModule } from '../mail/mail.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { BullModule } from '@nestjs/bullmq';
 import { EmailProcessor } from './email.processor';
+import { DesabonnementEmail } from './entities/desabonnement-email.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([DesabonnementEmail]),
     MailModule,
     PrismaModule,
     BullModule.registerQueue({


### PR DESCRIPTION
The default DataSource is created with `autoLoadEntities: true`, which only registers entities that appear in some module's `TypeOrmModule.forFeature(...)`. The polymorphic modules and notification-email never called forFeature — their services pull the repos via DataSourceResolver — so those three entities had no metadata, and any GET /forums request crashed with:

  EntityMetadataNotFoundError: No metadata for "LikeUser" was found.

Add a `forFeature([Entity])` import to each module so the entity metadata is loaded at boot. Services and the resolver continue to work unchanged.