### PR TITLE
feat(files): transitional Firebase<->R2 dual-write mirror

### DIFF
--- a/backend/src/fichiers/fichiers.module.ts
+++ b/backend/src/fichiers/fichiers.module.ts
@@ -6,9 +6,11 @@ import { Matiere } from '../matieres/entities/matiere.entity';
 import { Epreuve } from '../epreuves/entities/epreuve.entity';
 import { Ressource } from '../ressources/entities/ressource.entity';
 import { FirebaseConfig } from '../config/firebase.config';
+import { FilesModule } from '../files/files.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Matiere, Epreuve, Ressource])],
+  // TRANSITIONAL: FilesModule provides FilesService for the legacy → R2 mirror.
+  imports: [TypeOrmModule.forFeature([Matiere, Epreuve, Ressource]), FilesModule],
   controllers: [FichiersController],
   providers: [
     FichiersService,

--- a/backend/src/fichiers/fichiers.service.ts
+++ b/backend/src/fichiers/fichiers.service.ts
@@ -8,6 +8,7 @@ import { FirebaseConfig } from '../config/firebase.config';
 import { FichierUploadData } from './interfaces/fichier-upload-data.interface';
 import * as sharp from 'sharp';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
+import { FilesService } from '../files/files.service';
 
 @Injectable()
 export class FichiersService {
@@ -17,7 +18,50 @@ export class FichiersService {
     private readonly resolver: DataSourceResolver,
     @Inject('FirebaseConfig')
     private readonly firebaseConfig: any,
+    // TRANSITIONAL: mirrors legacy Firebase uploads into R2 + the new
+    // <slot>_path columns so admin/web sees mobile-created files.
+    private readonly filesService: FilesService,
   ) { }
+
+  /**
+   * TRANSITIONAL: map a legacy upload type to its (entity, slot) in the R2
+   * file registry, plus the row id to mirror against. Returns null for types
+   * with no clean single R2 slot (PUBLICITE / PARCOURS are multi-slot with an
+   * ambiguous subtype) or no entity id yet. Drop with the R2 mirror.
+   */
+  private resolveR2Target(
+    uploadData: FichierUploadData,
+    ids: { utilisateurId: number; epreuveId?: number; ressourceId?: number },
+  ): { entity: string; slot: string; id: number } | null {
+    switch (uploadData.type) {
+      case TypeFichier.PROFILE:
+        return { entity: 'utilisateurs', slot: 'profil', id: ids.utilisateurId };
+      case TypeFichier.EPREUVE:
+        return ids.epreuveId ? { entity: 'epreuves', slot: 'file', id: ids.epreuveId } : null;
+      case TypeFichier.RESSOURCE:
+        return ids.ressourceId ? { entity: 'ressources', slot: 'file', id: ids.ressourceId } : null;
+      case TypeFichier.EVENEMENT:
+        return uploadData.entityId ? { entity: 'evenements', slot: 'image', id: uploadData.entityId } : null;
+      case TypeFichier.OPPORTUNITE:
+        return uploadData.entityId ? { entity: 'opportunites', slot: 'image', id: uploadData.entityId } : null;
+      case TypeFichier.CONCOURS:
+        return uploadData.entityId ? { entity: 'concours', slot: 'file', id: uploadData.entityId } : null;
+      case TypeFichier.ETABLISSEMENT:
+        return uploadData.entityId ? { entity: 'etablissements', slot: 'logo', id: uploadData.entityId } : null;
+      case TypeFichier.CATEGORIES:
+        return uploadData.entityId ? { entity: 'categories', slot: 'icone', id: uploadData.entityId } : null;
+      case TypeFichier.FORUMS:
+        return uploadData.entityId ? { entity: 'forums', slot: 'file', id: uploadData.entityId } : null;
+      case TypeFichier.PRESTATAIRE:
+        return uploadData.entityId ? { entity: 'prestataires', slot: 'profil', id: uploadData.entityId } : null;
+      case TypeFichier.SERVICE:
+        return uploadData.entityId ? { entity: 'services', slot: 'image', id: uploadData.entityId } : null;
+      case TypeFichier.OFFRE:
+        return uploadData.entityId ? { entity: 'offres', slot: 'image', id: uploadData.entityId } : null;
+      default:
+        return null;
+    }
+  }
 
   private get matiereRepository(): Repository<Matiere> { return this.resolver.getRepository(Matiere); }
   private get epreuveRepository(): Repository<Epreuve> { return this.resolver.getRepository(Epreuve); }
@@ -352,6 +396,23 @@ export class FichiersService {
       const fileUrl = process.env.NODE_ENV === 'test'
         ? `https://storage.mock/${bucket.name}/${fileName}`
         : `https://storage.googleapis.com/${bucket.name}/${fileName}`;
+
+      // TRANSITIONAL: mirror the same bytes into R2 + the new <slot>_path
+      // columns so this legacy (mobile) upload is also visible to the admin/web
+      // R2 pipeline. Best-effort — mirrorLegacyToR2 swallows its own errors.
+      const r2Target = this.resolveR2Target(uploadData, {
+        utilisateurId,
+        epreuveId: actualEpreuveId,
+        ressourceId: actualRessourceId,
+      });
+      if (r2Target) {
+        const r2Ext = (fileName.split('.').pop() || '').toLowerCase();
+        await this.filesService.mirrorLegacyToR2(r2Target.entity, r2Target.slot, r2Target.id, {
+          buffer: fileBuffer,
+          extension: r2Ext,
+          mimetype: contentType,
+        });
+      }
 
       // Step 3: Update URL in epreuve or ressource table
       if (uploadData.type === TypeFichier.EPREUVE && actualEpreuveId) {

--- a/backend/src/files/files.module.ts
+++ b/backend/src/files/files.module.ts
@@ -1,10 +1,17 @@
 import { Module } from '@nestjs/common';
 import { FilesService } from './files.service';
 import { FilesController } from './files.controller';
+import { FirebaseConfig } from '../config/firebase.config';
 
 @Module({
     controllers: [FilesController],
-    providers: [FilesService],
+    providers: [
+        FilesService,
+        // TRANSITIONAL: enables the R2 → Firebase mirror in FilesService.
+        // Provided by class (not via FichiersModule) to avoid a module cycle —
+        // FichiersModule imports FilesModule for the reverse mirror.
+        { provide: 'FirebaseConfig', useClass: FirebaseConfig },
+    ],
     exports: [FilesService],
 })
 export class FilesModule { }

--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -1,5 +1,6 @@
 import {
     Injectable,
+    Inject,
     NotFoundException,
     BadRequestException,
     InternalServerErrorException,
@@ -52,6 +53,10 @@ export class FilesService {
     constructor(
         @InjectDataSource() private readonly dataSource: DataSource,
         private readonly config: ConfigService,
+        // TRANSITIONAL: used to mirror uploads into Firebase Storage so the
+        // mobile app (still reading legacy URL columns) sees R2-created rows.
+        // Injected by class so FilesModule doesn't depend on FichiersModule.
+        @Inject('FirebaseConfig') private readonly firebase: any,
     ) {
         const endpoint = this.config.get<string>('R2_ENDPOINT');
         const accessKeyId = this.config.get<string>('R2_ACCESS_KEY_ID');
@@ -330,6 +335,107 @@ export class FilesService {
 
         await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
 
+        // TRANSITIONAL: also push to Firebase + write the legacy URL column so
+        // the mobile app sees this file. Best-effort — a Firebase hiccup must
+        // not fail an upload that already succeeded against R2 (canonical).
+        await this.mirrorToFirebase(entity, uuid, slot, cfg, rowId, file.buffer, extension, file.mimetype);
+
         return { path: storedPath, extension, public: !!cfg.public };
+    }
+
+    /**
+     * TRANSITIONAL Firebase mirror (R2 → Firebase). Pushes the just-uploaded
+     * bytes to Firebase Storage under <entity>/<uuid>/<slot>.<ext> and writes
+     * the resulting public URL into the slot's legacy column, so the mobile
+     * app (which still reads those columns) sees R2-created files. No-op for
+     * slots without a legacyColumn (categories.icone, PII identity, the
+     * content slots). Best-effort: failures are logged, never thrown.
+     * Remove together with the `legacyColumn` registry field post-migration.
+     */
+    private async mirrorToFirebase(
+        entity: string,
+        uuid: string,
+        slot: string,
+        cfg: FileSlotConfig,
+        rowId: number,
+        buffer: Buffer,
+        extension: string,
+        mimetype: string,
+    ): Promise<void> {
+        if (!cfg.legacyColumn) return;
+        try {
+            const bucket = this.firebase.getBucket();
+            const key = buildObjectKey(entity, uuid, slot, extension);
+            await bucket.file(key).save(buffer, {
+                metadata: { contentType: mimetype || MIME_BY_EXT[extension] || 'application/octet-stream' },
+            });
+            const url = `https://storage.googleapis.com/${bucket.name}/${key}`;
+            await this.dataSource.query(
+                `UPDATE "${entity}" SET "${cfg.legacyColumn}" = $1 WHERE id = $2`,
+                [url, rowId],
+            );
+            this.logger.log(`Mirrored ${entity}/${uuid}/${slot} → Firebase (${cfg.legacyColumn}).`);
+        } catch (err) {
+            this.logger.warn(
+                `Firebase mirror failed for ${entity}/${uuid}/${slot}: ${err?.message ?? err}`,
+            );
+        }
+    }
+
+    /**
+     * TRANSITIONAL R2 mirror (Firebase → R2). Called by the legacy FichiersService
+     * after a Firebase upload: pushes the same bytes to the correct R2 bucket
+     * and writes the new <slot>_path / <slot>_extension columns, so a row
+     * created via the legacy mobile flow is also visible to the admin/web R2
+     * pipeline. Resolves the row uuid from its numeric id (the legacy service
+     * works in ids). Best-effort: unknown slot, bad extension, missing row, or
+     * an R2 error are logged and swallowed — never break the legacy upload.
+     * Remove post-migration.
+     */
+    async mirrorLegacyToR2(
+        entity: string,
+        slot: string,
+        rowId: number,
+        file: { buffer: Buffer; extension: string; mimetype?: string },
+    ): Promise<void> {
+        try {
+            const cfg = getSlotConfig(entity, slot);
+            if (!cfg) return;
+            const extension = file.extension.toLowerCase().replace(/^\./, '');
+            if (!cfg.authorized.includes(extension)) {
+                this.logger.warn(
+                    `R2 mirror skipped for ${entity}/${slot}: extension '${extension}' not authorized.`,
+                );
+                return;
+            }
+            const rows = await this.dataSource.query(
+                `SELECT uuid FROM "${entity}" WHERE id = $1 LIMIT 1`,
+                [rowId],
+            );
+            const uuid = rows[0]?.uuid;
+            if (!uuid) {
+                this.logger.warn(`R2 mirror skipped: no ${entity} row with id ${rowId}.`);
+                return;
+            }
+
+            const key = buildObjectKey(entity, uuid, slot, extension);
+            const bucket = this.bucketFor(cfg);
+            await this.client.send(
+                new PutObjectCommand({
+                    Bucket: bucket,
+                    Key: key,
+                    Body: file.buffer,
+                    ContentType: file.mimetype || MIME_BY_EXT[extension] || 'application/octet-stream',
+                    ...(cfg.public ? { CacheControl: PUBLIC_CACHE_CONTROL } : {}),
+                }),
+            );
+            const storedPath = this.storedPathFor(cfg, entity, uuid, slot, extension);
+            await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
+            this.logger.log(`Mirrored ${entity}/${uuid}/${slot} → R2 (${cfg.pathColumn}).`);
+        } catch (err) {
+            this.logger.warn(
+                `R2 mirror failed for ${entity} id=${rowId} slot=${slot}: ${err?.message ?? err}`,
+            );
+        }
     }
 }

--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -22,6 +22,18 @@ export interface FileSlotConfig {
     extColumn: string;
     authorized: readonly string[];
     public?: boolean;
+    /**
+     * TRANSITIONAL — Firebase↔R2 dual-write bridge. Name of the *legacy* column
+     * the mobile app still reads (e.g. `epreuves.url`, `opportunites.image`).
+     * When set, the file pipeline mirrors uploads into Firebase Storage and
+     * writes the resulting public URL here, so a row created via the new R2
+     * flow is still visible to mobile (and vice-versa). Slots with no legacy
+     * column (categories.icone), no clean target (parcours.content,
+     * publicites.content), or sensitive PII (prestataires.identity) leave this
+     * unset and are not mirrored. Mapping mirrors scripts/migrate-firebase-to-r2.js.
+     * Remove this field (and the mirror code) once mobile cuts over to R2.
+     */
+    legacyColumn?: string;
 }
 
 const IMAGE_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'avif'] as const;
@@ -35,51 +47,53 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
     },
     concours: {
         // Private: concours papers are gated behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
     },
     epreuves: {
         // Private: exam papers are gated behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
     },
     etablissements: {
-        logo: { pathColumn: 'logo_path', extColumn: 'logo_extension', authorized: IMAGE_EXTS_WITH_SVG, public: true },
+        logo: { pathColumn: 'logo_path', extColumn: 'logo_extension', authorized: IMAGE_EXTS_WITH_SVG, public: true, legacyColumn: 'logo' },
     },
     evenements: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image' },
     },
     forums: {
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: IMAGE_OR_PDF, public: true },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: IMAGE_OR_PDF, public: true, legacyColumn: 'photo' },
     },
     offres: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },
     },
     opportunites: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image' },
     },
     parcours: {
-        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true },
+        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },
+        // content has no clean legacy target (legacy `lien_video` is a video link) — not mirrored.
         content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS, public: true },
     },
     prestataires: {
-        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, public: true },
+        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'photo_profil' },
         // Private: identity documents (ID card / passport scans) are sensitive
-        // PII and must never be anonymously readable.
+        // PII and must never be anonymously readable — intentionally not mirrored.
         identity: { pathColumn: 'identity_photo_path', extColumn: 'identity_photo_extension', authorized: IMAGE_EXTS },
     },
     publicites: {
-        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true },
+        covert: { pathColumn: 'covert_image_path', extColumn: 'covert_image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image' },
+        // content (legacy `media`) is sometimes a video — no clean image target, not mirrored.
         content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS, public: true },
     },
     ressources: {
         // Private: resource files stay behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY },
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
     },
     services: {
-        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true },
+        image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },
     },
     utilisateurs: {
         // Private: user profile photos stay on the presigned-URL flow.
-        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS },
+        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, legacyColumn: 'photo' },
     },
 };
 

--- a/frontend/src/lib/services/files.service.ts
+++ b/frontend/src/lib/services/files.service.ts
@@ -31,6 +31,14 @@ export interface DownloadUrlResponse {
     public: boolean;
 }
 
+// Response from the server-proxied /upload endpoint.
+export interface UploadResponse {
+    // Public slots: full anonymous URL (stored on the row). Private: logical path.
+    path: string;
+    extension: string;
+    public: boolean;
+}
+
 export type FileRegistry = Record<string, Record<string, { authorized: string[]; public: boolean }>>;
 
 export const filesService = {
@@ -65,34 +73,19 @@ export const filesService = {
     },
 
     /**
-     * One-shot upload: fetch the presigned URL, PUT bytes to R2, return the
-     * server-side path. Throws if either step fails.
+     * One-shot upload via the server-proxied endpoint: POST the file as
+     * multipart/form-data; the backend streams it to R2 and returns the stored
+     * path. Throws if the upload fails.
      *
-     * The browser must be allowed to talk to R2 directly (CORS on the bucket
-     * must allow PUT from the admin origin) — Cloudflare R2 buckets default
-     * to public-read of presigned URLs but require per-origin CORS for PUT.
+     * TRANSITIONAL: we route through the proxy (rather than a presigned direct-
+     * to-R2 PUT) so the backend holds the bytes and can mirror them into
+     * Firebase Storage for the mobile app, which still reads the legacy URL
+     * columns. Once mobile cuts over to R2, this can revert to the presigned
+     * `getUploadUrl` + direct PUT flow (still available on the backend).
      */
-    async uploadFile(entity: string, uuid: string, slot: Slot, file: File): Promise<UploadUrlResponse> {
-        const extension = (file.name.split('.').pop() ?? '').toLowerCase();
-        if (!extension) {
-            throw new Error(`Cannot determine extension from filename "${file.name}".`);
-        }
-        const presigned = await filesService.getUploadUrl(entity, uuid, slot, extension);
-
-        // Replay exactly the headers the backend signed. For public slots that
-        // includes Cache-Control; omitting it triggers SignatureDoesNotMatch
-        // (this is why public-bucket uploads were silently failing).
-        const headers: Record<string, string> = presigned.required_headers
-            ?? { 'Content-Type': presigned.content_type };
-        const r = await fetch(presigned.url, {
-            method: 'PUT',
-            headers,
-            body: file,
-        });
-        if (!r.ok) {
-            const text = await r.text().catch(() => '');
-            throw new Error(`R2 upload failed (${r.status}): ${text || r.statusText}`);
-        }
-        return presigned;
+    async uploadFile(entity: string, uuid: string, slot: Slot, file: File): Promise<UploadResponse> {
+        const form = new FormData();
+        form.append('file', file);
+        return api.post<UploadResponse>(`/files/${entity}/${uuid}/${slot}/upload`, form);
     },
 };


### PR DESCRIPTION
During the mobile Firebase->R2 cutover, mirror every upload into both stores so a row is visible to both clients regardless of which endpoint created it:

- New /files proxy upload now also pushes bytes to Firebase and writes the legacy URL column (FilesService.proxyUpload -> mirrorToFirebase).
- Legacy /fichiers upload now also PutObjects to R2 and fills the new *_path columns (FichiersService -> FilesService.mirrorLegacyToR2).
- registry.ts gains an optional legacyColumn per slot (the column mobile reads); slots without it (categories.icone, parcours/publicites.content) and PII (prestataires.identity) are not mirrored.
- Frontend uploadFile switches to the multipart proxy endpoint so the backend holds the bytes; presign flow stays available for the revert.

Both directions are best-effort (logged, non-fatal). All transitional code is marked TRANSITIONAL for removal once mobile reads R2.