### PR TITLE
fix(deploy): bound every docker call with timeout to kill Run Command…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,14 +45,15 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT || 22 }}
           envs: COMPOSE_CONTENT,NGINX_CONTENT
-          # Bump above the 10m default for image pulls + certbot issuance.
-          # NOTE: the real "Run Command Timeout" cause was detached docker
-          # containers inheriting the SSH session's stdout/stderr pipe (the
-          # script finishes but sshd never sees EOF). That's fixed inside the
-          # script by redirecting FDs on `docker compose up -d`; this just
-          # gives the legit slow steps headroom.
+          # Backstop only. The real "Run Command Timeout" was `docker compose
+          # logs` (and other docker calls) blocking against the SSH session
+          # until this ceiling, so the job hung the full duration even though
+          # the deploy itself finished. Fixed in the script by wrapping EVERY
+          # docker call in `timeout` + `</dev/null` and using plain
+          # `docker logs` (no follow). This ceiling now only catches a wedged
+          # SSH connection; the script self-bounds well under it.
           timeout: 60s
-          command_timeout: 20m
+          command_timeout: 15m
           script: |
             set -e
             DEPLOY_DIR=/root/edukia
@@ -124,72 +125,73 @@ jobs:
             if [ ! -s "$CERT_DIR/fullchain.pem" ]; then
               echo "=== Aucun certificat trouvé pour $PRIMARY_DOMAIN — création d'un dummy"
               mkdir -p "$CERT_DIR"
-              docker run --rm \
+              timeout 300 docker run --rm \
                 -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
                 --entrypoint openssl certbot/certbot \
                 req -x509 -nodes -newkey rsa:4096 -days 1 \
                 -keyout "/etc/letsencrypt/live/$PRIMARY_DOMAIN/privkey.pem" \
                 -out "/etc/letsencrypt/live/$PRIMARY_DOMAIN/fullchain.pem" \
-                -subj "/CN=localhost"
+                -subj "/CN=localhost" </dev/null
               BOOTSTRAP_NEEDED=1
             fi
 
-            # Arrêter les conteneurs applicatifs (laisser db, redis, certbot, nginx)
-            $COMPOSE stop backend frontend
-            $COMPOSE rm -f backend frontend
+            # Every docker invocation below is wrapped in `timeout` and fed
+            # </dev/null. Root cause of the recurring "Run Command Timeout":
+            # `docker compose logs` (and occasionally pull/up) can block
+            # indefinitely against the SSH session, so the action waits out the
+            # full command_timeout. Bounding each call means a stuck step is
+            # killed in seconds and the script proceeds to its clean `exit 0`,
+            # rather than the whole job hanging ~20 min and failing.
 
-            # Pull les dernières images
-            $COMPOSE pull backend frontend redis
+            # Arrêter les conteneurs applicatifs (laisser db, redis, certbot, nginx)
+            timeout 120 $COMPOSE stop backend frontend </dev/null || true
+            timeout 60  $COMPOSE rm -f backend frontend </dev/null || true
+
+            # Pull les dernières images (le plus lent — large timeout).
+            timeout 900 $COMPOSE pull backend frontend redis </dev/null
 
             # Démarrer la pile (nginx avec dummy cert si nécessaire).
-            # Redirect stdin/stdout/stderr to /dev/null: detached containers
-            # otherwise inherit the SSH session's pipe FDs and keep them open
-            # after `up -d` returns, so sshd never sees EOF and appleboy/
-            # ssh-action waits out the full command_timeout ("Run Command
-            # Timeout") even though the deploy succeeded.
-            $COMPOSE up -d --remove-orphans </dev/null >/dev/null 2>&1
+            timeout 300 $COMPOSE up -d --remove-orphans </dev/null >/dev/null 2>&1
 
             # Si on a démarré avec un dummy cert, demander un vrai certificat
             # à Let's Encrypt via webroot (nginx est maintenant up sur le 80).
             if [ "$BOOTSTRAP_NEEDED" = "1" ]; then
               echo "=== Suppression du dummy cert et émission du vrai certificat"
-              docker run --rm \
+              timeout 60 docker run --rm \
                 -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
                 --entrypoint sh certbot/certbot \
-                -c "rm -rf /etc/letsencrypt/live/$PRIMARY_DOMAIN /etc/letsencrypt/archive/$PRIMARY_DOMAIN /etc/letsencrypt/renewal/$PRIMARY_DOMAIN.conf"
+                -c "rm -rf /etc/letsencrypt/live/$PRIMARY_DOMAIN /etc/letsencrypt/archive/$PRIMARY_DOMAIN /etc/letsencrypt/renewal/$PRIMARY_DOMAIN.conf" </dev/null || true
 
-              docker run --rm \
+              timeout 180 docker run --rm \
                 -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
                 -v "$DEPLOY_DIR/certbot/www:/var/www/certbot" \
                 certbot/certbot certonly --webroot \
                   --webroot-path=/var/www/certbot \
                   --email "$CERT_EMAIL" --agree-tos --no-eff-email \
                   --rsa-key-size 4096 \
-                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN"
+                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" </dev/null || true
 
               # Recharger nginx avec le vrai certificat
-              $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1
+              timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
             fi
 
             # Recharger nginx pour prendre en compte d'éventuels changements
-            # de configuration. On ne fail pas si nginx n'est pas up — le
-            # diagnostic ci-dessous montrera l'état réel.
-            $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
+            # de configuration. On ne fail pas si nginx n'est pas up.
+            timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
 
             # Attendre un peu pour que les conteneurs démarrent
             sleep 10
 
-            # Afficher l'état des conteneurs. `</dev/null` keeps these
-            # diagnostic commands from inheriting/holding the SSH pipe.
-            $COMPOSE ps </dev/null
+            # Diagnostic. Use plain `docker ps`/`docker logs` (never follow) and
+            # bound them with `timeout` so a stuck container log can't hang the
+            # SSH session. `|| true` so diagnostics never fail the deploy.
+            echo "=== Container status ==="
+            timeout 30 docker ps --filter name=edukia_ --format 'table {{.Names}}\t{{.Status}}' </dev/null || true
 
-            # Afficher les logs pour diagnostic. `--no-log-prefix` not used so
-            # we keep service tags; `</dev/null` detaches stdin so the call
-            # can't attach to a stream and hang the session.
             echo "=== Backend logs ==="
-            $COMPOSE logs --tail=50 backend </dev/null
+            timeout 20 docker logs edukia_backend --tail 50 </dev/null 2>&1 || true
             echo "=== Nginx logs ==="
-            $COMPOSE logs --tail=20 nginx </dev/null
+            timeout 20 docker logs edukia_nginx --tail 20 </dev/null 2>&1 || true
 
             # Explicit success marker + exit 0 so the SSH command returns a
             # clean status immediately after the last diagnostic.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Redis for BullMQ Queue
   redis:


### PR DESCRIPTION
… hang

The previous fix (FD redirect on `up -d`) treated the wrong cause: the job still hung the full command_timeout. The deploy log shows the script reaching "=== Nginx logs ===", emitting the compose warning, then silence until the timeout — i.e. `docker compose logs nginx` was blocking against the SSH session, not post-script FD inheritance.

Robustly fix it: wrap EVERY docker/compose call (stop, rm, pull, up, certbot runs, nginx reloads, diagnostics) in `timeout` + `</dev/null`, and replace `docker compose logs` with plain `docker logs --tail` (which cannot follow). A stuck step is now killed in seconds and the script proceeds to its clean `exit 0`, instead of hanging ~20 min and failing the job.

Also drop the obsolete `version:` key from docker-compose.yml (the warning that printed right as the hang began) and lower command_timeout 20m → 15m since the script now self-bounds well under it.