### PR TITLE
fix(files): public upload signature, uuid in JSON, longer private GET…

### DIFF
--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -79,8 +79,11 @@ export class EpreuvesService {
     // Transform to response DTO format with sanitized professeur
     const data = epreuves.map(epreuve => ({
       id: epreuve.id,
+      uuid: epreuve.uuid,
       titre: epreuve.titre,
       url: epreuve.url,
+      file_path: epreuve.file_path,
+      file_extension: epreuve.file_extension,
       duree_minutes: epreuve.duree_minutes,
       date_creation: epreuve.date_creation,
       date_publication: epreuve.date_publication,
@@ -135,8 +138,11 @@ export class EpreuvesService {
     // Transform to response DTO format with sanitized professeur
     return {
       id: epreuve.id,
+      uuid: epreuve.uuid,
       titre: epreuve.titre,
       url: epreuve.url,
+      file_path: epreuve.file_path,
+      file_extension: epreuve.file_extension,
       duree_minutes: epreuve.duree_minutes,
       date_creation: epreuve.date_creation,
       date_publication: epreuve.date_publication,

--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -76,7 +76,9 @@ export class FilesController {
         description:
             'Validates the requested extension against the slot allowlist, ' +
             'records the path/extension on the entity row, and returns a short-lived ' +
-            'presigned URL. Client uploads bytes directly to R2 with the returned URL.',
+            'presigned URL. The client PUTs bytes directly to R2 and MUST replay every ' +
+            'header in `required_headers` (Content-Type always; Cache-Control too for ' +
+            'public slots) — otherwise R2 rejects the PUT with SignatureDoesNotMatch.',
     })
     @ApiParam({ name: 'entity', example: 'categories' })
     @ApiParam({ name: 'uuid', description: 'UUID of the row that owns the file' })
@@ -124,10 +126,12 @@ export class FilesController {
 
     @Get(':entity/:uuid/:slot/download-url')
     @ApiOperation({
-        summary: 'Get a presigned GET URL for direct R2 download',
+        summary: 'Get a presigned GET URL for a private slot (public slots → 400)',
         description:
-            'Reads the path/extension recorded on the entity row, returns a short-lived ' +
-            'presigned URL. Returns 404 if no file has been uploaded for this slot yet.',
+            'PRIVATE slots only. Reads the path/extension recorded on the entity row and ' +
+            'returns a presigned GET URL valid for PRESIGN_DOWNLOAD_TTL_SECONDS (default ' +
+            '6h). Returns 400 for a public slot — read its URL directly from the entity\'s ' +
+            '<slot>_path field. Returns 404 if no file has been uploaded for this slot yet.',
     })
     @ApiParam({ name: 'entity', example: 'categories' })
     @ApiParam({ name: 'uuid', description: 'UUID of the row that owns the file' })

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -18,7 +18,15 @@ import {
     getSlotConfig,
 } from './registry';
 
-const PRESIGN_TTL_SECONDS = 5 * 60; // 5 minutes — enough for the client to start the upload.
+// TTL for presigned PUT URLs — short, just enough for the client to start
+// the upload right after requesting the URL.
+const UPLOAD_PRESIGN_TTL_SECONDS = 5 * 60; // 5 minutes
+// TTL for presigned GET URLs on PRIVATE slots. Longer than the upload window:
+// these back <FileImage>/clients that may keep a rendered page open for a
+// while, and a too-short link expires mid-view ("expired link"). 6h balances
+// usability against how long a leaked link stays live. Overridable via
+// PRESIGN_DOWNLOAD_TTL_SECONDS.
+const DOWNLOAD_PRESIGN_TTL_SECONDS_DEFAULT = 6 * 60 * 60; // 6 hours
 // Cache-Control written on PUT for public-bucket objects. R2 keys are
 // content-addressed by uuid, so a fresh upload always changes either the
 // (entity, uuid, slot) or extension — making `immutable` safe.
@@ -40,6 +48,7 @@ export class FilesService {
     private readonly bucket: string;
     private readonly publicBucket: string;
     private readonly publicBaseUrl: string;
+    private readonly downloadTtlSeconds: number;
 
     constructor(
         @InjectDataSource() private readonly dataSource: DataSource,
@@ -52,6 +61,16 @@ export class FilesService {
         this.publicBucket = this.config.get<string>('R2_PUBLIC_BUCKET') ?? '';
         // Strip trailing slash so concatenation with the key is idempotent.
         this.publicBaseUrl = (this.config.get<string>('R2_PUBLIC_BUCKET_URL') ?? '').replace(/\/+$/, '');
+
+        // Presigned-GET lifetime for private slots. Configurable so ops can
+        // tune it without a redeploy; falls back to the 6h default. Clamp to
+        // R2/S3 SigV4's hard maximum of 7 days.
+        const ttlRaw = Number(this.config.get<string>('PRESIGN_DOWNLOAD_TTL_SECONDS'));
+        const MAX_S3_PRESIGN_TTL = 7 * 24 * 60 * 60; // 604800s — SigV4 ceiling
+        this.downloadTtlSeconds =
+            Number.isFinite(ttlRaw) && ttlRaw > 0
+                ? Math.min(ttlRaw, MAX_S3_PRESIGN_TTL)
+                : DOWNLOAD_PRESIGN_TTL_SECONDS_DEFAULT;
 
         this.logger.log(
             `R2 config: endpoint=${endpoint ? 'set' : 'MISSING'}, ` +
@@ -215,7 +234,7 @@ export class FilesService {
             ContentType: contentType,
             ...(cfg.public ? { CacheControl: PUBLIC_CACHE_CONTROL } : {}),
         });
-        const url = await getSignedUrl(this.client, command, { expiresIn: PRESIGN_TTL_SECONDS });
+        const url = await getSignedUrl(this.client, command, { expiresIn: UPLOAD_PRESIGN_TTL_SECONDS });
 
         await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
 
@@ -223,9 +242,16 @@ export class FilesService {
             url,
             method: 'PUT',
             content_type: contentType,
+            // Echo back what the client must send on the PUT so the signature
+            // matches. For public slots we sign Cache-Control too — the client
+            // MUST replay it or R2 returns SignatureDoesNotMatch.
+            required_headers: {
+                'Content-Type': contentType,
+                ...(cfg.public ? { 'Cache-Control': PUBLIC_CACHE_CONTROL } : {}),
+            },
             path: storedPath,
             extension,
-            expires_in: PRESIGN_TTL_SECONDS,
+            expires_in: UPLOAD_PRESIGN_TTL_SECONDS,
             public: !!cfg.public,
         };
     }
@@ -261,13 +287,13 @@ export class FilesService {
 
         const key = buildObjectKey(entity, uuid, slot, row.ext);
         const command = new GetObjectCommand({ Bucket: this.bucketFor(cfg), Key: key });
-        const url = await getSignedUrl(this.client, command, { expiresIn: PRESIGN_TTL_SECONDS });
+        const url = await getSignedUrl(this.client, command, { expiresIn: this.downloadTtlSeconds });
         return {
             url,
             method: 'GET' as const,
             path: row.path,
             extension: row.ext,
-            expires_in: PRESIGN_TTL_SECONDS,
+            expires_in: this.downloadTtlSeconds,
             public: false,
         };
     }

--- a/backend/src/ressources/ressources.service.ts
+++ b/backend/src/ressources/ressources.service.ts
@@ -78,9 +78,12 @@ export class RessourcesService {
 
     const data = ressources.map(ressource => ({
       id: ressource.id,
+      uuid: ressource.uuid,
       titre: ressource.titre,
       type: ressource.type,
       url: ressource.url,
+      file_path: ressource.file_path,
+      file_extension: ressource.file_extension,
       date_creation: ressource.date_creation,
       date_publication: ressource.date_publication,
       nombre_pages: ressource.nombre_pages,
@@ -132,9 +135,12 @@ export class RessourcesService {
 
     return {
       id: ressource.id,
+      uuid: ressource.uuid,
       titre: ressource.titre,
       type: ressource.type,
       url: ressource.url,
+      file_path: ressource.file_path,
+      file_extension: ressource.file_extension,
       date_creation: ressource.date_creation,
       date_publication: ressource.date_publication,
       professeur: {

--- a/docs/files-upload-test-schema.md
+++ b/docs/files-upload-test-schema.md
@@ -1,0 +1,157 @@
+# Files pipeline — manual test schema
+
+Covers the four changes:
+1. Longer presigned-GET TTL for **private** slots.
+2. `uuid` present in every entity JSON (incl. `epreuves` / `ressources`).
+3. Upload routes private→private bucket, public→public bucket — and the
+   `required_headers` fix that makes public uploads actually work.
+
+Set these once (any REST client / shell):
+
+```bash
+BASE=https://api.educ-prime.com        # or http://localhost:3000
+COUNTRY=benin
+TOKEN=...                               # JWT from POST /auth/connexion
+AUTH="Authorization: Bearer $TOKEN"
+```
+
+Get a token:
+
+```bash
+curl -s -X POST "$BASE/auth/connexion" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@exemple.com","mot_de_passe":"<pwd>"}' | jq .access_token
+```
+
+---
+
+## (2) `uuid` present in entity JSON
+
+Pick any owning entity; `uuid` must be in each item. The two that were
+previously missing it are `epreuves` and `ressources`:
+
+```bash
+# epreuves — expect .data[].uuid (and file_path / file_extension) present
+curl -s "$BASE/epreuves?country=$COUNTRY&page=1&limit=2" -H "$AUTH" \
+  | jq '.data[] | {id, uuid, file_path, file_extension}'
+
+# ressources — same
+curl -s "$BASE/ressources?country=$COUNTRY&page=1&limit=2" -H "$AUTH" \
+  | jq '.data[] | {id, uuid, file_path, file_extension}'
+
+# spot-check a few public-bucket entities too
+curl -s "$BASE/etablissements?country=$COUNTRY&limit=2" -H "$AUTH" | jq '.data[].uuid'
+curl -s "$BASE/categories?country=$COUNTRY&limit=2"      -H "$AUTH" | jq '.data[].uuid'
+```
+
+PASS: every item has a non-null `uuid`.
+FAIL (regression): `uuid` is `null` / absent → the entity's `findAll`
+projection dropped it.
+
+---
+
+## (3) Upload routes to the correct bucket + public uploads work
+
+The flow is two steps: ask backend for a presigned PUT, then PUT the bytes
+to R2 **replaying `required_headers`**.
+
+### 3a. PUBLIC slot (e.g. `categories/icone`) — was failing before
+
+```bash
+CAT_UUID=$(curl -s "$BASE/categories?country=$COUNTRY&limit=1" -H "$AUTH" | jq -r '.data[0].uuid')
+
+# Step 1: presign. Note: response.public == true, and required_headers
+# carries BOTH Content-Type and Cache-Control.
+PRES=$(curl -s -X POST "$BASE/files/categories/$CAT_UUID/icone/upload-url?country=$COUNTRY" \
+  -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"extension":"png"}')
+echo "$PRES" | jq '{public, expires_in, required_headers, path}'
+
+URL=$(echo "$PRES" | jq -r '.url')
+
+# Step 2: PUT replaying EXACTLY the signed headers. This is the fix —
+# Cache-Control must be sent or R2 returns 401 SignatureDoesNotMatch.
+curl -i -X PUT "$URL" \
+  -H 'Content-Type: image/png' \
+  -H 'Cache-Control: public, max-age=31536000, immutable' \
+  --data-binary @/path/to/test.png
+# expect: HTTP/1.1 200 OK
+
+# Negative control — omit Cache-Control → expect 403 SignatureDoesNotMatch
+curl -i -X PUT "$URL" -H 'Content-Type: image/png' --data-binary @/path/to/test.png
+
+# Verify object landed in the PUBLIC bucket: response.path is a full URL;
+# a plain GET (no auth) must return 200.
+echo "$PRES" | jq -r '.path'                     # https://<public-host>/categories/<uuid>/icone.png
+curl -I "$(echo "$PRES" | jq -r '.path')"        # expect 200, Cache-Control: ...immutable
+```
+
+PASS: PUT with both headers → 200; `path` is a full public URL; anonymous
+GET on it → 200.
+
+### 3b. PRIVATE slot (e.g. `epreuves/file`) — routes to private bucket
+
+```bash
+EPR_UUID=$(curl -s "$BASE/epreuves?country=$COUNTRY&limit=1" -H "$AUTH" | jq -r '.data[0].uuid')
+
+PRES=$(curl -s -X POST "$BASE/files/epreuves/$EPR_UUID/file/upload-url?country=$COUNTRY" \
+  -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"extension":"pdf"}')
+echo "$PRES" | jq '{public, required_headers, path}'   # public:false; path is /epreuves/<uuid>/file (logical, NOT a URL)
+
+URL=$(echo "$PRES" | jq -r '.url')
+curl -i -X PUT "$URL" -H 'Content-Type: application/pdf' --data-binary @/path/to/test.pdf
+# expect 200 (private slot signs no Cache-Control, so Content-Type alone is correct)
+
+# Confirm it is NOT publicly readable: there is no public URL for it.
+# Anonymous GET against the public host for this key must 404/403.
+curl -I "https://<public-host>/epreuves/$EPR_UUID/file.pdf"   # expect 403/404
+```
+
+PASS: `public:false`, `path` is the logical `/epreuves/<uuid>/file`, PUT
+200, and the object is not anonymously reachable.
+
+---
+
+## (1) Private presigned-GET link lives longer
+
+```bash
+# Private slot only. expires_in should be 21600 (6h) by default,
+# or whatever PRESIGN_DOWNLOAD_TTL_SECONDS is set to.
+curl -s "$BASE/files/epreuves/$EPR_UUID/file/download-url?country=$COUNTRY" -H "$AUTH" \
+  | jq '{expires_in, public, url}'
+
+# The signed URL should GET 200 well past the old 5-minute window.
+DL=$(curl -s "$BASE/files/epreuves/$EPR_UUID/file/download-url?country=$COUNTRY" -H "$AUTH" | jq -r '.url')
+curl -I "$DL"          # 200 now; still 200 after >5 min, up to expires_in
+
+# Public slot must be REJECTED here (use the entity's <slot>_path instead):
+curl -s -o /dev/null -w '%{http_code}\n' \
+  "$BASE/files/categories/$CAT_UUID/icone/download-url?country=$COUNTRY" -H "$AUTH"
+# expect 400
+```
+
+PASS: private `expires_in` == 21600 (or configured value); link still valid
+after 5 min; public slot → 400.
+
+To change the TTL, set in `backend/.env` (and the deploy `.env`):
+
+```
+PRESIGN_DOWNLOAD_TTL_SECONDS=86400   # e.g. 24h; capped at 604800 (7 days)
+```
+
+---
+
+## Notes / gotchas
+
+- **R2 CORS**: for browser uploads to public slots, the bucket's CORS rule
+  for the admin origin must allow the `Cache-Control` **request header** on
+  `PUT` (in addition to `Content-Type`). The admin frontend
+  (`filesService.uploadFile`) now replays `required_headers` automatically.
+- The server-proxied `POST .../upload` path already set the bucket +
+  Cache-Control correctly and was never affected by the signature bug; it's
+  the direct presigned PUT that needed the header replay.
+- Bucket routing is driven solely by `public: true` in
+  `backend/src/files/registry.ts`. Private file slots today:
+  `epreuves.file`, `ressources.file`, `utilisateurs.profil`,
+  `prestataires.identity`.

--- a/frontend/src/lib/services/files.service.ts
+++ b/frontend/src/lib/services/files.service.ts
@@ -9,6 +9,10 @@ export interface UploadUrlResponse {
     url: string;
     method: 'PUT';
     content_type: string;
+    // Exact headers that MUST be replayed on the PUT — the backend signs these
+    // into the presigned URL. Public slots include Cache-Control; sending only
+    // Content-Type would make R2 reject the PUT with SignatureDoesNotMatch.
+    required_headers: Record<string, string>;
     // Private slots: logical /<entity>/<uuid>/<slot>. Public slots: the full
     // anonymous URL — it's stored verbatim in the row's <slot>_path column, so
     // a plain entity GET already carries a usable link (no download-url call).
@@ -75,9 +79,14 @@ export const filesService = {
         }
         const presigned = await filesService.getUploadUrl(entity, uuid, slot, extension);
 
+        // Replay exactly the headers the backend signed. For public slots that
+        // includes Cache-Control; omitting it triggers SignatureDoesNotMatch
+        // (this is why public-bucket uploads were silently failing).
+        const headers: Record<string, string> = presigned.required_headers
+            ?? { 'Content-Type': presigned.content_type };
         const r = await fetch(presigned.url, {
             method: 'PUT',
-            headers: { 'Content-Type': presigned.content_type },
+            headers,
             body: file,
         });
         if (!r.ok) {


### PR DESCRIPTION
… TTL

(1) Private presigned-GET TTL is now configurable via PRESIGN_DOWNLOAD_TTL_SECONDS (default 6h, clamped to the 7-day SigV4 max), up from the shared 5-min value, so private <FileImage>/links stop expiring mid-view. Upload-url presign stays at 5 min.

(2) epreuves.findAll/findOne and ressources.findAll/findOne projected an explicit field subset that dropped `uuid` (and file_path/file_extension) — breaking any client that needs the uuid to drive the /files flow. Added them back. All other registry entities already return uuid.

(3) Public-bucket uploads were failing: the presigned PUT signs Cache-Control for public slots but the client only sent Content-Type, so R2 rejected it with SignatureDoesNotMatch. upload-url now returns `required_headers` and the frontend replays them verbatim. Bucket routing (private→R2_BUCKET, public→R2_PUBLIC_BUCKET) was already correct via the registry `public` flag; the signature mismatch was the real failure.

Adds docs/files-upload-test-schema.md with curl flows to verify each.