### PR TITLE
fix(publicites): make lien_inscription truly optional

### DIFF
--- a/backend/src/publicites/dto/creer-publicite.dto.ts
+++ b/backend/src/publicites/dto/creer-publicite.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional, IsInt, IsBoolean, IsUrl } from 'class-validator';
+import { IsString, IsOptional, IsInt, IsBoolean, IsUrl, ValidateIf } from 'class-validator';
 
 export class CreerPubliciteDto {
     @ApiProperty({ example: 'Publicité Coca-Cola', description: 'Titre de la publicité' })
@@ -33,6 +33,7 @@ export class CreerPubliciteDto {
 
     @ApiProperty({ description: 'Lien d\'inscription', required: false })
     @IsOptional()
+    @ValidateIf((o) => o.lien_inscription !== undefined && o.lien_inscription !== null && o.lien_inscription !== '')
     @IsUrl()
     lien_inscription?: string;
 }

--- a/frontend/src/pages/Publicites.tsx
+++ b/frontend/src/pages/Publicites.tsx
@@ -210,6 +210,7 @@ export default function Publicites() {
                 ...formData,
                 image: formData.image || undefined,
                 media: formData.media || undefined,
+                lien_inscription: formData.lien_inscription?.trim() || undefined,
             });
             createdEntityId = createdPublicite.id;
 
@@ -295,7 +296,7 @@ export default function Publicites() {
                     titre: editingPublicite.titre,
                     media: editingPublicite.type_media === 'Video' ? editingPublicite.media : undefined,
                     type_media: editingPublicite.type_media,
-                    lien_inscription: editingPublicite.lien_inscription || "",
+                    lien_inscription: editingPublicite.lien_inscription?.trim() || undefined,
                     ordre: editingPublicite.ordre,
                     actif: editingPublicite.actif,
                 },


### PR DESCRIPTION
## Problem
Creating a publicité from the admin without a registration link **failed**, even though the field is labelled "(Optionnel)" and has no `required` attribute.

**Root cause:** the form initialises `lien_inscription: ""` and sends the empty string. The backend DTO had `@IsOptional() @IsUrl()`, but `@IsOptional()` only skips validation for `undefined`/`null` — **not** `""`. So `@IsUrl()` rejected `""` → HTTP 400.

## Fix
- **Backend** (`creer-publicite.dto.ts`): gate the URL check with `@ValidateIf(o => lien_inscription is not undefined/null/'' )` so an empty value is accepted but a non-URL string still 400s. `MajPubliciteDto extends PartialType(CreerPubliciteDto)`, so the update path inherits the same rule — no second edit needed.
- **Frontend** (`Publicites.tsx`): create & edit handlers now send `lien_inscription?.trim() || undefined` instead of `""`, matching how other optional fields (`image`, `media`) are already handled.

## Verification
- `cd backend && npx tsc --noEmit` ✅
- `cd frontend && npx tsc --noEmit -p tsconfig.app.json` ✅
- Empty / omitted `lien_inscription` → accepted; `"notaurl"` → still 400; valid URL → accepted.

## Out of scope
Required fields (`titre`, cover image) unchanged. No DB migration (column already `nullable`). No `pays`/`country` added to DTOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)