### PR TITLE
fix(education): scope GET /filieres and /epreuves by country

### DIFF
--- a/backend/src/epreuves/epreuves.controller.ts
+++ b/backend/src/epreuves/epreuves.controller.ts
@@ -9,6 +9,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { FilterEpreuveDto } from './dto/filter-epreuve.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
 
 @ApiTags('epreuves')
 @Controller('epreuves')
@@ -35,8 +36,8 @@ export class EpreuvesController {
   @ApiQuery({ name: 'matiere', required: false, type: String, description: 'Filtrer par nom de matière' })
   @ApiQuery({ name: 'sort_by', required: false, type: String, description: 'Champ de tri (ex: date_creation)' })
   @ApiQuery({ name: 'sort_order', required: false, enum: ['ASC', 'DESC'], description: 'Ordre de tri' })
-  async findAll(@Query() filterDto: FilterEpreuveDto) {
-    return this.epreuvesService.findAll(filterDto);
+  async findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterEpreuveDto) {
+    return this.epreuvesService.findAll(pays, filterDto);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -54,9 +54,9 @@ export class EpreuvesService {
     return saved;
   }
 
-  async findAll(filterDto: FilterEpreuveDto): Promise<PaginationResponse<EpreuveResponseDto>> {
+  async findAll(pays: string, filterDto: FilterEpreuveDto): Promise<PaginationResponse<EpreuveResponseDto>> {
     const { page = 1, limit = 10, search, type, matiere } = filterDto;
-    this.logger.log(`Récupération des épreuves - Page: ${page}, Limite: ${limit}, Search: ${search}, Type: ${type}, Matière: ${matiere}`);
+    this.logger.log(`Récupération des épreuves (pays=${pays}) - Page: ${page}, Limite: ${limit}, Search: ${search}, Type: ${type}, Matière: ${matiere}`);
 
     const queryBuilder = this.epreuvesRepository.createQueryBuilder('epreuve')
       .leftJoinAndSelect('epreuve.matiere', 'matiere')
@@ -64,6 +64,7 @@ export class EpreuvesService {
       .leftJoinAndSelect('niveau_etude.filiere', 'filiere')
       .leftJoinAndSelect('filiere.etablissement', 'etablissement')
       .leftJoinAndSelect('epreuve.professeur', 'professeur')
+      .where('epreuve.pays = :pays', { pays })
       .orderBy('epreuve.date_creation', filterDto.sort_order || 'DESC')
       .skip((page - 1) * limit)
       .take(limit);

--- a/backend/src/filieres/filieres.controller.ts
+++ b/backend/src/filieres/filieres.controller.ts
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { FilterFiliereDto } from './dto/filter-filiere.dto';
 import { FiliereResponseDto } from './dto/filiere-response.dto';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
 
 @ApiTags('filieres')
 @Controller('filieres')
@@ -27,8 +28,8 @@ export class FilieresController {
   @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Nombre d\'éléments par page' })
   @ApiQuery({ name: 'search', required: false, type: String, description: 'Recherche globale (nom filière, nom établissement, ville établissement)' })
   @ApiQuery({ name: 'etablissement', required: false, type: String, description: 'Filtrer par nom d\'établissement' })
-  async findAll(@Query() filterDto: FilterFiliereDto) {
-    return this.filieresService.findAll(filterDto);
+  async findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterFiliereDto) {
+    return this.filieresService.findAll(pays, filterDto);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/filieres/filieres.service.ts
+++ b/backend/src/filieres/filieres.service.ts
@@ -47,12 +47,13 @@ export class FilieresService {
     return saved;
   }
 
-  async findAll(filterDto: FilterFiliereDto): Promise<PaginationResponse<FiliereResponseDto>> {
+  async findAll(pays: string, filterDto: FilterFiliereDto): Promise<PaginationResponse<FiliereResponseDto>> {
     const { page = 1, limit = 10, search, etablissement } = filterDto;
-    this.logger.log(`Récupération des filières - Page: ${page}, Limite: ${limit}, Search: ${search}, Etablissement: ${etablissement}`);
+    this.logger.log(`Récupération des filières (pays=${pays}) - Page: ${page}, Limite: ${limit}, Search: ${search}, Etablissement: ${etablissement}`);
 
     const queryBuilder = this.filieresRepository.createQueryBuilder('filiere')
       .leftJoinAndSelect('filiere.etablissement', 'etablissement')
+      .where('filiere.pays = :pays', { pays })
       .orderBy('filiere.nom', filterDto.sort_order || 'ASC')
       .skip((page - 1) * limit)
       .take(limit);


### PR DESCRIPTION
## Problem
Switching the country in the admin UI didn't filter the **Filière** list — it showed filières from all countries. Root cause is backend, not frontend: the frontend already appends `?country=` to every GET, but `GET /filieres` and `GET /epreuves` lacked `@CurrentCountry()` + a `pays` where-clause, so they ignored the param and returned all rows. (`niveau-etude`, `matieres`, `etablissements` already filter correctly.)

This also fixed the NiveauÉtude create form's filière dropdown, which reuses `GET /filieres`.

## Fix
For both endpoints, mirroring the existing `matieres`/`niveau-etude` pattern:
- Controller `findAll` takes `@CurrentCountry() pays: string` (first arg).
- Service `findAll(pays, filterDto)` adds `.where('<entity>.pays = :pays', { pays })` as the base clause; existing search/etablissement/type filters were already `.andWhere`, so they AND-compose unchanged.

No DTO/entity/schema changes, no migration.

## Verification (live, against Neon)
Booted the branch backend and curled with an authenticated token. Data is currently all `benin`:

| Endpoint | benin | senegal | congo |
|---|---|---|---|
| `GET /filieres` | 52 | 0 | 0 |
| `GET /epreuves` | 2681 | 0 | 0 |

`senegal`/`congo` returning 0 while `benin` returns the full set confirms the filter is active (un-fixed code returns everything). Search still composes within a country. `tsc --noEmit` clean.

Country-scoped creation (Filiere/NiveauEtude/Matiere/Epreuve) confirmed: parent dropdowns are country-scoped (this fix + the already-merged hierarchical endpoints) and each child derives `pays` from its parent (merged hotfix #137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)