### PR TITLE
feat(files): 1h download-url TTL for private PDF slots

### DIFF
--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -27,6 +27,9 @@ const UPLOAD_PRESIGN_TTL_SECONDS = 10 * 60; // 10 minutes
 // consistent. Overridable via PRESIGN_DOWNLOAD_TTL_SECONDS for ops that want
 // longer-lived read links.
 const DOWNLOAD_PRESIGN_TTL_SECONDS_DEFAULT = 10 * 60; // 10 minutes
+// R2/S3 SigV4 hard ceiling for presigned-URL lifetimes. Every resolved TTL
+// (env override or per-slot registry override) is clamped to this.
+const MAX_S3_PRESIGN_TTL = 7 * 24 * 60 * 60; // 604800s — SigV4 ceiling
 // Cache-Control written on PUT for public-bucket objects. R2 keys are
 // content-addressed by uuid, so a fresh upload always changes either the
 // (entity, uuid, slot) or extension — making `immutable` safe.
@@ -70,7 +73,6 @@ export class FilesService {
         // tune it without a redeploy; falls back to the 6h default. Clamp to
         // R2/S3 SigV4's hard maximum of 7 days.
         const ttlRaw = Number(this.config.get<string>('PRESIGN_DOWNLOAD_TTL_SECONDS'));
-        const MAX_S3_PRESIGN_TTL = 7 * 24 * 60 * 60; // 604800s — SigV4 ceiling
         this.downloadTtlSeconds =
             Number.isFinite(ttlRaw) && ttlRaw > 0
                 ? Math.min(ttlRaw, MAX_S3_PRESIGN_TTL)
@@ -292,13 +294,16 @@ export class FilesService {
 
         const key = buildObjectKey(entity, uuid, slot, row.ext);
         const command = new GetObjectCommand({ Bucket: this.bucketFor(cfg), Key: key });
-        const url = await getSignedUrl(this.client, command, { expiresIn: this.downloadTtlSeconds });
+        // Per-slot override (e.g. 1h for large exam/concours/resource PDFs)
+        // falls back to the env-tuned default; clamp to the SigV4 ceiling.
+        const downloadTtl = Math.min(cfg.downloadTtlSeconds ?? this.downloadTtlSeconds, MAX_S3_PRESIGN_TTL);
+        const url = await getSignedUrl(this.client, command, { expiresIn: downloadTtl });
         return {
             url,
             method: 'GET' as const,
             path: row.path,
             extension: row.ext,
-            expires_in: this.downloadTtlSeconds,
+            expires_in: downloadTtl,
             public: false,
         };
     }

--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -29,6 +29,13 @@ export interface FileSlotConfig {
      */
     uploadTtlSeconds?: number;
     /**
+     * Override for the presigned-GET lifetime on this slot (seconds). Defaults
+     * to PRESIGN_DOWNLOAD_TTL_SECONDS (10 min). Large private PDFs (exam,
+     * concours, resource papers) get a 1-hour window so the read link doesn't
+     * expire mid-session. Clamped to the 7-day SigV4 max on resolution.
+     */
+    downloadTtlSeconds?: number;
+    /**
      * TRANSITIONAL — Firebase↔R2 dual-write bridge. Name of the *legacy* column
      * the mobile app still reads (e.g. `epreuves.url`, `opportunites.image`).
      * When set, the file pipeline mirrors uploads into Firebase Storage and
@@ -53,12 +60,13 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
     },
     concours: {
         // Private: concours papers are gated behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
+        // 1-hour download window — concours PDFs are large, don't drop mid-session.
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url', downloadTtlSeconds: 3600 },
     },
     epreuves: {
         // Private: exam papers are gated behind authorized, short-lived reads.
-        // 1-hour upload window — exam PDFs are large and slow to push.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url', uploadTtlSeconds: 3600 },
+        // 1-hour upload + download window — exam PDFs are large and slow to push.
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url', uploadTtlSeconds: 3600, downloadTtlSeconds: 3600 },
     },
     etablissements: {
         logo: { pathColumn: 'logo_path', extColumn: 'logo_extension', authorized: IMAGE_EXTS_WITH_SVG, public: true, legacyColumn: 'logo' },
@@ -93,7 +101,8 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
     },
     ressources: {
         // Private: resource files stay behind authorized, short-lived reads.
-        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url' },
+        // 1-hour download window — resource PDFs are large, don't drop mid-session.
+        file: { pathColumn: 'file_path', extColumn: 'file_extension', authorized: PDF_ONLY, legacyColumn: 'url', downloadTtlSeconds: 3600 },
     },
     services: {
         image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },


### PR DESCRIPTION
## What
Give the presigned **download** URL (`GET /files/:entity/:uuid/:slot/download-url`) a **1-hour (3600s)** lifetime for the private PDF slots `epreuves.file`, `concours.file`, and `ressources.file`. Large exam/concours/resource PDFs no longer lose their link mid-session. All other private slots keep the env-tuned default (10 min).

## Why
The download-url TTL was a single instance value (`PRESIGN_DOWNLOAD_TTL_SECONDS`, default 600s) for every slot — only the *upload* side had a per-slot override (`uploadTtlSeconds`). The docs already claimed a per-slot download override existed; this makes it real.

## How (mirrors the existing `uploadTtlSeconds` pattern)
- `registry.ts`: add optional `downloadTtlSeconds?: number` to `FileSlotConfig`; set `3600` on the three PDF slots.
- `files.service.ts`: `createDownloadUrl` resolves `Math.min(cfg.downloadTtlSeconds ?? this.downloadTtlSeconds, MAX_S3_PRESIGN_TTL)` and uses it for both the signed `expiresIn` and the echoed `expires_in`. `MAX_S3_PRESIGN_TTL` (7-day SigV4 ceiling) hoisted to a module const.

Route stays `GET` (unchanged). Public slots still 400 on this endpoint.

## Verification
- `cd backend && npx tsc --noEmit` ✅
- epreuves/concours/ressources → `expires_in: 3600`; other private slots → default; resolved TTL clamped to the 7-day max.
- CLAUDE.md / AGENTS.md (gitignored local docs) already describe the override and list `ressources.file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)