### PR TITLE
feat(files): serve public slots via direct URL, presign private only

### DIFF
--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -131,6 +131,21 @@ export class FilesService {
         return `${this.publicBaseUrl}/${key}`;
     }
 
+    /**
+     * Value written to the row's <slot>_path column. Private slots store the
+     * logical path (`/<entity>/<uuid>/<slot>`) and reconstruct the R2 key on
+     * read; public slots store the full anonymous URL so a plain entity GET
+     * already carries a ready-to-use link with no /files/... round trip.
+     * Trade-off: if R2_PUBLIC_BUCKET_URL ever changes, public rows need a
+     * re-backfill (scripts/backfill-public-urls.js).
+     */
+    private storedPathFor(cfg: FileSlotConfig, entity: string, uuid: string, slot: string, extension: string): string {
+        if (cfg.public) {
+            return this.publicUrl(buildObjectKey(entity, uuid, slot, extension));
+        }
+        return buildLogicalPath(entity, uuid, slot);
+    }
+
     private validateExtension(cfg: FileSlotConfig, extension: string) {
         const normalized = extension.toLowerCase().replace(/^\./, '');
         if (!cfg.authorized.includes(normalized)) {
@@ -180,15 +195,16 @@ export class FilesService {
      * Optimistically writes path/extension on the row at presign time — if
      * the upload never lands, the column points at a non-existent object,
      * which clients can detect via download-url returning 404. Public-
-     * flagged slots route to the public bucket and tag the object with a
-     * long Cache-Control so CDNs can cache aggressively.
+     * flagged slots route to the public bucket, tag the object with a long
+     * Cache-Control so CDNs can cache aggressively, and store the full
+     * anonymous URL in <slot>_path (clients read it straight off the row).
      */
     async createUploadUrl(entity: string, uuid: string, slot: string, rawExtension: string) {
         const cfg = this.resolveSlot(entity, slot);
         const extension = this.validateExtension(cfg, rawExtension);
         const rowId = await this.findRowIdByUuid(entity, uuid);
 
-        const path = buildLogicalPath(entity, uuid, slot);
+        const storedPath = this.storedPathFor(cfg, entity, uuid, slot, extension);
         const key = buildObjectKey(entity, uuid, slot, extension);
         const contentType = MIME_BY_EXT[extension] ?? 'application/octet-stream';
         const bucket = this.bucketFor(cfg);
@@ -201,13 +217,13 @@ export class FilesService {
         });
         const url = await getSignedUrl(this.client, command, { expiresIn: PRESIGN_TTL_SECONDS });
 
-        await this.writePathOnRow(entity, rowId, cfg, path, extension);
+        await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
 
         return {
             url,
             method: 'PUT',
             content_type: contentType,
-            path,
+            path: storedPath,
             extension,
             expires_in: PRESIGN_TTL_SECONDS,
             public: !!cfg.public,
@@ -215,13 +231,21 @@ export class FilesService {
     }
 
     /**
-     * Return a URL for the file currently registered on this slot. For
-     * public slots this is a deterministic anonymous URL with no expiry;
-     * for private slots it's a 5-minute presigned GET. Throws 404 if no
-     * file has been registered yet.
+     * Return a short-lived presigned GET URL for a PRIVATE slot's file.
+     * Public slots don't go through here: their full anonymous URL is stored
+     * on the entity's <slot>_path field and served directly over a plain GET,
+     * so calling this for a public slot is a 400. Throws 404 if no file has
+     * been registered yet.
      */
     async createDownloadUrl(entity: string, uuid: string, slot: string) {
         const cfg = this.resolveSlot(entity, slot);
+        if (cfg.public) {
+            throw new BadRequestException(
+                `Slot '${entity}/${slot}' is public — no presigned download URL is ` +
+                `issued. Read its URL straight from the entity's '${cfg.pathColumn}' ` +
+                `field; a plain GET on that URL serves the file.`,
+            );
+        }
         const rowId = await this.findRowIdByUuid(entity, uuid);
 
         const rows = await this.dataSource.query(
@@ -236,18 +260,6 @@ export class FilesService {
         }
 
         const key = buildObjectKey(entity, uuid, slot, row.ext);
-
-        if (cfg.public) {
-            return {
-                url: this.publicUrl(key),
-                method: 'GET' as const,
-                path: row.path,
-                extension: row.ext,
-                expires_in: 0,
-                public: true,
-            };
-        }
-
         const command = new GetObjectCommand({ Bucket: this.bucketFor(cfg), Key: key });
         const url = await getSignedUrl(this.client, command, { expiresIn: PRESIGN_TTL_SECONDS });
         return {
@@ -277,7 +289,7 @@ export class FilesService {
         const extension = this.validateExtension(cfg, extFromName);
         const rowId = await this.findRowIdByUuid(entity, uuid);
 
-        const path = buildLogicalPath(entity, uuid, slot);
+        const storedPath = this.storedPathFor(cfg, entity, uuid, slot, extension);
         const key = buildObjectKey(entity, uuid, slot, extension);
         const bucket = this.bucketFor(cfg);
 
@@ -291,8 +303,8 @@ export class FilesService {
             }),
         );
 
-        await this.writePathOnRow(entity, rowId, cfg, path, extension);
+        await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
 
-        return { path, extension, public: !!cfg.public };
+        return { path: storedPath, extension, public: !!cfg.public };
     }
 }

--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -9,9 +9,13 @@
  *   updates after generating a presigned URL.
  * - `authorized` is the allowlist of file extensions accepted on this slot.
  * - `public` (optional, default false) routes uploads to the public R2 bucket
- *   and makes downloads return a deterministic anonymous URL with no
- *   expiry. Use only for content meant to be world-visible (brand assets,
- *   country logos). Private slots stay on the existing presigned-URL flow.
+ *   and makes downloads return a deterministic anonymous URL with no expiry.
+ *   Public slots also store that full URL directly in the `<slot>_path`
+ *   column, so a plain entity GET carries a ready-to-use link and clients
+ *   never need to call /files/.../download-url. Everything non-sensitive is
+ *   public; the private slots (exam papers, resource files, user profile
+ *   photos, identity documents) stay on the presigned-URL flow where each
+ *   read is authorized and short-lived.
  */
 export interface FileSlotConfig {
     pathColumn: string;
@@ -30,45 +34,50 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
         icone: { pathColumn: 'icone_path', extColumn: 'icone_extension', authorized: IMAGE_EXTS, public: true },
     },
     concours: {
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, public: true },
     },
     epreuves: {
+        // Private: exam papers are gated behind authorized, short-lived reads.
         file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
     },
     etablissements: {
         logo: { pathColumn: 'logo_path', extColumn: 'logo_extension', authorized: IMAGE_EXTS_WITH_SVG, public: true },
     },
     evenements: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
     },
     forums: {
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: IMAGE_OR_PDF },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: IMAGE_OR_PDF, public: true },
     },
     offres: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
     },
     opportunites: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
     },
     parcours: {
-        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS },
-        content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS },
+        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true },
+        content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS, public: true },
     },
     prestataires: {
-        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS },
+        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, public: true },
+        // Private: identity documents (ID card / passport scans) are sensitive
+        // PII and must never be anonymously readable.
         identity: { pathColumn: 'identity_photo_path', extColumn: 'identity_photo_extension', authorized: IMAGE_EXTS },
     },
     publicites: {
-        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS },
-        content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS },
+        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true },
+        content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS, public: true },
     },
     ressources: {
+        // Private: resource files stay behind authorized, short-lived reads.
         file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
     },
     services: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
     },
     utilisateurs: {
+        // Private: user profile photos stay on the presigned-URL flow.
         profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS },
     },
 };

--- a/frontend/src/components/FileImage.tsx
+++ b/frontend/src/components/FileImage.tsx
@@ -11,10 +11,17 @@ interface FileImageProps extends Omit<ComponentProps<'img'>, 'src'> {
     /** Slot key registered in backend FILE_FIELD_REGISTRY. */
     slot: Slot;
     /**
-     * Legacy URL to use when the new R2 file isn't registered yet. Only set
-     * this for entities still in migration; for fully-migrated entities
-     * (categories, etablissements) leave it unset and the placeholder will
-     * render directly.
+     * Direct URL for a PUBLIC slot, read straight off the entity row's
+     * `<slot>_path` field (which now stores the full anonymous URL). When set,
+     * the file renders over a plain GET with no presign round-trip. Leave unset
+     * for private slots (epreuves, ressources, utilisateurs, prestataires
+     * identity) so the component resolves a short-lived presigned URL instead.
+     */
+    url?: string | null;
+    /**
+     * Legacy URL to use when neither `url` nor a registered R2 file is
+     * available yet. Only set this for entities still in migration; for
+     * fully-migrated entities leave it unset and the placeholder renders.
      */
     fallback?: string | null;
     /** Rendered when there's nothing valid to show. */
@@ -22,42 +29,44 @@ interface FileImageProps extends Omit<ComponentProps<'img'>, 'src'> {
 }
 
 /**
- * Resolve and render a file from the R2 pipeline. Auto-fetches a download
- * URL from /files/.../download-url (presigned for private slots; a
- * deterministic public URL with no expiry for public slots) and caches it
- * in TanStack Query.
+ * Resolve and render a file from the R2 pipeline.
+ *
+ * - Public slots: pass the full URL via `url` (read from the entity row's
+ *   `<slot>_path` field). It renders over a plain GET — no backend call.
+ * - Private slots: omit `url`; the component fetches a short-lived presigned
+ *   URL from /files/.../download-url and caches it in TanStack Query.
  *
  * Three failure modes are handled, each falling through to `placeholder`:
- *   1. No row uuid (entity not loaded yet, or has no row in scope).
- *   2. download-url 404 (row exists but no file registered yet).
- *   3. <img> onError (download-url 200 but the file is missing from R2 —
- *      happens when the bucket sync missed a key, the public bucket
- *      drifted from the private one, etc.).
+ *   1. No URL and no row uuid (entity not loaded yet, or no row in scope).
+ *   2. download-url 404 (private slot row exists but no file uploaded yet).
+ *   3. <img> onError (URL resolves but the bytes are missing from R2).
  *
  * The optional `fallback` lets pages that haven't been migrated yet point
- * at a legacy URL; pages whose entity has been fully migrated to R2 should
- * omit it so a missing file degrades to the placeholder instead of a noisy
- * legacy 404/400.
+ * at a legacy URL; fully-migrated entities should omit it so a missing file
+ * degrades to the placeholder instead of a noisy legacy 404/400.
  */
 export function FileImage({
     entity,
     uuid,
     slot,
+    url,
     fallback,
     placeholder,
     alt,
     onError: onErrorProp,
     ...imgProps
 }: FileImageProps) {
-    const enabled = !!uuid;
+    // A non-empty `url` means this is a public slot whose URL came straight off
+    // the entity row — render it directly and skip the presign request entirely.
+    const directUrl = url || null;
+    const usePresign = !directUrl && !!uuid;
 
     const { data, isLoading } = useQuery({
         queryKey: ['file-download-url', entity, uuid, slot],
         queryFn: () => filesService.getDownloadUrl(entity, uuid as string, slot),
-        enabled,
+        enabled: usePresign,
         // Presigned URLs expire in 5 min; cache for 4 to avoid serving expired
-        // URLs while staying well below the wall. Public-slot URLs are stable
-        // but reusing the same TTL keeps the cache logic uniform.
+        // URLs while staying well below the wall.
         staleTime: 4 * 60 * 1000,
         gcTime: 4 * 60 * 1000,
         retry: 1,
@@ -69,12 +78,12 @@ export function FileImage({
     const [imgFailed, setImgFailed] = useState(false);
     // Reset the error state when the URL we'd render changes — otherwise
     // a recovered upload would never re-attempt.
-    const currentSrc = data?.url ?? fallback ?? null;
+    const currentSrc = directUrl ?? data?.url ?? fallback ?? null;
     useEffect(() => {
         setImgFailed(false);
     }, [currentSrc]);
 
-    if (enabled && isLoading) {
+    if (usePresign && isLoading) {
         return <div {...(imgProps as any)} aria-busy="true" />;
     }
 

--- a/frontend/src/lib/services/files.service.ts
+++ b/frontend/src/lib/services/files.service.ts
@@ -9,7 +9,10 @@ export interface UploadUrlResponse {
     url: string;
     method: 'PUT';
     content_type: string;
-    path: string;        // logical /<entity>/<uuid>/<slot>
+    // Private slots: logical /<entity>/<uuid>/<slot>. Public slots: the full
+    // anonymous URL — it's stored verbatim in the row's <slot>_path column, so
+    // a plain entity GET already carries a usable link (no download-url call).
+    path: string;
     extension: string;
     expires_in: number;  // 0 for public slots (deterministic anonymous URL)
     public: boolean;
@@ -18,7 +21,7 @@ export interface UploadUrlResponse {
 export interface DownloadUrlResponse {
     url: string;
     method: 'GET';
-    path: string;
+    path: string;        // public slots: full URL (same as `url`); private: logical path
     extension: string;
     expires_in: number;  // 0 for public slots (URL never expires)
     public: boolean;
@@ -43,7 +46,9 @@ export const filesService = {
     },
 
     /**
-     * Get a presigned GET URL for the file currently registered on this slot.
+     * Get a presigned GET URL for a PRIVATE slot's file. Public slots don't
+     * use this — their URL lives on the entity row's `<slot>_path` field and a
+     * plain GET serves the file (the backend returns 400 if called for one).
      * Returns null if no file has been uploaded yet (404 from backend).
      */
     async getDownloadUrl(entity: string, uuid: string, slot: Slot): Promise<DownloadUrlResponse | null> {

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -335,6 +335,7 @@ export default function Categories() {
                                                 entity="categories"
                                                 uuid={item.uuid}
                                                 slot="icone"
+                                                url={item.icone_path}
                                                 alt={item.nom}
                                                 className="h-10 w-10 object-contain rounded-md bg-muted/20"
                                                 placeholder={
@@ -452,6 +453,7 @@ export default function Categories() {
                                                     entity="categories"
                                                     uuid={editingCategory.uuid}
                                                     slot="icone"
+                                                    url={editingCategory.icone_path}
                                                     alt="Current Icon"
                                                     className="h-full w-full object-contain rounded-md border"
                                                 />

--- a/frontend/src/pages/Etablissements.tsx
+++ b/frontend/src/pages/Etablissements.tsx
@@ -50,7 +50,7 @@ export default function Etablissements() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
-  const [editingEtablissement, setEditingEtablissement] = useState<{ id: number; uuid?: string } & EtablissementFormData | null>(null);
+  const [editingEtablissement, setEditingEtablissement] = useState<{ id: number; uuid?: string; logo_path?: string } & EtablissementFormData | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebounce(searchQuery, 500);
   const [logoFile, setLogoFile] = useState<File | null>(null);
@@ -394,6 +394,7 @@ export default function Etablissements() {
                           entity="etablissements"
                           uuid={etablissement.uuid}
                           slot="logo"
+                          url={etablissement.logo_path}
                           alt={`Logo ${etablissement.nom}`}
                           className="h-10 w-10 object-contain rounded-md"
                           placeholder={
@@ -531,6 +532,7 @@ export default function Etablissements() {
                       entity="etablissements"
                       uuid={editingEtablissement.uuid}
                       slot="logo"
+                      url={editingEtablissement.logo_path}
                       alt="Current Logo"
                       className="h-full w-full object-contain rounded-md border"
                     />

--- a/frontend/src/pages/Evenements.tsx
+++ b/frontend/src/pages/Evenements.tsx
@@ -399,6 +399,7 @@ export default function Evenements() {
                                                 entity="evenements"
                                                 uuid={evenement.uuid}
                                                 slot="image"
+                                                url={evenement.image_path}
                                                 fallback={evenement.image ? `${API_URL}/evenements/${evenement.id}/image?v=${imageVersion}` : null}
                                                 alt={evenement.titre}
                                                 className="h-10 w-10 object-cover rounded-md cursor-pointer hover:opacity-80 transition-opacity"
@@ -544,6 +545,7 @@ export default function Evenements() {
                                                 entity="evenements"
                                                 uuid={editingEvenement.uuid}
                                                 slot="image"
+                                                url={editingEvenement.image_path}
                                                 fallback={editingEvenement.image ? `${API_URL}/evenements/${editingEvenement.id}/image?v=${imageVersion}` : null}
                                                 alt="Current Image"
                                                 className="h-full w-full object-cover rounded-md border"

--- a/frontend/src/pages/Opportunites.tsx
+++ b/frontend/src/pages/Opportunites.tsx
@@ -374,6 +374,7 @@ export default function Opportunites() {
                                                 entity="opportunites"
                                                 uuid={opp.uuid}
                                                 slot="image"
+                                                url={opp.image_path}
                                                 fallback={opp.image ? `${API_URL}/opportunites/${opp.id}/image?v=${imageVersion}` : null}
                                                 alt={opp.titre}
                                                 className="h-10 w-10 object-cover rounded-md cursor-pointer hover:opacity-80 transition-opacity"
@@ -503,6 +504,7 @@ export default function Opportunites() {
                                                 entity="opportunites"
                                                 uuid={editingOpportunite.uuid}
                                                 slot="image"
+                                                url={editingOpportunite.image_path}
                                                 fallback={editingOpportunite.image ? `${API_URL}/opportunites/${editingOpportunite.id}/image?v=${imageVersion}` : null}
                                                 alt="Current Image"
                                                 className="h-full w-full object-cover rounded-md border"

--- a/frontend/src/pages/Parcours.tsx
+++ b/frontend/src/pages/Parcours.tsx
@@ -338,11 +338,21 @@ export default function Parcours() {
 
                 setPreviewUrl(url);
                 setIsPreviewOpen(true);
-            } else if ((item.type_media === 'image' || !item.type_media) && item.image_couverture) {
-                setIsPreviewOpen(true);
-                const blob = await parcoursService.downloadImage(item.id);
-                const url = window.URL.createObjectURL(blob);
-                setPreviewUrl(url);
+            } else if (item.type_media === 'image' || !item.type_media) {
+                // covert is a public slot: its full URL is on the row — render
+                // it directly. Fall back to the legacy blob download only for
+                // rows that predate the public-URL backfill.
+                if (item.covert_image_path) {
+                    setPreviewUrl(item.covert_image_path);
+                    setIsPreviewOpen(true);
+                } else if (item.image_couverture) {
+                    setIsPreviewOpen(true);
+                    const blob = await parcoursService.downloadImage(item.id);
+                    const url = window.URL.createObjectURL(blob);
+                    setPreviewUrl(url);
+                } else {
+                    toast({ title: "Info", description: "Aucun contenu à visualiser", variant: "default" });
+                }
             } else {
                 toast({ title: "Info", description: "Aucun contenu à visualiser", variant: "default" });
             }

--- a/frontend/src/pages/Publicites.tsx
+++ b/frontend/src/pages/Publicites.tsx
@@ -332,8 +332,13 @@ export default function Publicites() {
                 }
                 setPreviewUrl(url);
                 setIsPreviewOpen(true);
+            } else if (item.content_image_path) {
+                // content is a public slot: full URL is on the row — use it
+                // directly instead of downloading the bytes.
+                setPreviewUrl(item.content_image_path);
+                setIsPreviewOpen(true);
             } else {
-                // Assume Image or file download
+                // Legacy rows predating the public-URL backfill.
                 setIsPreviewOpen(true);
                 const blob = await publicitesService.downloadMedia(item.id);
                 const url = window.URL.createObjectURL(blob);
@@ -348,10 +353,11 @@ export default function Publicites() {
 
     const closePreview = () => {
         setIsPreviewOpen(false);
-        if (previewUrl) {
+        // Only blob: URLs need revoking; public/YouTube http URLs must not be.
+        if (previewUrl && !previewUrl.startsWith('http')) {
             window.URL.revokeObjectURL(previewUrl);
-            setPreviewUrl(null);
         }
+        setPreviewUrl(null);
     };
 
     if (isLoading) {


### PR DESCRIPTION
Public-bucket slots now store their full anonymous URL in the row's <slot>_path field and are read over a plain GET — no presign round-trip. The /files/.../download-url endpoint is restricted to private slots (epreuves, ressources, utilisateurs.profil, prestataires.identity) and returns 400 for public ones.

Frontend: <FileImage> gains a `url` prop that renders directly and skips the download-url query when set; the four admin pages using it pass `url={row.<slot>_path}`. Parcours/Publicites preview dialogs read the stored public URL instead of downloading bytes, falling back to the legacy blob download only for un-backfilled rows.