### PR TITLE
refonte(admin): grouped collapsible sidebar + refreshed dashboard

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -1,67 +1,283 @@
-import { LayoutDashboard, Users, BookOpen, Calendar, FileText, Settings, Building2, BookMarked, Megaphone, CalendarDays, Briefcase, GraduationCap, UserCheck, Layers, Bell, Smartphone, MessageSquare, ClipboardList, UserPen, Wrench, Award } from "lucide-react";
+import {
+  LayoutDashboard,
+  GraduationCap,
+  Building2,
+  GitFork,
+  Layers,
+  BookMarked,
+  FileText,
+  List,
+  Building,
+  Award,
+  MessageCircle,
+  MessagesSquare,
+  Route,
+  MessageSquare,
+  Tags,
+  Briefcase,
+  Wrench,
+  UserCheck,
+  UserCog,
+  Star,
+  Cog,
+  Megaphone,
+  CalendarDays,
+  Lightbulb,
+  Settings,
+  User,
+  Users,
+  BarChart3,
+  SlidersHorizontal,
+  UserPlus,
+  Contact,
+  Bell,
+  Smartphone,
+  ChevronRight,
+  BookOpen,
+  type LucideIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { NavLink } from "@/components/NavLink";
-import { useLocation }
-  from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import {
   Sidebar,
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarHeader,
   useSidebar,
 } from "@/components/ui/sidebar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { useApp } from "@/hooks/useApp";
+import { cn } from "@/lib/utils";
 
-const academicItems = [
-  { title: "Dashboard", url: "/", icon: LayoutDashboard },
-  { title: "Utilisateurs", url: "/users", icon: Users },
-  { title: "Parrainages", url: "/parrainages", icon: Users },
-  { title: "Établissements", url: "/etablissements", icon: Building2 },
-  { title: "Filières", url: "/filieres", icon: BookOpen },
-  { title: "Niveaux d'études", url: "/niveaux", icon: Calendar },
-  { title: "Matières", url: "/matieres", icon: BookMarked },
-  { title: "Épreuves", url: "/epreuves", icon: FileText },
-  { title: "Forums", url: "/forums", icon: MessageSquare },
+// A nav entry is either a leaf (route, or disabled "à venir") or a group with
+// children. Groups may nest one level (Concours sits under Éducation).
+interface NavItem {
+  title: string;
+  icon: LucideIcon;
+  url?: string;
+  badge?: string;
+  children?: NavItem[];
+}
+
+const navTree: NavItem[] = [
+  { title: "Tableau de bord", icon: LayoutDashboard, url: "/" },
+  {
+    title: "Éducation",
+    icon: GraduationCap,
+    children: [
+      { title: "Établissements", icon: Building2, url: "/etablissements" },
+      { title: "Filières", icon: GitFork, url: "/filieres" },
+      { title: "Niveaux d'étude", icon: Layers, url: "/niveaux" },
+      { title: "Matières", icon: BookMarked, url: "/matieres" },
+      { title: "Épreuves", icon: FileText, url: "/epreuves" },
+      {
+        title: "Concours",
+        icon: GraduationCap,
+        children: [
+          { title: "Concours", icon: List, url: "/concours" },
+          { title: "Structures", icon: Building, url: "/structures", badge: "NEW" },
+          { title: "Titres", icon: Award, url: "/titres", badge: "NEW" },
+        ],
+      },
+    ],
+  },
+  {
+    title: "Communauté",
+    icon: MessageCircle,
+    children: [
+      { title: "Forums", icon: MessagesSquare, url: "/forums" },
+      {
+        title: "Parcours",
+        icon: Route,
+        children: [
+          { title: "Parcours", icon: Route, url: "/parcours" },
+          { title: "Catégories", icon: Tags, url: "/categories" },
+        ],
+      },
+      { title: "Commentaires", icon: MessageSquare },
+    ],
+  },
+  {
+    title: "JobKia",
+    icon: Briefcase,
+    children: [
+      { title: "Services", icon: Wrench, url: "/admin/services" },
+      { title: "Offres", icon: Briefcase, url: "/admin/offres" },
+      { title: "Prestataires", icon: UserCheck },
+      { title: "Recruteurs", icon: UserCog, url: "/admin/recruteurs" },
+      { title: "Avis", icon: Star },
+      { title: "Types (Services, Offres)", icon: Layers, url: "/admin/service-types" },
+      { title: "Compétences", icon: Cog, url: "/admin/competences" },
+    ],
+  },
+  {
+    title: "Contenu",
+    icon: Megaphone,
+    children: [
+      { title: "Publicités", icon: Megaphone, url: "/publicites" },
+      { title: "Événements", icon: CalendarDays, url: "/evenements" },
+      { title: "Opportunités", icon: Lightbulb, url: "/opportunites" },
+    ],
+  },
+  {
+    title: "Utilisateurs",
+    icon: Users,
+    children: [
+      { title: "Utilisateurs", icon: User, url: "/users" },
+      { title: "Parrainage", icon: UserPlus, url: "/parrainages" },
+    ],
+  },
+  {
+    title: "Système",
+    icon: Settings,
+    children: [
+      { title: "Statistiques", icon: BarChart3 },
+      { title: "Paramètres", icon: SlidersHorizontal },
+      { title: "Contacts Pro", icon: Contact, url: "/contacts-professionnels" },
+      { title: "Notifications", icon: Bell, url: "/notifications" },
+      { title: "Versions App", icon: Smartphone, url: "/app-versions" },
+    ],
+  },
 ];
 
-const publicContentItems = [
-  { title: "Catégories", url: "/categories", icon: Layers },
-  { title: "Parcours", url: "/parcours", icon: BookOpen },
-  { title: "Publicités", url: "/publicites", icon: Megaphone },
-  { title: "Événements", url: "/evenements", icon: CalendarDays },
-  { title: "Opportunités", url: "/opportunites", icon: Briefcase },
-  { title: "Concours", url: "/concours", icon: GraduationCap },
-  { title: "Structures", url: "/structures", icon: Building2 },
-  { title: "Titres", url: "/titres", icon: Award },
-  { title: "Contacts Pro", url: "/contacts-professionnels", icon: UserCheck },
-];
+const collectUrls = (item: NavItem): string[] =>
+  item.children ? item.children.flatMap(collectUrls) : item.url ? [item.url] : [];
 
-const jobkiaItems = [
-  { title: "Recruteurs", url: "/admin/recruteurs", icon: UserPen },
-  { title: "Services", url: "/admin/services", icon: ClipboardList },
-  { title: "Offres", url: "/admin/offres", icon: ClipboardList },
-  { title: "Types (Services, Offres)", url: "/admin/service-types", icon: Layers },
-  { title: "Compétences", url: "/admin/competences", icon: Wrench },
-];
+const containsPath = (item: NavItem, path: string) =>
+  collectUrls(item).includes(path);
 
-const settingsItems = [
-  { title: "Paramètres", url: "/settings", icon: Settings },
-  { title: "Notifications", url: "/notifications", icon: Bell },
-  { title: "Versions App", url: "/app-versions", icon: Smartphone },
-];
+function SubLeaf({ item, currentPath }: { item: NavItem; currentPath: string }) {
+  if (!item.url) {
+    return (
+      <SidebarMenuSubItem>
+        <SidebarMenuSubButton asChild>
+          <span aria-disabled className="cursor-default">
+            <item.icon className="h-3.5 w-3.5" />
+            <span>{item.title}</span>
+            <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+              à venir
+            </span>
+          </span>
+        </SidebarMenuSubButton>
+      </SidebarMenuSubItem>
+    );
+  }
+
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton asChild isActive={currentPath === item.url}>
+        <NavLink to={item.url} end>
+          <item.icon className="h-3.5 w-3.5" />
+          <span>{item.title}</span>
+          {item.badge && (
+            <span className="ml-auto rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-600">
+              {item.badge}
+            </span>
+          )}
+        </NavLink>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  );
+}
+
+// Second-level collapsible group (e.g. Concours), rendered inside a SidebarMenuSub.
+function SubGroup({ item, currentPath }: { item: NavItem; currentPath: string }) {
+  const hasActive = useMemo(() => containsPath(item, currentPath), [item, currentPath]);
+  const [open, setOpen] = useState(hasActive);
+  useEffect(() => {
+    if (hasActive) setOpen(true);
+  }, [hasActive]);
+
+  return (
+    <SidebarMenuSubItem>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuSubButton asChild>
+            <button type="button" className="w-full">
+              <item.icon className="h-3.5 w-3.5" />
+              <span>{item.title}</span>
+              <span className="ml-auto flex shrink-0 items-center gap-1.5">
+                <span className="text-[10px] text-muted-foreground">
+                  {item.children?.length}
+                </span>
+                <ChevronRight
+                  className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-90")}
+                />
+              </span>
+            </button>
+          </SidebarMenuSubButton>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub>
+            {item.children?.map((child) => (
+              <SubLeaf key={child.title} item={child} currentPath={currentPath} />
+            ))}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </Collapsible>
+    </SidebarMenuSubItem>
+  );
+}
+
+// Top-level collapsible group.
+function TopGroup({ item, currentPath }: { item: NavItem; currentPath: string }) {
+  const hasActive = useMemo(() => containsPath(item, currentPath), [item, currentPath]);
+  const [open, setOpen] = useState(hasActive);
+  useEffect(() => {
+    if (hasActive) setOpen(true);
+  }, [hasActive]);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <SidebarMenuItem>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuButton tooltip={item.title} className="font-medium">
+            <item.icon className="h-4 w-4" />
+            <span>{item.title}</span>
+            <span className="ml-auto flex shrink-0 items-center gap-1.5">
+              <span className="text-[10px] text-muted-foreground">
+                {item.children?.length}
+              </span>
+              <ChevronRight
+                className={cn("h-4 w-4 transition-transform", open && "rotate-90")}
+              />
+            </span>
+          </SidebarMenuButton>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub>
+            {item.children?.map((child) =>
+              child.children ? (
+                <SubGroup key={child.title} item={child} currentPath={currentPath} />
+              ) : (
+                <SubLeaf key={child.title} item={child} currentPath={currentPath} />
+              ),
+            )}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </SidebarMenuItem>
+    </Collapsible>
+  );
+}
 
 export function AppSidebar() {
   const { state } = useSidebar();
   const location = useLocation();
   const currentPath = location.pathname;
   const { data: app } = useApp();
-
-  const isActive = (path: string) => currentPath === path;
 
   const brandName = app?.name ?? "Admin Panel";
   const Logo = () =>
@@ -94,93 +310,31 @@ export function AppSidebar() {
 
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Contenu Académique</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {academicItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActive(item.url)}>
-                    <NavLink
-                      to={item.url}
-                      end
-                      className="hover:bg-sidebar-accent/50"
-                      activeClassName="bg-sidebar-accent text-sidebar-accent-foreground font-medium"
+              {navTree.map((item) =>
+                item.children ? (
+                  <TopGroup key={item.title} item={item} currentPath={currentPath} />
+                ) : (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={currentPath === item.url}
+                      tooltip={item.title}
                     >
-                      <item.icon className="h-4 w-4" />
-                      {state !== "collapsed" && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Contenu Public</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {publicContentItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActive(item.url)}>
-                    <NavLink
-                      to={item.url}
-                      end
-                      className="hover:bg-sidebar-accent/50"
-                      activeClassName="bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                    >
-                      <item.icon className="h-4 w-4" />
-                      {state !== "collapsed" && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Jobkia</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {jobkiaItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActive(item.url)}>
-                    <NavLink
-                      to={item.url}
-                      end
-                      className="hover:bg-sidebar-accent/50"
-                      activeClassName="bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                    >
-                      <item.icon className="h-4 w-4" />
-                      {state !== "collapsed" && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Système</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {settingsItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild isActive={isActive(item.url)}>
-                    <NavLink
-                      to={item.url}
-                      end
-                      className="hover:bg-sidebar-accent/50"
-                      activeClassName="bg-sidebar-accent text-sidebar-accent-foreground font-medium"
-                    >
-                      <item.icon className="h-4 w-4" />
-                      {state !== "collapsed" && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+                      <NavLink
+                        to={item.url!}
+                        end
+                        className="hover:bg-sidebar-accent/50"
+                        activeClassName="bg-sidebar-accent text-sidebar-accent-foreground font-medium"
+                      >
+                        <item.icon className="h-4 w-4" />
+                        <span>{item.title}</span>
+                      </NavLink>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ),
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -88,8 +88,8 @@ const navTree: NavItem[] = [
         icon: GraduationCap,
         children: [
           { title: "Concours", icon: List, url: "/concours" },
-          { title: "Structures", icon: Building, url: "/structures", badge: "NEW" },
-          { title: "Titres", icon: Award, url: "/titres", badge: "NEW" },
+          { title: "Structures", icon: Building, url: "/structures" },
+          { title: "Titres", icon: Award, url: "/titres" },
         ],
       },
     ],

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,25 +1,24 @@
-import { Users, BookOpen, FileText, Loader2, Building2, BookMarked } from "lucide-react";
+import { Users, FileText, Loader2, Building2, GraduationCap, GitFork } from "lucide-react";
 import { StatCard } from "@/components/StatCard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Link } from "react-router-dom";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { useQuery } from "@tanstack/react-query";
 import { statsService } from "@/lib/services/stats.service";
 import { filieresService } from "@/lib/services/filieres.service";
 
-const recentActivities = [
-  { user: "Admin", action: "Upload épreuve", filiere: "Informatique", time: "Il y a 5 min" },
-  { user: "Modérateur", action: "Ajout filière", filiere: "Mathématiques", time: "Il y a 1h" },
-  { user: "Admin", action: "Modification", filiere: "Physique", time: "Il y a 2h" },
-  { user: "Admin", action: "Upload épreuve", filiere: "Chimie", time: "Il y a 3h" },
-];
+const BREAKDOWN_COLORS = ["#4f46e5", "#10b981", "#f59e0b"];
 
 export default function Dashboard() {
   const { data: stats, isLoading: statsLoading } = useQuery({
@@ -35,8 +34,6 @@ export default function Dashboard() {
   });
   const filieres = filieresResponse?.data || [];
 
-
-
   const isLoading = statsLoading || filieresLoading;
 
   if (isLoading) {
@@ -47,152 +44,181 @@ export default function Dashboard() {
     );
   }
 
+  const country = localStorage.getItem("country") || "benin";
+  const countryLabel = country.charAt(0).toUpperCase() + country.slice(1);
+  const today = new Date().toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  // All chart/breakdown data comes from the real /stats counts.
+  const contentBars = [
+    { name: "Épreuves", value: stats?.epreuvesCount ?? 0 },
+    { name: "Concours", value: stats?.concoursCount ?? 0 },
+    { name: "Parcours", value: stats?.parcoursCount ?? 0 },
+    { name: "Publicités", value: stats?.publicitesCount ?? 0 },
+    { name: "Événements", value: stats?.evenementsCount ?? 0 },
+    { name: "Opportunités", value: stats?.opportunitesCount ?? 0 },
+  ];
+
+  const breakdownRaw = [
+    { name: "Épreuves", value: stats?.epreuvesCount ?? 0 },
+    { name: "Concours", value: stats?.concoursCount ?? 0 },
+    { name: "Parcours", value: stats?.parcoursCount ?? 0 },
+  ];
+  const breakdownTotal = breakdownRaw.reduce((sum, d) => sum + d.value, 0);
+  const breakdown = breakdownRaw.map((d) => ({
+    ...d,
+    pct: breakdownTotal ? Math.round((d.value / breakdownTotal) * 100) : 0,
+  }));
+
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-foreground">Dashboard</h1>
-        <p className="text-muted-foreground">Vue d'ensemble de votre plateforme</p>
+        <h1 className="text-3xl font-bold text-foreground">Tableau de bord</h1>
+        <p className="text-muted-foreground">
+          Vue d'ensemble — <span className="font-medium text-foreground">{countryLabel}</span> · {today}
+        </p>
       </div>
 
-      <div>
-        <h2 className="text-2xl font-semibold mb-4">Contenu Académique</h2>
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <StatCard
-            title="Utilisateurs"
-            value={stats?.usersCount.toString() || "0"}
-            icon={Users}
-            variant="primary"
-          />
-          <StatCard
-            title="Établissements"
-            value={stats?.etablissementsCount.toString() || "0"}
-            icon={Building2}
-            variant="accent"
-          />
-          <StatCard
-            title="Filières"
-            value={stats?.filieresCount.toString() || "0"}
-            icon={BookOpen}
-            variant="success"
-          />
-          <StatCard
-            title="Matières"
-            value={stats?.matieresCount.toString() || "0"}
-            icon={BookMarked}
-          />
-          <StatCard
-            title="Épreuves"
-            value={stats?.epreuvesCount.toString() || "0"}
-            icon={FileText}
-            variant="primary"
-          />
-
-        </div>
+      {/* Stat cards — bound to real /stats counts */}
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        <StatCard
+          title="Utilisateurs"
+          value={stats?.usersCount.toLocaleString("fr-FR") || "0"}
+          icon={Users}
+          variant="primary"
+        />
+        <StatCard
+          title="Établissements"
+          value={stats?.etablissementsCount.toLocaleString("fr-FR") || "0"}
+          icon={Building2}
+          variant="accent"
+        />
+        <StatCard
+          title="Épreuves"
+          value={stats?.epreuvesCount.toLocaleString("fr-FR") || "0"}
+          icon={FileText}
+          variant="success"
+        />
+        <StatCard
+          title="Concours"
+          value={stats?.concoursCount.toLocaleString("fr-FR") || "0"}
+          icon={GraduationCap}
+        />
       </div>
 
-      <div>
-        <h2 className="text-2xl font-semibold mb-4">Contenu Public</h2>
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <StatCard
-            title="Parcours"
-            value={stats?.parcoursCount.toString() || "0"}
-            icon={BookOpen}
-            variant="accent"
-          />
-          <StatCard
-            title="Publicités"
-            value={stats?.publicitesCount.toString() || "0"}
-            icon={FileText}
-            variant="primary"
-          />
-          <StatCard
-            title="Événements"
-            value={stats?.evenementsCount.toString() || "0"}
-            icon={FileText}
-            variant="accent"
-          />
-          <StatCard
-            title="Opportunités"
-            value={stats?.opportunitesCount.toString() || "0"}
-            icon={FileText}
-            variant="success"
-          />
-          <StatCard
-            title="Concours"
-            value={stats?.concoursCount.toString() || "0"}
-            icon={FileText}
-          />
-          <StatCard
-            title="Contacts Pro"
-            value={stats?.contactsProfessionnelsCount.toString() || "0"}
-            icon={Users}
-          />
-        </div>
-      </div>
-
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Card className="shadow-md">
+      {/* Chart + breakdown — both derived from real counts */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="shadow-md lg:col-span-2">
           <CardHeader>
-            <CardTitle>Activités récentes</CardTitle>
-            <CardDescription>Dernières actions effectuées sur la plateforme</CardDescription>
+            <CardTitle>Répartition des contenus</CardTitle>
+            <CardDescription>Volume par type de contenu</CardDescription>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Utilisateur</TableHead>
-                  <TableHead>Action</TableHead>
-                  <TableHead>Filière</TableHead>
-                  <TableHead>Date</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {recentActivities.map((activity, index) => (
-                  <TableRow key={index}>
-                    <TableCell className="font-medium">{activity.user}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline">{activity.action}</Badge>
-                    </TableCell>
-                    <TableCell>{activity.filiere}</TableCell>
-                    <TableCell className="text-muted-foreground">{activity.time}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <ResponsiveContainer width="100%" height={224}>
+              <BarChart data={contentBars} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  allowDecimals={false}
+                  tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={40}
+                />
+                <Tooltip
+                  cursor={{ fill: "hsl(var(--muted))" }}
+                  contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                />
+                <Bar dataKey="value" name="Total" fill="#4f46e5" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
           </CardContent>
         </Card>
 
         <Card className="shadow-md">
           <CardHeader>
-            <CardTitle>Filières</CardTitle>
-            <CardDescription>Liste des filières disponibles</CardDescription>
+            <CardTitle>Répartition du contenu</CardTitle>
+            <CardDescription>Épreuves · Concours · Parcours</CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="space-y-4">
-              {filieres.length === 0 ? (
-                <p className="text-center text-muted-foreground py-4">Aucune filière disponible</p>
-              ) : (
-                filieres.slice(0, 5).map((filiere, index) => (
-                  <div key={filiere.id} className="space-y-2">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="font-medium text-foreground">{filiere.nom}</span>
-                      <span className="text-muted-foreground text-xs">
-                        {filiere.etablissement?.nom || 'N/A'}
+            {breakdownTotal === 0 ? (
+              <p className="py-12 text-center text-sm text-muted-foreground">
+                Aucun contenu disponible
+              </p>
+            ) : (
+              <>
+                <ResponsiveContainer width="100%" height={160}>
+                  <PieChart>
+                    <Pie
+                      data={breakdown}
+                      dataKey="value"
+                      nameKey="name"
+                      innerRadius={45}
+                      outerRadius={70}
+                      paddingAngle={2}
+                      strokeWidth={0}
+                    >
+                      {breakdown.map((_, i) => (
+                        <Cell key={i} fill={BREAKDOWN_COLORS[i % BREAKDOWN_COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} />
+                  </PieChart>
+                </ResponsiveContainer>
+                <div className="mt-4 space-y-2 text-sm">
+                  {breakdown.map((d, i) => (
+                    <div key={d.name} className="flex items-center justify-between">
+                      <span className="flex items-center gap-2">
+                        <span
+                          className="h-2.5 w-2.5 rounded-full"
+                          style={{ background: BREAKDOWN_COLORS[i % BREAKDOWN_COLORS.length] }}
+                        />
+                        {d.name}
                       </span>
+                      <span className="text-muted-foreground">{d.pct}%</span>
                     </div>
-                    <div className="h-2 w-full rounded-full bg-secondary overflow-hidden">
-                      <div
-                        className="h-full bg-gradient-primary transition-all"
-                        style={{ width: `${Math.max(20, 100 - index * 15)}%` }}
-                      />
-                    </div>
-                  </div>
-                ))
-              )}
-            </div>
+                  ))}
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
       </div>
+
+      {/* Recent list — real filières from filieresService */}
+      <Card className="shadow-md">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Filières récentes</CardTitle>
+            <CardDescription>Dernières filières enregistrées</CardDescription>
+          </div>
+          <Link to="/filieres" className="text-sm font-medium text-primary">
+            Tout voir →
+          </Link>
+        </CardHeader>
+        <CardContent>
+          {filieres.length === 0 ? (
+            <p className="py-4 text-center text-muted-foreground">Aucune filière disponible</p>
+          ) : (
+            <div className="divide-y divide-border">
+              {filieres.slice(0, 5).map((filiere) => (
+                <div key={filiere.id} className="flex items-center gap-3 py-3 text-sm">
+                  <GitFork className="h-4 w-4 text-primary" />
+                  <span className="flex-1 font-medium text-foreground">{filiere.nom}</span>
+                  <Badge variant="outline">{filiere.etablissement?.nom || "N/A"}</Badge>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
Admin dashboard UI redesign (frontend-only, 2 files). Signed off on the static mockup (`docs/redesign/admin-dashboard.html`) and validated live on the dev stack.

## Sidebar
- ~25 flat items → **grouped, collapsible** sections (Éducation / Communauté / JobKia / Contenu / Système) with count badges, chevrons, active-group auto-expand.
- Nested **Concours** sub-group → Concours / Structures / Titres.
- **Utilisateurs** is its own section → Utilisateurs + Parrainage.
- **Communauté → Parcours** sub-group → Parcours + Catégories.
- **Paramètres** shown disabled with an "À venir" badge (route preserved, just unlinked).

## Dashboard
- Refreshed card/chart/breakdown layout, bound to the real stats data.

Built on top of the three feature merges (epreuves annee/section, concours structure/titre, ressources removed), so the nav already reflects them (Structures/Titres present, no Ressources). `tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)