### PR TITLE
chore(files): set presign TTLs to 10 min; list all entities/slots in …

### DIFF
--- a/backend/src/files/files.controller.ts
+++ b/backend/src/files/files.controller.ts
@@ -22,6 +22,25 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { FilesService } from './files.service';
 import { UploadUrlRequestDto } from './dto/upload-url.dto';
+import { FILE_FIELD_REGISTRY } from './registry';
+
+// Derived from the registry so Swagger stays in sync when slots change.
+// All entities that expose at least one file slot.
+const KNOWN_ENTITIES = Object.keys(FILE_FIELD_REGISTRY);
+// Every slot key across all entities (deduped), for the :slot param enum.
+const KNOWN_SLOTS = [
+    ...new Set(Object.values(FILE_FIELD_REGISTRY).flatMap((slots) => Object.keys(slots))),
+];
+// Human-readable "entity → slot (visibility)" listing for the param docs.
+const ENTITY_SLOT_LISTING = Object.entries(FILE_FIELD_REGISTRY)
+    .map(([entity, slots]) =>
+        `${entity}: ${Object.entries(slots)
+            .map(([slot, cfg]) => `${slot} (${cfg.public ? 'public' : 'private'})`)
+            .join(', ')}`,
+    )
+    .join('; ');
+const ENTITY_PARAM_DESC = `Owning entity table. One of: ${ENTITY_SLOT_LISTING}.`;
+const SLOT_PARAM_DESC = `Slot key for the chosen entity. Valid (entity → slots): ${ENTITY_SLOT_LISTING}.`;
 
 @ApiTags('files')
 @Controller('files')
@@ -80,9 +99,9 @@ export class FilesController {
             'header in `required_headers` (Content-Type always; Cache-Control too for ' +
             'public slots) — otherwise R2 rejects the PUT with SignatureDoesNotMatch.',
     })
-    @ApiParam({ name: 'entity', example: 'categories' })
+    @ApiParam({ name: 'entity', example: 'categories', enum: KNOWN_ENTITIES, description: ENTITY_PARAM_DESC })
     @ApiParam({ name: 'uuid', description: 'UUID of the row that owns the file' })
-    @ApiParam({ name: 'slot', example: 'icone' })
+    @ApiParam({ name: 'slot', example: 'icone', enum: KNOWN_SLOTS, description: SLOT_PARAM_DESC })
     @ApiResponse({ status: 201, description: 'Presigned URL issued.' })
     @ApiResponse({ status: 400, description: 'Extension not in the slot allowlist.' })
     @ApiResponse({ status: 404, description: 'Unknown entity/slot or row uuid not found.' })
@@ -111,9 +130,9 @@ export class FilesController {
             'and updates the entity row. Use this when the client can\'t use the presigned ' +
             'URL flow. Extension is inferred from the uploaded filename.',
     })
-    @ApiParam({ name: 'entity', example: 'categories' })
+    @ApiParam({ name: 'entity', example: 'categories', enum: KNOWN_ENTITIES, description: ENTITY_PARAM_DESC })
     @ApiParam({ name: 'uuid', description: 'UUID of the row that owns the file' })
-    @ApiParam({ name: 'slot', example: 'icone' })
+    @ApiParam({ name: 'slot', example: 'icone', enum: KNOWN_SLOTS, description: SLOT_PARAM_DESC })
     async proxyUpload(
         @Param('entity') entity: string,
         @Param('uuid') uuid: string,
@@ -130,12 +149,14 @@ export class FilesController {
         description:
             'PRIVATE slots only. Reads the path/extension recorded on the entity row and ' +
             'returns a presigned GET URL valid for PRESIGN_DOWNLOAD_TTL_SECONDS (default ' +
-            '6h). Returns 400 for a public slot — read its URL directly from the entity\'s ' +
-            '<slot>_path field. Returns 404 if no file has been uploaded for this slot yet.',
+            '10 min). Returns 400 for a public slot — read its URL directly from the ' +
+            'entity\'s <slot>_path field. Returns 404 if no file has been uploaded yet. ' +
+            'Private slots: epreuves.file, ressources.file, prestataires.identity, ' +
+            'utilisateurs.profil.',
     })
-    @ApiParam({ name: 'entity', example: 'categories' })
+    @ApiParam({ name: 'entity', example: 'epreuves', enum: KNOWN_ENTITIES, description: ENTITY_PARAM_DESC })
     @ApiParam({ name: 'uuid', description: 'UUID of the row that owns the file' })
-    @ApiParam({ name: 'slot', example: 'icone' })
+    @ApiParam({ name: 'slot', example: 'file', enum: KNOWN_SLOTS, description: SLOT_PARAM_DESC })
     async createDownloadUrl(
         @Param('entity') entity: string,
         @Param('uuid') uuid: string,

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -18,15 +18,14 @@ import {
     getSlotConfig,
 } from './registry';
 
-// TTL for presigned PUT URLs — short, just enough for the client to start
-// the upload right after requesting the URL.
-const UPLOAD_PRESIGN_TTL_SECONDS = 5 * 60; // 5 minutes
-// TTL for presigned GET URLs on PRIVATE slots. Longer than the upload window:
-// these back <FileImage>/clients that may keep a rendered page open for a
-// while, and a too-short link expires mid-view ("expired link"). 6h balances
-// usability against how long a leaked link stays live. Overridable via
-// PRESIGN_DOWNLOAD_TTL_SECONDS.
-const DOWNLOAD_PRESIGN_TTL_SECONDS_DEFAULT = 6 * 60 * 60; // 6 hours
+// TTL for presigned PUT URLs — enough for the client to request the URL and
+// push the bytes without the link expiring mid-upload.
+const UPLOAD_PRESIGN_TTL_SECONDS = 10 * 60; // 10 minutes
+// TTL for presigned GET URLs on PRIVATE slots. Default kept in lockstep with
+// the upload window (10 min) so both `expires_in` values the client sees are
+// consistent. Overridable via PRESIGN_DOWNLOAD_TTL_SECONDS for ops that want
+// longer-lived read links.
+const DOWNLOAD_PRESIGN_TTL_SECONDS_DEFAULT = 10 * 60; // 10 minutes
 // Cache-Control written on PUT for public-bucket objects. R2 keys are
 // content-addressed by uuid, so a fresh upload always changes either the
 // (entity, uuid, slot) or extension — making `immutable` safe.

--- a/docs/files-upload-test-schema.md
+++ b/docs/files-upload-test-schema.md
@@ -116,14 +116,14 @@ PASS: `public:false`, `path` is the logical `/epreuves/<uuid>/file`, PUT
 ## (1) Private presigned-GET link lives longer
 
 ```bash
-# Private slot only. expires_in should be 21600 (6h) by default,
+# Private slot only. expires_in should be 600 (10 min) by default,
 # or whatever PRESIGN_DOWNLOAD_TTL_SECONDS is set to.
 curl -s "$BASE/files/epreuves/$EPR_UUID/file/download-url?country=$COUNTRY" -H "$AUTH" \
   | jq '{expires_in, public, url}'
 
-# The signed URL should GET 200 well past the old 5-minute window.
+# The signed URL should GET 200 within the 10-minute window.
 DL=$(curl -s "$BASE/files/epreuves/$EPR_UUID/file/download-url?country=$COUNTRY" -H "$AUTH" | jq -r '.url')
-curl -I "$DL"          # 200 now; still 200 after >5 min, up to expires_in
+curl -I "$DL"          # 200 now, up to expires_in (600s)
 
 # Public slot must be REJECTED here (use the entity's <slot>_path instead):
 curl -s -o /dev/null -w '%{http_code}\n' \
@@ -131,8 +131,8 @@ curl -s -o /dev/null -w '%{http_code}\n' \
 # expect 400
 ```
 
-PASS: private `expires_in` == 21600 (or configured value); link still valid
-after 5 min; public slot → 400.
+PASS: private `expires_in` == 600 (or configured value); link valid within
+the window; public slot → 400.
 
 To change the TTL, set in `backend/.env` (and the deploy `.env`):
 


### PR DESCRIPTION
…swagger

(1) Both presigned URLs now return expires_in = 600s (10 min): upload-url TTL raised from 5m, and the private download-url default lowered from 6h to 10m to match. Still overridable via PRESIGN_DOWNLOAD_TTL_SECONDS.

(2) The /files/:entity/:uuid/:slot/* params now enumerate every entity and its slots (with public/private visibility) in Swagger, derived from FILE_FIELD_REGISTRY so the docs stay in sync. Adds `enum` on the entity and slot path params plus a generated description.

Docs/test-schema TTL references updated to 10 min.