### PR TITLE
fix(education): derive pays from parent Etablissement (source of truth)

### DIFF
--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, ForbiddenException, Logger, BadRequestEx
 import { FichiersService } from '../fichiers/fichiers.service';
 import { Repository, Like, FindOptionsWhere, Brackets } from 'typeorm';
 import { Epreuve } from './entities/epreuve.entity';
+import { Matiere } from '../matieres/entities/matiere.entity';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
 import { CreerEpreuveDto } from './dto/creer-epreuve.dto';
 import { MajEpreuveDto } from './dto/maj-epreuve.dto';
@@ -23,8 +24,21 @@ export class EpreuvesService {
     return this.resolver.getRepository(Epreuve);
   }
 
+  private get matieresRepository(): Repository<Matiere> {
+    return this.resolver.getRepository(Matiere);
+  }
+
   async create(creerEpreuveDto: CreerEpreuveDto, professeurId: number) {
     this.logger.log(`Création d'une épreuve: ${creerEpreuveDto.titre} par professeur ID: ${professeurId}`);
+    // pays is DERIVED from the parent Matiere (cascading up to the Etablissement),
+    // never defaulted to 'benin' nor taken from the request country.
+    const matiere = await this.matieresRepository.findOne({
+      where: { id: creerEpreuveDto.matiere_id },
+    });
+    if (!matiere) {
+      this.logger.warn(`Matière ID ${creerEpreuveDto.matiere_id} introuvable`);
+      throw new NotFoundException('Matière non trouvée');
+    }
     const newEpreuve = new Epreuve();
     newEpreuve.titre = creerEpreuveDto.titre;
     newEpreuve.url = creerEpreuveDto.url;
@@ -34,8 +48,9 @@ export class EpreuvesService {
     newEpreuve.date_publication = creerEpreuveDto.date_publication;
     newEpreuve.nombre_pages = creerEpreuveDto.nombre_pages;
     newEpreuve.type = creerEpreuveDto.type;
+    newEpreuve.pays = matiere.pays;
     const saved = await this.epreuvesRepository.save(newEpreuve);
-    this.logger.log(`Épreuve créée: ${saved.titre} (ID: ${saved.id}, Matière: ${saved.matiere_id})`);
+    this.logger.log(`Épreuve créée: ${saved.titre} (ID: ${saved.id}, Matière: ${saved.matiere_id}, pays: ${saved.pays})`);
     return saved;
   }
 
@@ -210,6 +225,19 @@ export class EpreuvesService {
     }
 
     Object.assign(epreuve, majEpreuveDto);
+
+    // Parent changed → re-derive pays from the new Matiere.
+    if (majEpreuveDto.matiere_id) {
+      const matiere = await this.matieresRepository.findOne({
+        where: { id: majEpreuveDto.matiere_id },
+      });
+      if (!matiere) {
+        this.logger.warn(`Matière ID ${majEpreuveDto.matiere_id} introuvable`);
+        throw new NotFoundException('Matière non trouvée');
+      }
+      epreuve.pays = matiere.pays;
+    }
+
     const updated = await this.epreuvesRepository.save(epreuve);
     this.logger.log(`Épreuve mise à jour: ${updated.titre} (ID: ${id})`);
     return updated;

--- a/backend/src/filieres/filieres.service.ts
+++ b/backend/src/filieres/filieres.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException, Logger, ConflictException } from '@nestjs/common';
 import { Repository, Like, FindOptionsWhere, Brackets } from 'typeorm';
 import { Filiere } from './entities/filiere.entity';
+import { Etablissement } from '../etablissements/entities/etablissement.entity';
 import { CreerFiliereDto } from './dto/creer-filiere.dto';
 import { MajFiliereDto } from './dto/maj-filiere.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
@@ -21,14 +22,28 @@ export class FilieresService {
     return this.resolver.getRepository(Filiere);
   }
 
+  private get etablissementsRepository(): Repository<Etablissement> {
+    return this.resolver.getRepository(Etablissement);
+  }
+
   async create(creerFiliereDto: CreerFiliereDto) {
     this.logger.log(`Création d'une filière: ${creerFiliereDto.nom} (Établissement ID: ${creerFiliereDto.etablissement_id})`);
+    // pays is DERIVED from the parent Etablissement (single source of truth),
+    // never from the request country switcher nor the column default.
+    const etablissement = await this.etablissementsRepository.findOne({
+      where: { id: creerFiliereDto.etablissement_id },
+    });
+    if (!etablissement) {
+      this.logger.warn(`Établissement ID ${creerFiliereDto.etablissement_id} introuvable`);
+      throw new NotFoundException('Établissement non trouvé');
+    }
     const newFiliere = this.filieresRepository.create({
       nom: creerFiliereDto.nom,
       etablissement: { id: creerFiliereDto.etablissement_id } as any,
+      pays: etablissement.pays,
     });
     const saved = await this.filieresRepository.save(newFiliere);
-    this.logger.log(`Filière créée: ${saved.nom} (ID: ${saved.id})`);
+    this.logger.log(`Filière créée: ${saved.nom} (ID: ${saved.id}, pays: ${saved.pays})`);
     return saved;
   }
 
@@ -112,7 +127,16 @@ export class FilieresService {
     }
 
     if (majFiliereDto.etablissement_id) {
+      // Parent changed → re-derive pays from the new Etablissement.
+      const etablissement = await this.etablissementsRepository.findOne({
+        where: { id: majFiliereDto.etablissement_id },
+      });
+      if (!etablissement) {
+        this.logger.warn(`Établissement ID ${majFiliereDto.etablissement_id} introuvable`);
+        throw new NotFoundException('Établissement non trouvé');
+      }
       filiere.etablissement = { id: majFiliereDto.etablissement_id } as any;
+      filiere.pays = etablissement.pays;
     }
 
     const updated = await this.filieresRepository.save(filiere);

--- a/backend/src/matieres/matieres.module.ts
+++ b/backend/src/matieres/matieres.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { MatieresController } from './matieres.controller';
 import { MatieresService } from './matieres.service';
 import { Matiere } from './entities/matiere.entity';
+import { NiveauEtude } from '../niveau-etude/entities/niveau-etude.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Matiere])],
+  imports: [TypeOrmModule.forFeature([Matiere, NiveauEtude])],
   controllers: [MatieresController],
   providers: [MatieresService],
   exports: [MatieresService],

--- a/backend/src/matieres/matieres.service.ts
+++ b/backend/src/matieres/matieres.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, Logger, ConflictException } from '@nestj
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets } from 'typeorm';
 import { Matiere } from './entities/matiere.entity';
+import { NiveauEtude } from '../niveau-etude/entities/niveau-etude.entity';
 import { CreerMatiereDto } from './dto/creer-matiere.dto';
 import { MajMatiereDto } from './dto/maj-matiere.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
@@ -15,13 +16,25 @@ export class MatieresService {
   constructor(
     @InjectRepository(Matiere)
     private readonly matieresRepository: Repository<Matiere>,
+    @InjectRepository(NiveauEtude)
+    private readonly niveauEtudeRepository: Repository<NiveauEtude>,
   ) { }
 
+  // Note: `pays` (from @CurrentCountry) is intentionally ignored as the saved
+  // value — it stays in the signature so the controller/middleware scoping is
+  // unaffected, but the stored pays is DERIVED from the parent NiveauEtude.
   async create(pays: string, creerMatiereDto: CreerMatiereDto) {
-    this.logger.log(`Création d'une matière (pays=${pays}): ${creerMatiereDto.nom}`);
-    const newMatiere = this.matieresRepository.create({ ...creerMatiereDto, pays });
+    this.logger.log(`Création d'une matière: ${creerMatiereDto.nom} (Niveau d'étude ID: ${creerMatiereDto.niveau_etude_id})`);
+    const niveauEtude = await this.niveauEtudeRepository.findOne({
+      where: { id: creerMatiereDto.niveau_etude_id },
+    });
+    if (!niveauEtude) {
+      this.logger.warn(`Niveau d'étude ID ${creerMatiereDto.niveau_etude_id} introuvable`);
+      throw new NotFoundException('Niveau d\'étude non trouvé');
+    }
+    const newMatiere = this.matieresRepository.create({ ...creerMatiereDto, pays: niveauEtude.pays });
     const saved = await this.matieresRepository.save(newMatiere);
-    this.logger.log(`Matière créée: ${saved.nom} (ID: ${saved.id})`);
+    this.logger.log(`Matière créée: ${saved.nom} (ID: ${saved.id}, pays: ${saved.pays})`);
     return saved;
   }
 
@@ -126,6 +139,19 @@ export class MatieresService {
     }
 
     Object.assign(matiere, majMatiereDto);
+
+    // Parent changed → re-derive pays from the new NiveauEtude (canonical parent).
+    if (majMatiereDto.niveau_etude_id) {
+      const niveauEtude = await this.niveauEtudeRepository.findOne({
+        where: { id: majMatiereDto.niveau_etude_id },
+      });
+      if (!niveauEtude) {
+        this.logger.warn(`Niveau d'étude ID ${majMatiereDto.niveau_etude_id} introuvable`);
+        throw new NotFoundException('Niveau d\'étude non trouvé');
+      }
+      matiere.pays = niveauEtude.pays;
+    }
+
     const updated = await this.matieresRepository.save(matiere);
     this.logger.log(`Matière mise à jour: ${updated.nom} (ID: ${id})`);
     return updated;

--- a/backend/src/niveau-etude/niveau-etude.module.ts
+++ b/backend/src/niveau-etude/niveau-etude.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { NiveauEtudeController } from './niveau-etude.controller';
 import { NiveauEtudeService } from './niveau-etude.service';
 import { NiveauEtude } from './entities/niveau-etude.entity';
+import { Filiere } from '../filieres/entities/filiere.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([NiveauEtude])],
+  imports: [TypeOrmModule.forFeature([NiveauEtude, Filiere])],
   controllers: [NiveauEtudeController],
   providers: [NiveauEtudeService],
   exports: [NiveauEtudeService],

--- a/backend/src/niveau-etude/niveau-etude.service.ts
+++ b/backend/src/niveau-etude/niveau-etude.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, Logger, ConflictException } from '@nestj
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Like, FindOptionsWhere, Brackets } from 'typeorm';
 import { NiveauEtude } from './entities/niveau-etude.entity';
+import { Filiere } from '../filieres/entities/filiere.entity';
 import { CreerNiveauEtudeDto } from './dto/creer-niveau-etude.dto';
 import { MajNiveauEtudeDto } from './dto/maj-niveau-etude.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
@@ -15,13 +16,25 @@ export class NiveauEtudeService {
   constructor(
     @InjectRepository(NiveauEtude)
     private readonly niveauEtudeRepository: Repository<NiveauEtude>,
+    @InjectRepository(Filiere)
+    private readonly filieresRepository: Repository<Filiere>,
   ) { }
 
+  // Note: `pays` (from @CurrentCountry) is intentionally ignored as the saved
+  // value — it stays in the signature so the controller/middleware scoping is
+  // unaffected, but the stored pays is DERIVED from the parent Filiere.
   async create(pays: string, creerNiveauEtudeDto: CreerNiveauEtudeDto) {
-    this.logger.log(`Création d'un niveau d'étude (pays=${pays}): ${creerNiveauEtudeDto.nom}`);
-    const newNiveauEtude = this.niveauEtudeRepository.create({ ...creerNiveauEtudeDto, pays });
+    this.logger.log(`Création d'un niveau d'étude: ${creerNiveauEtudeDto.nom} (Filière ID: ${creerNiveauEtudeDto.filiere_id})`);
+    const filiere = await this.filieresRepository.findOne({
+      where: { id: creerNiveauEtudeDto.filiere_id },
+    });
+    if (!filiere) {
+      this.logger.warn(`Filière ID ${creerNiveauEtudeDto.filiere_id} introuvable`);
+      throw new NotFoundException('Filière non trouvée');
+    }
+    const newNiveauEtude = this.niveauEtudeRepository.create({ ...creerNiveauEtudeDto, pays: filiere.pays });
     const saved = await this.niveauEtudeRepository.save(newNiveauEtude);
-    this.logger.log(`Niveau d'étude créé: ${saved.nom} (ID: ${saved.id})`);
+    this.logger.log(`Niveau d'étude créé: ${saved.nom} (ID: ${saved.id}, pays: ${saved.pays})`);
     return saved;
   }
 
@@ -113,16 +126,26 @@ export class NiveauEtudeService {
       throw new NotFoundException('Niveau d\'étude non trouvé');
     }
 
-    // Si on met à jour la filière
+    // Si on met à jour la filière, re-dériver le pays du nouveau parent.
     let filiere = niveauEtude.filiere;
+    let pays = niveauEtude.pays;
     if (majNiveauEtudeDto.filiere_id) {
+      const parent = await this.filieresRepository.findOne({
+        where: { id: majNiveauEtudeDto.filiere_id },
+      });
+      if (!parent) {
+        this.logger.warn(`Filière ID ${majNiveauEtudeDto.filiere_id} introuvable`);
+        throw new NotFoundException('Filière non trouvée');
+      }
       filiere = { id: majNiveauEtudeDto.filiere_id } as any;
+      pays = parent.pays;
     }
 
     const updated = await this.niveauEtudeRepository.save({
       ...niveauEtude,
       ...majNiveauEtudeDto,
       filiere,
+      pays,
     });
 
     this.logger.log(`Niveau d'étude mis à jour: ${updated.nom}`);


### PR DESCRIPTION
## Problem
The `pays` (country) on the education child entities — **Filiere, NiveauEtude, Matiere, Epreuve** — was not derived from their parent Etablissement. On create it either defaulted to `'benin'` (Filiere, Epreuve) or took the request country switcher value (NiveauEtude, Matiere). Result: a Filiere under a `congo` Etablissement could wrongly be `'benin'`, breaking country-scoped display and creation logic. The source of truth must be the parent Etablissement, cascading down the chain.

## Fix
Each child now derives `pays` from its **immediate parent** (which itself carries the correct value, cascading up to the Etablissement root):

| Entity | Derives pays from |
|---|---|
| Filiere | Etablissement (`etablissement_id`) |
| NiveauEtude | Filiere (`filiere_id`) |
| Matiere | NiveauEtude (`niveau_etude_id`) |
| Epreuve | Matiere (`matiere_id`) |

- On **create**: fetch the parent (adds a `NotFound` guard for bad parent ids), set `pays = parent.pays`. The request country / body `pays` is no longer used for these four.
- On **update**: re-derive `pays` when the parent FK changes, so moving a child across countries stays consistent.
- No DTO/schema/column-default or frontend changes.

## Data migration
Paired migration `010_backfill_pays_from_etablissement.sql` (edukia-db, separate PR) corrects any existing mis-scoped rows via parents-first cascading `UPDATE`s, guarded by `pays IS DISTINCT FROM parent.pays` (idempotent). **Applied to Neon**: 0 rows changed — current prod data is already consistent; this fix prevents future drift.

## Verification
- `tsc --noEmit` clean across the four modules.
- Migration applied + idempotent re-run = 0 mismatches; post-backfill no child's pays differs from its parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)