### PR TITLE
fix(opportunites): tolerate empty date on create, document R2 public-…

### DIFF
--- a/backend/src/opportunites/dto/create-opportunite.dto.ts
+++ b/backend/src/opportunites/dto/create-opportunite.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsOptional, IsBoolean, IsUrl, IsEnum, IsDate } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import { OpportuniteType } from '../entities/opportunite.entity';
 
 export class CreerOpportuniteDto {
@@ -24,7 +24,12 @@ export class CreerOpportuniteDto {
 
     @ApiProperty({ description: 'Date de publication', required: false })
     @IsOptional()
-    @Type(() => Date)
+    // An empty string from an unfilled date field must collapse to undefined:
+    // @IsOptional ignores undefined but not '', and @Type(() => Date) would turn
+    // '' into an Invalid Date that @IsDate rejects — 400ing the whole create.
+    @Transform(({ value }) =>
+        value === '' || value == null ? undefined : value instanceof Date ? value : new Date(value),
+    )
     @IsDate()
     date_publication?: Date;
 

--- a/frontend/src/pages/Opportunites.tsx
+++ b/frontend/src/pages/Opportunites.tsx
@@ -138,6 +138,7 @@ export default function Opportunites() {
                 ...formData,
                 image: formData.image || undefined,
                 lien_postuler: formData.lien_postuler || undefined,
+                date_publication: formData.date_publication || undefined,
             });
 
             // Step 2: PUT bytes to R2 via presigned URL.


### PR DESCRIPTION
…bucket CORS

Creating a Bourse 400'd because the form sends date_publication=""; @IsOptional skips undefined but not '', so @Type(() => Date) built an Invalid Date that @IsDate rejected. Coerce '' (and null) to undefined in the DTO via @Transform, and stop the admin form from sending an empty string.

The companion R2 upload failed its CORS preflight (403) because the public bucket had no CORS policy allowing the signed Cache-Control PUT header — an ops-side fix (backend/scripts/set-r2-cors.js, gitignored like other scripts).