### PR TITLE
feat(files): 1h presigned-upload TTL for epreuves slot

### DIFF
--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -238,7 +238,8 @@ export class FilesService {
             ContentType: contentType,
             ...(cfg.public ? { CacheControl: PUBLIC_CACHE_CONTROL } : {}),
         });
-        const url = await getSignedUrl(this.client, command, { expiresIn: UPLOAD_PRESIGN_TTL_SECONDS });
+        const uploadTtl = cfg.uploadTtlSeconds ?? UPLOAD_PRESIGN_TTL_SECONDS;
+        const url = await getSignedUrl(this.client, command, { expiresIn: uploadTtl });
 
         await this.writePathOnRow(entity, rowId, cfg, storedPath, extension);
 
@@ -255,7 +256,7 @@ export class FilesService {
             },
             path: storedPath,
             extension,
-            expires_in: UPLOAD_PRESIGN_TTL_SECONDS,
+            expires_in: uploadTtl,
             public: !!cfg.public,
         };
     }

--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -23,6 +23,12 @@ export interface FileSlotConfig {
     authorized: readonly string[];
     public?: boolean;
     /**
+     * Override for the presigned-PUT lifetime on this slot (seconds). Defaults
+     * to the 10-min UPLOAD_PRESIGN_TTL_SECONDS. Large private PDFs (exam papers)
+     * can take a while to push, so `epreuves.file` gets a 1-hour window.
+     */
+    uploadTtlSeconds?: number;
+    /**
      * TRANSITIONAL — Firebase↔R2 dual-write bridge. Name of the *legacy* column
      * the mobile app still reads (e.g. `epreuves.url`, `opportunites.image`).
      * When set, the file pipeline mirrors uploads into Firebase Storage and
@@ -51,7 +57,8 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
     },
     epreuves: {
         // Private: exam papers are gated behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
+        // 1-hour upload window — exam PDFs are large and slow to push.
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url', uploadTtlSeconds: 3600 },
     },
     etablissements: {
         logo: { pathColumn: 'logo_path', extColumn: 'logo_extension', authorized: IMAGE_EXTS_WITH_SVG, public: true, legacyColumn: 'logo' },


### PR DESCRIPTION
## What

Give the `epreuves.file` slot a **1-hour** presigned-PUT (upload-url) window instead of the flat 10-minute default.

## Why

Exam papers are large PDFs and slow to push to R2; the 10-min `upload-url` TTL can expire mid-upload. Only the *download*-url side had a configurable TTL — uploads were a flat constant for every slot.

## How

- `registry.ts` — added optional `uploadTtlSeconds` to `FileSlotConfig`; set `uploadTtlSeconds: 3600` on `epreuves.file`. Registry-driven so it's a per-slot override, not an entity special-case.
- `files.service.ts` — `createUploadUrl` resolves `cfg.uploadTtlSeconds ?? UPLOAD_PRESIGN_TTL_SECONDS` for both the presign `expiresIn` and the echoed `expires_in`.

All other slots keep the 10-minute default. `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)