### PR TITLE
chore(dx): dev/test environment onboarding (env templates + setup guide)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,8 @@ R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 R2_BUCKET=edukia-dev
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
-R2_PUBLIC_BUCKET=edukia-public
-R2_PUBLIC_BUCKET_URL=https://assets.edukia.net
+R2_PUBLIC_BUCKET=edukia-public-dev
+R2_PUBLIC_BUCKET_URL=https://assets-dev.edukia.net
 
 # --- SMTP --------------------------------------------------------------------
 SMTP_HOST=

--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,8 @@ R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 R2_BUCKET=edukia-dev
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
-R2_PUBLIC_BUCKET=edukia-dev-public
-R2_PUBLIC_BUCKET_URL=https://<dev-public-bucket-domain>
+R2_PUBLIC_BUCKET=edukia-public
+R2_PUBLIC_BUCKET_URL=https://assets.edukia.net
 
 # --- SMTP --------------------------------------------------------------------
 SMTP_HOST=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Root env template — consumed by docker-compose.dev.yml / docker-compose.yml
+# (variable interpolation: ${VAR}).  Copy to ./.env and fill in.
+#   cp .env.example .env
+# The real ./.env is gitignored.
+#
+# ⚠️  TEST database only on dev machines. Never the production DB.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- Database (TEST: edukia-dev) ---------------------------------------------
+DATABASE_URL=postgresql://USER:PASSWORD@HOST.neon.tech/edukia-dev?sslmode=require
+
+# --- Auth --------------------------------------------------------------------
+JWT_SECRET=dev-only-change-me
+
+# --- Runtime -----------------------------------------------------------------
+NODE_ENV=development
+
+# --- Redis -------------------------------------------------------------------
+# In docker-compose.dev.yml the backend talks to the bundled `redis` service,
+# so these are mainly for non-docker runs.
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# --- Cloudflare R2 (DEV buckets) ---------------------------------------------
+R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+R2_BUCKET=edukia-dev
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_PUBLIC_BUCKET=edukia-dev-public
+R2_PUBLIC_BUCKET_URL=https://<dev-public-bucket-domain>
+
+# --- SMTP --------------------------------------------------------------------
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+
+# --- Firebase (legacy, transitional) -----------------------------------------
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=
+
+# --- Frontend build arg ------------------------------------------------------
+# Leave unset to use the nginx "/backend" proxy in compose.
+VITE_API_URL=
+
+# --- Docker images (compose pulls these tags; for local builds you can ignore) -
+DOCKER_IMAGE_BACKEND=ghcr.io/dkayode/edukia-backend:latest
+DOCKER_IMAGE_FRONTEND=ghcr.io/dkayode/edukia-frontend:latest

--- a/README.md
+++ b/README.md
@@ -26,11 +26,18 @@ La façon la plus simple de lancer toute la plateforme est d'utiliser Docker.
     ```
 
 2.  **Configurer l'environnement :**
-    Créez un fichier `.env` à la racine :
+    Copiez les modèles `*.example` et remplissez-les avec les identifiants de
+    **test** (jamais la production). Guide complet pour les nouveaux devs :
+    [`docs/DEV_SETUP.md`](docs/DEV_SETUP.md).
     ```bash
-    # Créez le fichier .env
-    # Assurez-vous qu'il contient la configuration nécessaire (identifiants BDD, etc.)
+    cp .env.example .env
+    cp backend/.env.example backend/.env
+    cp frontend/.env.example frontend/.env
+    cp backend/config/config.example.json backend/config/config.json
+    cp backend/config/firebase-serviceaccount.example.json backend/config/firebase-serviceaccount.json
     ```
+    > ⚠️ Utilisez la base de données de **test `edukia-dev`**, jamais la base de
+    > production.
 
 3.  **Démarrer les services :**
     ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,55 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Edukia backend — local dev environment template.
+#   cp backend/.env.example backend/.env   then fill in the blanks.
+#
+# This file is committed (template only). The real backend/.env is gitignored.
+#
+# ⚠️  NEVER point a dev machine at the PRODUCTION database.
+#     Use the shared TEST database `edukia-dev` (ask a maintainer for the URL).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- Database (Neon Postgres) ------------------------------------------------
+# TEST database only. The host/credentials come from the edukia-dev Neon project.
+# Must end with ?sslmode=require for Neon.
+DATABASE_URL=postgresql://USER:PASSWORD@HOST.neon.tech/edukia-dev?sslmode=require
+
+# --- Auth --------------------------------------------------------------------
+# Any non-empty string for local dev. Does NOT need to match production.
+JWT_SECRET=dev-only-change-me
+
+# --- Runtime -----------------------------------------------------------------
+NODE_ENV=development
+PORT=3000
+FRONTEND_URL=http://localhost:8080
+# CONFIG_PATH=./config/config.json   # optional; this is the default
+
+# --- Redis (BullMQ queue) ----------------------------------------------------
+# Easiest: `docker compose -f docker-compose.dev.yml up -d redis`
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# --- Cloudflare R2 (USE THE DEV BUCKETS, not prod) ---------------------------
+# Same Cloudflare account as prod; only the bucket names differ.
+R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+R2_BUCKET=edukia-dev
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_PUBLIC_BUCKET=edukia-dev-public
+R2_PUBLIC_BUCKET_URL=https://<dev-public-bucket-domain>
+
+# --- SMTP (transactional email) ----------------------------------------------
+# For dev use a mail catcher (Mailpit/Mailtrap). Leave blank to no-op if your
+# task doesn't send mail.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+
+# --- Firebase (legacy storage, transitional — being retired) -----------------
+# Also requires the file backend/config/firebase-serviceaccount.json
+# (see firebase-serviceaccount.example.json for its shape). The backend will
+# NOT boot without that file present.
+FIREBASE_PROJECT_ID=
+FIREBASE_CLIENT_EMAIL=
+FIREBASE_PRIVATE_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,8 +34,8 @@ R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 R2_BUCKET=edukia-dev
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
-R2_PUBLIC_BUCKET=edukia-public
-R2_PUBLIC_BUCKET_URL=https://assets.edukia.net
+R2_PUBLIC_BUCKET=edukia-public-dev
+R2_PUBLIC_BUCKET_URL=https://assets-dev.edukia.net
 
 # --- SMTP (transactional email) ----------------------------------------------
 # For dev use a mail catcher (Mailpit/Mailtrap). Leave blank to no-op if your

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,8 +34,8 @@ R2_ENDPOINT=https://<ACCOUNT_ID>.r2.cloudflarestorage.com
 R2_BUCKET=edukia-dev
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
-R2_PUBLIC_BUCKET=edukia-dev-public
-R2_PUBLIC_BUCKET_URL=https://<dev-public-bucket-domain>
+R2_PUBLIC_BUCKET=edukia-public
+R2_PUBLIC_BUCKET_URL=https://assets.edukia.net
 
 # --- SMTP (transactional email) ----------------------------------------------
 # For dev use a mail catcher (Mailpit/Mailtrap). Leave blank to no-op if your

--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Template for backend/config/config.json (gitignored). Copy to config.json and adjust. Read by loadConfig() in src/config/country-config.ts; exposed via GET /countries and GET /app.",
+  "country": [
+    { "name": "benin",   "logo": "https://<assets-host>/benin.svg",   "timezone": "Africa/Cotonou", "currency": "XOF" },
+    { "name": "senegal", "logo": "https://<assets-host>/senegal.svg", "timezone": "Africa/Dakar",   "currency": "XOF" },
+    { "name": "congo",   "logo": "https://<assets-host>/congo.svg",   "timezone": "Africa/Brazzaville", "currency": "XAF" }
+  ],
+  "app": {
+    "name": "Edukia",
+    "logo": "https://<assets-host>/logo.png",
+    "favicon": "https://<assets-host>/favicon.png"
+  }
+}

--- a/backend/config/firebase-serviceaccount.example.json
+++ b/backend/config/firebase-serviceaccount.example.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Template for backend/config/firebase-serviceaccount.json (gitignored, REQUIRED to boot). This is a Google service-account key. Ask a maintainer for the dev project's key, or generate one in Firebase console → Project settings → Service accounts → Generate new private key. Do NOT commit the real file.",
+  "type": "service_account",
+  "project_id": "<firebase-dev-project-id>",
+  "private_key_id": "<private-key-id>",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n<...>\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk-xxxxx@<project-id>.iam.gserviceaccount.com",
+  "client_id": "<client-id>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/<...>"
+}

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,0 +1,92 @@
+# Edukia — dev / test environment setup
+
+Onboarding for new developers. Goal: get a working **test** environment that
+never touches production data.
+
+> ⚠️ **Golden rule:** dev machines use the **`edukia-dev`** Neon database and the
+> **`edukia-dev` / `edukia-dev-public`** R2 buckets. **Never** point your local
+> setup at the production database or buckets.
+
+---
+
+## 1. Prerequisites
+
+- Node 20 + npm
+- Docker + Docker Compose v2 (for the bundled redis, and the all-in-one path)
+- Access to the team secrets (see step 2)
+
+## 2. Get the secrets
+
+These files are **gitignored** — you create them from the committed `*.example`
+templates and fill in real values. Ask a maintainer for the shared **test**
+credentials (or the secrets vault link):
+
+| You create | From template | What it holds |
+|---|---|---|
+| `backend/.env` | `backend/.env.example` | DB URL (edukia-dev), JWT, R2 (dev), SMTP, Firebase |
+| `frontend/.env` | `frontend/.env.example` | `VITE_API_URL` |
+| `.env` (root) | `.env.example` | same vars, for docker-compose |
+| `backend/config/config.json` | `backend/config/config.example.json` | countries + app metadata |
+| `backend/config/firebase-serviceaccount.json` | `backend/config/firebase-serviceaccount.example.json` | Firebase key (**backend won't boot without it**) |
+
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+cp .env.example .env
+cp backend/config/config.example.json backend/config/config.json
+cp backend/config/firebase-serviceaccount.example.json backend/config/firebase-serviceaccount.json
+# then edit each and paste the real TEST values
+```
+
+The `DATABASE_URL` you receive must point at **edukia-dev**. If it says
+`edukia-prod` / the production host, stop and ask — that's the wrong one.
+
+## 3. Run it
+
+### Option A — Docker (closest to prod)
+```bash
+docker compose -f docker-compose.dev.yml up -d --build
+# backend + frontend + nginx + redis. App via nginx; API under /backend.
+docker compose -f docker-compose.dev.yml logs -f backend
+```
+
+### Option B — Local (fast iteration)
+```bash
+# 1) redis (BullMQ needs it)
+docker compose -f docker-compose.dev.yml up -d redis
+# 2) backend
+cd backend && npm install && npm run start:dev      # http://localhost:3000
+# 3) frontend (new shell)
+cd frontend && npm install && npm run dev            # http://localhost:8080
+```
+
+## 4. Database schema (edukia-dev)
+
+Schema/migrations live in the sister repo
+[`edukia-db`](https://github.com/DKayode/edukia-db) as raw SQL — never Prisma
+migrate / TypeORM synchronize. The `edukia-dev` database must have the schema
+applied. To apply a migration against edukia-dev, point the apply script at the
+edukia-dev connection string:
+
+```bash
+cd ../edukia-db
+DATABASE_URL="<edukia-dev url>" ./scripts/apply-migration.sh 0XX_description.sql
+```
+
+(Ask a maintainer whether edukia-dev is already seeded/migrated before running.)
+
+## 5. Smoke check
+
+```bash
+curl http://localhost:3000/countries     # -> configured countries (no auth)
+```
+Then log in via the frontend and confirm the country switcher + a list page work.
+
+## 6. Conventions (read before pushing)
+
+- Work on a feature branch → PR → squash-merge. Never push to `main`.
+- Country scoping: services take `pays` as the first arg via `@CurrentCountry()`.
+- Files go through `FilesModule` (R2 presign) + `<FileImage>`.
+- SQL migrations go in `edukia-db`, raw + idempotent, applied to the DB before the
+  dependent code merges.
+- See `CLAUDE.md` / `AGENTS.md` for the full architecture rules.

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -3,9 +3,12 @@
 Onboarding for new developers. Goal: get a working **test** environment that
 never touches production data.
 
-> ⚠️ **Golden rule:** dev machines use the **`edukia-dev`** Neon database and the
-> **`edukia-dev` / `edukia-dev-public`** R2 buckets. **Never** point your local
-> setup at the production database or buckets.
+> ⚠️ **Golden rule:** dev machines use the **`edukia-dev`** Neon database. **Never**
+> point your local setup at the production database.
+>
+> R2 (file storage): the **`edukia-dev`** private bucket is dev-scoped. The public
+> bucket (`edukia-public`, served at `assets.edukia.net`) is currently shared — ask
+> a maintainer before relying on public-slot uploads in dev.
 
 ---
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -6,9 +6,9 @@ never touches production data.
 > ⚠️ **Golden rule:** dev machines use the **`edukia-dev`** Neon database. **Never**
 > point your local setup at the production database.
 >
-> R2 (file storage): the **`edukia-dev`** private bucket is dev-scoped. The public
-> bucket (`edukia-public`, served at `assets.edukia.net`) is currently shared — ask
-> a maintainer before relying on public-slot uploads in dev.
+> R2 (file storage): dev uses the **`edukia-dev`** private bucket and the
+> **`edukia-public-dev`** public bucket (served at `assets-dev.edukia.net`).
+> Never the prod buckets (`edukia` / `edukia-public` at `assets.edukia.net`).
 
 ---
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,9 @@
+# Edukia frontend (Vite) — env template.
+#   cp frontend/.env.example frontend/.env
+# The real frontend/.env is gitignored.
+
+# Base URL of the backend API.
+# Local dev against a locally-running backend:
+VITE_API_URL=http://localhost:3000
+# When served behind nginx (docker-compose), leave this UNSET so the app uses
+# the default "/backend" reverse-proxy path.


### PR DESCRIPTION
Onboarding scaffolding so new devs can spin up a **test** environment without touching production.

## What's added
- **`.env.example`** (root), **`backend/.env.example`**, **`frontend/.env.example`** — every required key with placeholders. `DATABASE_URL` points at the **`edukia-dev`** test database with an explicit "never prod" warning; R2 points at the `edukia-dev` / `edukia-dev-public` buckets.
- **`backend/config/config.example.json`** + **`backend/config/firebase-serviceaccount.example.json`** — the two gitignored config files new devs must create (the backend won't boot without the firebase one), with their shapes.
- **`docs/DEV_SETUP.md`** — full walkthrough (prereqs, secrets, Docker vs local run, schema, smoke check, conventions). README now links to it.

## Safety
- No real secrets committed — verified the four real secret files (`.env`, `backend/.env`, `config.json`, `firebase-serviceaccount.json`) remain gitignored; only `*.example` + docs are tracked.
- The `edukia-dev` test database (a separate Neon endpoint, copy of prod data) was boot-verified: the backend starts against it and serves live authed queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)