### PR TITLE
fix(epreuves): création échoue depuis le frontend (url + duree_minutes)

### DIFF
--- a/backend/src/epreuves/dto/creer-epreuve.dto.ts
+++ b/backend/src/epreuves/dto/creer-epreuve.dto.ts
@@ -7,9 +7,10 @@ export class CreerEpreuveDto {
   @IsString()
   titre: string;
 
-  @ApiProperty({ description: 'URL du fichier de l\'épreuve' })
+  @ApiProperty({ description: 'URL du fichier de l\'épreuve', required: false })
+  @IsOptional()
   @IsString()
-  url: string;
+  url?: string;
 
   @ApiProperty({ example: 120, description: 'Durée en minutes', required: false })
   @IsOptional()

--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -41,8 +41,8 @@ export class EpreuvesService {
     }
     const newEpreuve = new Epreuve();
     newEpreuve.titre = creerEpreuveDto.titre;
-    newEpreuve.url = creerEpreuveDto.url;
-    newEpreuve.duree_minutes = creerEpreuveDto.duree_minutes;
+    newEpreuve.url = creerEpreuveDto.url ?? '';
+    newEpreuve.duree_minutes = creerEpreuveDto.duree_minutes ?? 0;
     newEpreuve.matiere_id = creerEpreuveDto.matiere_id;
     newEpreuve.professeur_id = professeurId;
     newEpreuve.date_publication = creerEpreuveDto.date_publication;


### PR DESCRIPTION
## Bug
Creating an épreuve from the admin frontend popped **"Le champ url doit être une chaîne de caractères"**. The frontend create is 2-step — it POSTs only `{titre, matiere_id}` then PUTs the rest — but the create path required more:
- `CreerEpreuveDto.url` was `@IsString()` **without** `@IsOptional()` → 400 on the missing `url`.
- `epreuves.url` and `epreuves.duree_minutes` are **NOT NULL with no DB default**, and the service passed `undefined` → would 500 on insert once `url` was fixed.

## Fix (backend, 2 files)
- `creer-epreuve.dto.ts`: `url` → `@IsOptional() @IsString() url?`.
- `epreuves.service.ts`: `url = dto.url ?? ''` and `duree_minutes = dto.duree_minutes ?? 0` (the real values are filled by the subsequent file-upload + update steps).

## Verified (against edukia-dev)
`POST /epreuves` with exactly `{titre, matiere_id}` now returns **201** (created with `url=""`, `duree_minutes=0`) — previously 400. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)