### PR TITLE
feat(epreuves): add annee + section fields

### DIFF
--- a/backend/src/epreuves/dto/creer-epreuve.dto.ts
+++ b/backend/src/epreuves/dto/creer-epreuve.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNumber, IsOptional, IsDate, IsEnum } from 'class-validator';
-import { EpreuveType } from '../entities/epreuve.entity';
+import { IsString, IsNumber, IsOptional, IsDate, IsEnum, IsInt } from 'class-validator';
+import { EpreuveType, EpreuveSection } from '../entities/epreuve.entity';
 
 export class CreerEpreuveDto {
   @ApiProperty({ example: 'Epreuve de Mathématiques 2023', description: 'Titre de l\'épreuve' })
@@ -34,4 +34,14 @@ export class CreerEpreuveDto {
   @IsOptional()
   @IsEnum(EpreuveType, { message: 'Le type doit être une valeur valide' })
   type?: EpreuveType;
+
+  @ApiProperty({ example: 2023, description: 'Année de l\'épreuve', required: false })
+  @IsOptional()
+  @IsInt()
+  annee?: number;
+
+  @ApiProperty({ enum: EpreuveSection, description: 'Session de l\'épreuve', required: false })
+  @IsOptional()
+  @IsEnum(EpreuveSection, { message: 'La section doit être une valeur valide' })
+  section?: EpreuveSection;
 }

--- a/backend/src/epreuves/dto/epreuve-response.dto.ts
+++ b/backend/src/epreuves/dto/epreuve-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { EpreuveType } from '../entities/epreuve.entity';
+import { EpreuveType, EpreuveSection } from '../entities/epreuve.entity';
 import { Etablissement } from '../../etablissements/entities/etablissement.entity';
 
 class FiliereInEpreuveDto {
@@ -164,6 +164,12 @@ export class EpreuveResponseDto {
 
     @ApiProperty({ enum: EpreuveType })
     type: EpreuveType;
+
+    @ApiProperty({ required: false, nullable: true })
+    annee: number;
+
+    @ApiProperty({ enum: EpreuveSection })
+    section: EpreuveSection;
 
     @ApiProperty({ type: () => ProfesseurInEpreuveDto })
     professeur: ProfesseurInEpreuveDto;

--- a/backend/src/epreuves/dto/maj-epreuve.dto.ts
+++ b/backend/src/epreuves/dto/maj-epreuve.dto.ts
@@ -1,5 +1,5 @@
-import { IsString, IsNumber, IsOptional, IsDate, IsEnum } from 'class-validator';
-import { EpreuveType } from '../entities/epreuve.entity';
+import { IsString, IsNumber, IsOptional, IsDate, IsEnum, IsInt } from 'class-validator';
+import { EpreuveType, EpreuveSection } from '../entities/epreuve.entity';
 
 export class MajEpreuveDto {
   @IsOptional()
@@ -29,4 +29,12 @@ export class MajEpreuveDto {
   @IsOptional()
   @IsEnum(EpreuveType, { message: 'Le type doit être une valeur valide' })
   type?: EpreuveType;
+
+  @IsOptional()
+  @IsInt()
+  annee?: number;
+
+  @IsOptional()
+  @IsEnum(EpreuveSection, { message: 'La section doit être une valeur valide' })
+  section?: EpreuveSection;
 }

--- a/backend/src/epreuves/entities/epreuve.entity.ts
+++ b/backend/src/epreuves/entities/epreuve.entity.ts
@@ -40,7 +40,9 @@ export class Epreuve {
   @Column({ type: 'int', nullable: true })
   annee: number;
 
-  @Column({ type: 'enum', enum: EpreuveSection, default: EpreuveSection.NORMAL })
+  // DB column is varchar(20) + CHECK (not a native pg enum like `type`);
+  // value space is enforced by EpreuveSection / IsEnum + the CHECK constraint.
+  @Column({ type: 'varchar', length: 20, default: EpreuveSection.NORMAL })
   section: EpreuveSection;
 
   @Column()

--- a/backend/src/epreuves/entities/epreuve.entity.ts
+++ b/backend/src/epreuves/entities/epreuve.entity.ts
@@ -9,6 +9,11 @@ export enum EpreuveType {
   EXAMENS = 'Examens',
 }
 
+export enum EpreuveSection {
+  NORMAL = 'normal',
+  RATTRAPAGE = 'rattrapage',
+}
+
 @Entity('epreuves')
 export class Epreuve {
   @PrimaryGeneratedColumn()
@@ -31,6 +36,12 @@ export class Epreuve {
 
   @Column({ type: 'enum', enum: EpreuveType, nullable: true })
   type: EpreuveType;
+
+  @Column({ type: 'int', nullable: true })
+  annee: number;
+
+  @Column({ type: 'enum', enum: EpreuveSection, default: EpreuveSection.NORMAL })
+  section: EpreuveSection;
 
   @Column()
   url: string;

--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -34,6 +34,10 @@ export class EpreuvesService {
     newEpreuve.date_publication = creerEpreuveDto.date_publication;
     newEpreuve.nombre_pages = creerEpreuveDto.nombre_pages;
     newEpreuve.type = creerEpreuveDto.type;
+    newEpreuve.annee = creerEpreuveDto.annee;
+    if (creerEpreuveDto.section !== undefined) {
+      newEpreuve.section = creerEpreuveDto.section;
+    }
     const saved = await this.epreuvesRepository.save(newEpreuve);
     this.logger.log(`Épreuve créée: ${saved.titre} (ID: ${saved.id}, Matière: ${saved.matiere_id})`);
     return saved;
@@ -90,6 +94,8 @@ export class EpreuvesService {
       nombre_pages: epreuve.nombre_pages,
       nombre_telechargements: epreuve.nombre_telechargements,
       type: epreuve.type,
+      annee: epreuve.annee,
+      section: epreuve.section,
       professeur: {
         nom: epreuve.professeur.nom,
         prenom: epreuve.professeur.prenom,
@@ -149,6 +155,8 @@ export class EpreuvesService {
       nombre_pages: epreuve.nombre_pages,
       nombre_telechargements: epreuve.nombre_telechargements,
       type: epreuve.type,
+      annee: epreuve.annee,
+      section: epreuve.section,
       professeur: {
         nom: epreuve.professeur.nom,
         prenom: epreuve.professeur.prenom,

--- a/frontend/src/lib/services/epreuves.service.ts
+++ b/frontend/src/lib/services/epreuves.service.ts
@@ -16,6 +16,8 @@ export const epreuvesService = {
   async create(data: {
     titre: string;
     matiere_id: number;
+    annee?: number;
+    section?: 'normal' | 'rattrapage';
   }): Promise<Epreuve> {
     return api.post<Epreuve>('/epreuves', data);
   },
@@ -27,6 +29,8 @@ export const epreuvesService = {
     duree_minutes?: number;
     nombre_pages?: number;
     date_publication?: string;
+    annee?: number;
+    section?: 'normal' | 'rattrapage';
   }): Promise<Epreuve> {
     return api.put<Epreuve>(`/epreuves/${id}`, data);
   },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -77,6 +77,8 @@ export interface Utilisateur {
 
 export type EpreuveType = 'Interrogation' | 'Devoirs' | 'Concours' | 'Examens';
 
+export type EpreuveSection = 'normal' | 'rattrapage';
+
 export interface Epreuve {
   id: number;
   uuid?: string;
@@ -94,6 +96,8 @@ export interface Epreuve {
   nombre_pages?: number;
   nombre_telechargements?: number;
   type?: EpreuveType;
+  annee?: number;
+  section?: EpreuveSection;
 }
 
 export interface Ressource {

--- a/frontend/src/pages/Epreuves.tsx
+++ b/frontend/src/pages/Epreuves.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { type EpreuveType } from "@/lib/types";
+import { type EpreuveType, type EpreuveSection } from "@/lib/types";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -77,6 +77,8 @@ export default function Epreuves() {
     nombre_pages: "",
     matiere_id: "",
     date_publication: "",
+    annee: "",
+    section: "normal" as EpreuveSection,
   });
 
   const queryClient = useQueryClient();
@@ -137,7 +139,7 @@ export default function Epreuves() {
   const matieres = matieresResponse?.data || [];
 
   const createMutation = useMutation({
-    mutationFn: async (data: { file: File; titre: string; type?: string; duree_minutes: number; nombre_pages?: number; matiere_id: number; date_publication?: string }) => {
+    mutationFn: async (data: { file: File; titre: string; type?: string; duree_minutes: number; nombre_pages?: number; matiere_id: number; date_publication?: string; annee?: number; section?: EpreuveSection }) => {
       // 1. Create the epreuve row — backend assigns the uuid we use as
       //    the R2 key on the next step. Metadata that the legacy
       //    /fichiers/epreuve endpoint accepted as form fields is set
@@ -151,6 +153,8 @@ export default function Epreuves() {
         duree_minutes: data.duree_minutes,
         nombre_pages: data.nombre_pages,
         date_publication: data.date_publication,
+        annee: data.annee,
+        section: data.section,
       });
 
       // 2. PUT bytes to R2 via presigned URL.
@@ -171,7 +175,7 @@ export default function Epreuves() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: (data: { id: string; titre: string; type?: string; duree_minutes: number; nombre_pages?: number; matiere_id: number; date_publication?: string }) =>
+    mutationFn: (data: { id: string; titre: string; type?: string; duree_minutes: number; nombre_pages?: number; matiere_id: number; date_publication?: string; annee?: number; section?: EpreuveSection }) =>
       epreuvesService.update(data.id, {
         titre: data.titre,
         type: data.type,
@@ -179,6 +183,8 @@ export default function Epreuves() {
         nombre_pages: data.nombre_pages,
         matiere_id: data.matiere_id,
         date_publication: data.date_publication,
+        annee: data.annee,
+        section: data.section,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['epreuves'] });
@@ -210,6 +216,8 @@ export default function Epreuves() {
       nombre_pages: "",
       matiere_id: "",
       date_publication: "",
+      annee: "",
+      section: "normal",
     });
     setSelectedFile(null);
     setEditData(null);
@@ -250,6 +258,8 @@ export default function Epreuves() {
       nombre_pages: epreuve.nombre_pages?.toString() || "",
       matiere_id: (epreuve.matiere_id || epreuve.matiere?.id)?.toString() || "",
       date_publication: epreuve.date_publication ? new Date(epreuve.date_publication).toISOString().slice(0, 16) : "",
+      annee: epreuve.annee?.toString() || "",
+      section: epreuve.section || "normal",
     });
     setIsDialogOpen(true);
   };
@@ -269,6 +279,8 @@ export default function Epreuves() {
         nombre_pages: formData.nombre_pages ? parseInt(formData.nombre_pages, 10) : undefined,
         matiere_id: parseInt(formData.matiere_id, 10),
         date_publication: formData.date_publication || undefined,
+        annee: formData.annee ? parseInt(formData.annee, 10) : undefined,
+        section: formData.section,
       });
     } else {
       // Create mode - Requires File
@@ -282,6 +294,8 @@ export default function Epreuves() {
         nombre_pages: formData.nombre_pages ? parseInt(formData.nombre_pages, 10) : undefined,
         matiere_id: parseInt(formData.matiere_id, 10),
         date_publication: formData.date_publication || undefined,
+        annee: formData.annee ? parseInt(formData.annee, 10) : undefined,
+        section: formData.section,
       });
     }
   };
@@ -415,6 +429,34 @@ export default function Epreuves() {
                     value={formData.nombre_pages}
                     onChange={(e) => setFormData({ ...formData, nombre_pages: e.target.value })}
                   />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="annee">Année</Label>
+                  <Input
+                    id="annee"
+                    type="number"
+                    placeholder="Ex: 2023"
+                    value={formData.annee}
+                    onChange={(e) => setFormData({ ...formData, annee: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="section">Session</Label>
+                  <Select
+                    value={formData.section}
+                    onValueChange={(value) => setFormData({ ...formData, section: value as EpreuveSection })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sélectionner la session" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="normal">Normal</SelectItem>
+                      <SelectItem value="rattrapage">Rattrapage</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
 


### PR DESCRIPTION
Adds two fields to `epreuves`, end-to-end (DB → backend → admin form).

- **`annee`** — exam year (nullable int).
- **`section`** — enum `normal | rattrapage`, default `normal`, enforced by a DB CHECK constraint.

Backend: entity + create/update/response DTOs + service persistence. Frontend: Année input + Section select in the create/edit dialog. Paired migration: edukia-db `007_add_annee_section_to_epreuves.sql` (apply to prod before merge).

**Validated** in the integration build against `edukia-dev` (007 applied): create persists annee/section, default `normal`, invalid section → 400, and `pays` is derived from the parent matière (merged hotfix). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)