### PR TITLE
feat(kpi): Indicateurs dashboard — 15 KPIs (users, learners, engagement)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -59,6 +59,7 @@ import { PrestatairesModule } from './prestataires/prestataires.module';
 import { RecruteursModule } from './recruteurs/recruteurs.module';
 import { CompetencesModule } from './competences/competences.module';
 import { OffresModule } from './offres/offres.module';
+import { KpiModule } from './kpi/kpi.module';
 import { NotificationEmailModule } from './notification-email/notification-email.module';
 import { BullModule } from '@nestjs/bullmq';
 import { CountryConfigModule } from './config/country-config.module';
@@ -146,6 +147,7 @@ import { CountryMiddleware } from './config/country.middleware';
     RecruteursModule,
     CompetencesModule,
     OffresModule,
+    KpiModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -43,6 +43,9 @@ export class AuthService {
       mot_de_passe: hashedPassword, // Note: InscriptionDto expects plain password, but we hash here? check service
       role: registerDto.role,
       sexe: registerDto.sexe,
+      date_naissance: registerDto.date_naissance,
+      zone_residence: registerDto.zone_residence,
+      situation_handicap: registerDto.situation_handicap,
       code_parrainage: registerDto.code_parrainage
     });
     this.logger.log(`Inscription réussie via /auth/register: ${user.email} (ID: ${user.id})`);

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsEmail, MinLength, IsEnum, IsOptional } from 'class-validator';
+import { IsString, IsEmail, MinLength, IsEnum, IsOptional, IsDateString, IsIn } from 'class-validator';
 import { RoleType, SexeType } from '../../utilisateurs/entities/utilisateur.entity';
 
 export class RegisterDto {
@@ -38,4 +38,19 @@ export class RegisterDto {
     @IsOptional()
     @IsString()
     code_parrainage?: string;
+
+    @ApiProperty({ example: '1995-04-23', description: 'Date de naissance (PII optionnelle, consentement)', required: false })
+    @IsOptional()
+    @IsDateString()
+    date_naissance?: string;
+
+    @ApiProperty({ enum: ['rural', 'urbain'], description: 'Zone de résidence (PII optionnelle)', required: false })
+    @IsOptional()
+    @IsIn(['rural', 'urbain'])
+    zone_residence?: string;
+
+    @ApiProperty({ enum: ['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'], description: 'Situation de handicap (PII optionnelle)', required: false })
+    @IsOptional()
+    @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
+    situation_handicap?: string;
 }

--- a/backend/src/concours/concours.controller.ts
+++ b/backend/src/concours/concours.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus, Request } from '@nestjs/common';
 import { Response } from 'express';
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 import { ConcoursService } from './concours.service';
@@ -10,6 +10,8 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { FilterConcoursDto } from './dto/filter-concours.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { ResourceAccessService } from '../resource-access/resource-access.service';
 
 @ApiTags('concours')
 @Controller('concours')
@@ -17,6 +19,7 @@ export class ConcoursController {
   constructor(
     private readonly concoursService: ConcoursService,
     private readonly fichiersService: FichiersService,
+    private readonly resourceAccessService: ResourceAccessService,
   ) { }
 
   @UseGuards(JwtAuthGuard, RoleGuard)
@@ -50,10 +53,14 @@ export class ConcoursController {
   @Get(':id/telechargement')
   async downloadFile(
     @Param('id') id: string,
+    @CurrentCountry() pays: string,
+    @Request() req,
     @Res() res: Response
   ) {
     const { url } = await this.concoursService.findOneForDownload(+id);
     const { buffer, contentType, filename } = await this.fichiersService.downloadFile(url);
+
+    await this.resourceAccessService.log('concours', +id, req.user?.utilisateurId ?? null, pays);
 
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);

--- a/backend/src/concours/concours.module.ts
+++ b/backend/src/concours/concours.module.ts
@@ -4,11 +4,13 @@ import { Concours } from './entities/concours.entity';
 import { ConcoursController } from './concours.controller';
 import { ConcoursService } from './concours.service';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { ResourceAccessModule } from '../resource-access/resource-access.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Concours]),
     FichiersModule,
+    ResourceAccessModule,
   ],
   controllers: [ConcoursController],
   providers: [ConcoursService],

--- a/backend/src/epreuves/epreuves.controller.ts
+++ b/backend/src/epreuves/epreuves.controller.ts
@@ -10,6 +10,7 @@ import { PaginationDto } from '../common/dto/pagination.dto';
 import { FilterEpreuveDto } from './dto/filter-epreuve.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { ResourceAccessService } from '../resource-access/resource-access.service';
 
 @ApiTags('epreuves')
 @Controller('epreuves')
@@ -17,6 +18,7 @@ export class EpreuvesController {
   constructor(
     private readonly epreuvesService: EpreuvesService,
     private readonly fichiersService: FichiersService,
+    private readonly resourceAccessService: ResourceAccessService,
   ) { }
 
   @UseGuards(JwtAuthGuard)
@@ -44,10 +46,14 @@ export class EpreuvesController {
   @Get(':id/telechargement')
   async downloadFile(
     @Param('id') id: string,
+    @CurrentCountry() pays: string,
+    @Request() req,
     @Res() res: Response
   ) {
     const { url } = await this.epreuvesService.findOneForDownload(id);
     const { buffer, contentType, filename } = await this.fichiersService.downloadFile(url);
+
+    await this.resourceAccessService.log('epreuve', +id, req.user?.utilisateurId ?? null, pays);
 
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);

--- a/backend/src/epreuves/epreuves.module.ts
+++ b/backend/src/epreuves/epreuves.module.ts
@@ -4,11 +4,13 @@ import { EpreuvesController } from './epreuves.controller';
 import { EpreuvesService } from './epreuves.service';
 import { Epreuve } from './entities/epreuve.entity';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { ResourceAccessModule } from '../resource-access/resource-access.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Epreuve]),
     FichiersModule,
+    ResourceAccessModule,
   ],
   controllers: [EpreuvesController],
   providers: [EpreuvesService],

--- a/backend/src/kpi/dto/kpi-query.dto.ts
+++ b/backend/src/kpi/dto/kpi-query.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString } from 'class-validator';
+
+export class KpiQueryDto {
+  @ApiProperty({ example: '2025-01-01', description: 'Début de la période (inclus)' })
+  @IsDateString()
+  startDate: string;
+
+  @ApiProperty({ example: '2025-12-31', description: 'Fin de la période (inclus)' })
+  @IsDateString()
+  endDate: string;
+}

--- a/backend/src/kpi/kpi.controller.ts
+++ b/backend/src/kpi/kpi.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { KpiService } from './kpi.service';
+import { KpiQueryDto } from './dto/kpi-query.dto';
+
+@ApiTags('kpi')
+@Controller('kpi')
+export class KpiController {
+  constructor(private readonly kpiService: KpiService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Indicateurs (KPI) sur une période, scopés par pays' })
+  @ApiResponse({ status: 200, description: 'Les 15 indicateurs groupés par section' })
+  async getKpis(@CurrentCountry() pays: string, @Query() query: KpiQueryDto) {
+    return this.kpiService.getKpis(pays, query.startDate, query.endDate);
+  }
+}

--- a/backend/src/kpi/kpi.module.ts
+++ b/backend/src/kpi/kpi.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { KpiController } from './kpi.controller';
+import { KpiService } from './kpi.service';
+
+@Module({
+  controllers: [KpiController],
+  providers: [KpiService],
+})
+export class KpiModule {}

--- a/backend/src/kpi/kpi.service.ts
+++ b/backend/src/kpi/kpi.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+/**
+ * KPI dashboard (Mastercard Foundation reporting). Every figure is scoped by
+ * country (pays) and by a [startDate, endDate] period. endDate is inclusive of
+ * the whole day — the SQL upper bound is exclusive at endDate + 1 day.
+ *
+ * Conventions (confirmed in the spec):
+ *  - apprenant / learner = role 'étudiant'; female = sexe 'F'.
+ *  - age ≤ 35 at registration: born on/after date_creation − 35 years, i.e.
+ *    date_naissance >= date_creation − interval '35 years'. NULL birthdates are
+ *    excluded automatically (the comparison is NULL → not counted).
+ *  - disability: situation_handicap IS NOT NULL AND <> 'aucun'.
+ *  - logins (KPI 8 / 15): distinct refresh_tokens.utilisateur_id in the period
+ *    (refresh_tokens has no pays, so we join utilisateurs for the country scope).
+ *  - KPI 16: distinct learners with a resource_access row (épreuve|concours) in
+ *    the trailing week / 2 weeks / month windows, all anchored on endDate.
+ */
+@Injectable()
+export class KpiService {
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async getKpis(pays: string, startDate: string, endDate: string) {
+    const n = (v: unknown) => Number(v ?? 0);
+
+    const [demographics] = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(*)                                                                                  AS total_users,
+        COUNT(*) FILTER (WHERE date_naissance >= (date_creation - interval '35 years'))           AS users_age_35,
+        COUNT(*) FILTER (WHERE sexe = 'F')                                                         AS female_users,
+        COUNT(*) FILTER (WHERE sexe = 'F' AND date_naissance >= (date_creation - interval '35 years')) AS female_age_35,
+        COUNT(*) FILTER (WHERE zone_residence = 'rural')                                           AS rural_users,
+        COUNT(*) FILTER (WHERE situation_handicap IS NOT NULL AND situation_handicap <> 'aucun')   AS disability_users,
+        COUNT(*) FILTER (WHERE role = 'étudiant')                                                  AS learners,
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND date_naissance >= (date_creation - interval '35 years')) AS learners_age_35,
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND sexe = 'F' AND date_naissance >= (date_creation - interval '35 years')) AS learners_age_35_female,
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND sexe = 'F')                                   AS female_learners,
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND zone_residence = 'rural')                     AS rural_learners,
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND situation_handicap IS NOT NULL AND situation_handicap <> 'aucun') AS disability_learners
+      FROM utilisateurs
+      WHERE pays = $1
+        AND date_creation >= $2::date
+        AND date_creation < ($3::date + interval '1 day')
+      `,
+      [pays, startDate, endDate],
+    );
+
+    const [logins] = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(DISTINCT rt.utilisateur_id)                                       AS users_logged_in,
+        COUNT(DISTINCT rt.utilisateur_id) FILTER (WHERE u.role = 'étudiant')    AS learners_logged_in
+      FROM refresh_tokens rt
+      JOIN utilisateurs u ON u.id = rt.utilisateur_id
+      WHERE u.pays = $1
+        AND rt.date_creation >= $2::date
+        AND rt.date_creation < ($3::date + interval '1 day')
+      `,
+      [pays, startDate, endDate],
+    );
+
+    const [access] = await this.dataSource.query(
+      `
+      SELECT
+        COUNT(DISTINCT ra.utilisateur_id) FILTER (WHERE ra.accessed_at >= (($2::date + interval '1 day') - interval '7 days'))  AS last_week,
+        COUNT(DISTINCT ra.utilisateur_id) FILTER (WHERE ra.accessed_at >= (($2::date + interval '1 day') - interval '14 days')) AS last_two_weeks,
+        COUNT(DISTINCT ra.utilisateur_id) FILTER (WHERE ra.accessed_at >= (($2::date + interval '1 day') - interval '1 month')) AS last_month
+      FROM resource_access ra
+      JOIN utilisateurs u ON u.id = ra.utilisateur_id AND u.role = 'étudiant'
+      WHERE ra.pays = $1
+        AND ra.resource_type IN ('epreuve', 'concours')
+        AND ra.accessed_at < ($2::date + interval '1 day')
+      `,
+      [pays, endDate],
+    );
+
+    return {
+      pays,
+      periode: { startDate, endDate },
+      // Section 2 — Utilisateurs (over the period, by date_creation)
+      utilisateurs: {
+        total: n(demographics.total_users),               // KPI 2
+        age_35_max: n(demographics.users_age_35),          // KPI 3
+        femmes: n(demographics.female_users),              // KPI 4
+        femmes_35_max: n(demographics.female_age_35),      // KPI 5
+        zone_rurale: n(demographics.rural_users),          // KPI 6
+        situation_handicap: n(demographics.disability_users), // KPI 7
+        connectes: n(logins.users_logged_in),              // KPI 8
+      },
+      // Section 3 — Apprenants / Inscription (role 'étudiant')
+      apprenants: {
+        total: n(demographics.learners),                   // KPI 9
+        age_35_max: n(demographics.learners_age_35),       // KPI 10
+        age_35_max_femmes: n(demographics.learners_age_35_female), // KPI 11
+        femmes: n(demographics.female_learners),           // KPI 12
+        zone_rurale: n(demographics.rural_learners),       // KPI 13
+        situation_handicap: n(demographics.disability_learners),  // KPI 14
+      },
+      // Section 4 — Engagement
+      engagement: {
+        apprenants_connectes: n(logins.learners_logged_in), // KPI 15
+        apprenants_ressource: {                             // KPI 16
+          semaine: n(access.last_week),
+          deux_semaines: n(access.last_two_weeks),
+          mois: n(access.last_month),
+        },
+      },
+    };
+  }
+}

--- a/backend/src/resource-access/resource-access.module.ts
+++ b/backend/src/resource-access/resource-access.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ResourceAccessService } from './resource-access.service';
+
+@Module({
+  providers: [ResourceAccessService],
+  exports: [ResourceAccessService],
+})
+export class ResourceAccessModule {}

--- a/backend/src/resource-access/resource-access.service.ts
+++ b/backend/src/resource-access/resource-access.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+export type ResourceType = 'epreuve' | 'concours';
+
+/**
+ * Append-only access log feeding KPI 16 (distinct learners who accessed an
+ * épreuve/concours). Best-effort: a failed insert is logged and swallowed so
+ * it never breaks the download it instruments. utilisateur_id may be null
+ * (e.g. unauthenticated access) — the FK is ON DELETE SET NULL anyway.
+ */
+@Injectable()
+export class ResourceAccessService {
+  private readonly logger = new Logger(ResourceAccessService.name);
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async log(
+    resourceType: ResourceType,
+    resourceId: number,
+    utilisateurId: number | null,
+    pays: string,
+  ): Promise<void> {
+    try {
+      await this.dataSource.query(
+        `INSERT INTO resource_access (utilisateur_id, resource_type, resource_id, pays)
+         VALUES ($1, $2, $3, $4)`,
+        [utilisateurId ?? null, resourceType, resourceId, pays],
+      );
+    } catch (err) {
+      this.logger.warn(
+        `resource_access log failed (${resourceType} #${resourceId}): ${err?.message ?? err}`,
+      );
+    }
+  }
+}

--- a/backend/src/utilisateurs/dto/inscription.dto.ts
+++ b/backend/src/utilisateurs/dto/inscription.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsNumber } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsNumber, IsDateString, IsIn } from 'class-validator';
 import { RoleType, SexeType } from '../entities/utilisateur.entity';
 
 export class InscriptionDto {
@@ -68,4 +68,19 @@ export class InscriptionDto {
   @IsOptional()
   @IsString()
   code_parrainage?: string;
+
+  @ApiProperty({ example: '1995-04-23', description: 'Date de naissance (PII optionnelle, consentement)', required: false })
+  @IsOptional()
+  @IsDateString()
+  date_naissance?: string;
+
+  @ApiProperty({ enum: ['rural', 'urbain'], description: 'Zone de résidence (PII optionnelle)', required: false })
+  @IsOptional()
+  @IsIn(['rural', 'urbain'])
+  zone_residence?: string;
+
+  @ApiProperty({ enum: ['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'], description: 'Situation de handicap (PII optionnelle)', required: false })
+  @IsOptional()
+  @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
+  situation_handicap?: string;
 }

--- a/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsEnum, IsNumber } from 'class-validator';
+import { IsOptional, IsString, IsEnum, IsNumber, IsDateString, IsIn } from 'class-validator';
 import { RoleType, SexeType } from '../entities/utilisateur.entity';
 
 export class MajUtilisateurDto {
@@ -21,6 +21,18 @@ export class MajUtilisateurDto {
   @IsOptional()
   @IsEnum(SexeType)
   sexe?: SexeType;
+
+  @IsOptional()
+  @IsDateString()
+  date_naissance?: string;
+
+  @IsOptional()
+  @IsIn(['rural', 'urbain'])
+  zone_residence?: string;
+
+  @IsOptional()
+  @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
+  situation_handicap?: string;
 
   @IsOptional()
   @IsString()

--- a/backend/src/utilisateurs/dto/update-profil.dto.ts
+++ b/backend/src/utilisateurs/dto/update-profil.dto.ts
@@ -10,4 +10,7 @@ export class UpdateProfilDto extends PickType(MajUtilisateurDto, [
     'niveau_etude_id',
     'sexe',
     'telephone',
+    'date_naissance',
+    'zone_residence',
+    'situation_handicap',
 ] as const) { }

--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -78,6 +78,15 @@ export class Utilisateur {
   @Column({ type: 'enum', enum: SexeType, nullable: true })
   sexe: SexeType;
 
+  @Column({ type: 'date', nullable: true })
+  date_naissance: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  zone_residence: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  situation_handicap: string;
+
   @Column({ nullable: true })
   telephone: string;
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import CompetencesAdmin from "./pages/CompetencesAdmin";
 import Notifications from "./pages/Notifications";
 import AppVersions from "./pages/AppVersions";
 import Parrainages from "./pages/Parrainages";
+import Indicateurs from "./pages/Indicateurs";
 import Login from "./pages/Login";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
@@ -84,6 +85,7 @@ const App = () => (
                       <Route path="/parrainages" element={<Parrainages />} />
                       <Route path="/admin/recruteurs" element={<RecruteursAdmin />} />
                       <Route path="/admin/competences" element={<CompetencesAdmin />} />
+                      <Route path="/indicateurs" element={<Indicateurs />} />
                       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -137,6 +137,7 @@ const navTree: NavItem[] = [
     icon: Users,
     children: [
       { title: "Utilisateurs", icon: User, url: "/users" },
+      { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Parrainage", icon: UserPlus, url: "/parrainages" },
     ],
   },
@@ -144,7 +145,6 @@ const navTree: NavItem[] = [
     title: "Système",
     icon: Settings,
     children: [
-      { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Statistiques", icon: BarChart3 },
       { title: "Paramètres", icon: SlidersHorizontal },
       { title: "Contacts Pro", icon: Contact, url: "/contacts-professionnels" },

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -144,6 +144,7 @@ const navTree: NavItem[] = [
     title: "Système",
     icon: Settings,
     children: [
+      { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Statistiques", icon: BarChart3 },
       { title: "Paramètres", icon: SlidersHorizontal },
       { title: "Contacts Pro", icon: Contact, url: "/contacts-professionnels" },

--- a/frontend/src/lib/services/kpi.service.ts
+++ b/frontend/src/lib/services/kpi.service.ts
@@ -1,0 +1,39 @@
+import { api } from '../api';
+
+// Mirrors the backend GET /kpi payload (grouped by section). Country is
+// auto-appended by the api client (withCountryQuery) — don't add pays here.
+export interface KpiResponse {
+  pays: string;
+  periode: { startDate: string; endDate: string };
+  utilisateurs: {
+    total: number;              // KPI 2
+    age_35_max: number;         // KPI 3
+    femmes: number;             // KPI 4
+    femmes_35_max: number;      // KPI 5
+    zone_rurale: number;        // KPI 6
+    situation_handicap: number; // KPI 7
+    connectes: number;          // KPI 8
+  };
+  apprenants: {
+    total: number;              // KPI 9
+    age_35_max: number;         // KPI 10
+    age_35_max_femmes: number;  // KPI 11
+    femmes: number;             // KPI 12
+    zone_rurale: number;        // KPI 13
+    situation_handicap: number; // KPI 14
+  };
+  engagement: {
+    apprenants_connectes: number; // KPI 15
+    apprenants_ressource: {       // KPI 16
+      semaine: number;
+      deux_semaines: number;
+      mois: number;
+    };
+  };
+}
+
+export const kpiService = {
+  async getKpis(startDate: string, endDate: string): Promise<KpiResponse> {
+    return api.get<KpiResponse>(`/kpi?startDate=${startDate}&endDate=${endDate}`);
+  },
+};

--- a/frontend/src/pages/Indicateurs.tsx
+++ b/frontend/src/pages/Indicateurs.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Users,
+  UserCheck,
+  UserCircle,
+  Cake,
+  MapPin,
+  Accessibility,
+  LogIn,
+  Activity,
+  Loader2,
+  type LucideIcon,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { kpiService } from "@/lib/services/kpi.service";
+
+// Default range: the trailing 6 months.
+const fmt = (d: Date) => d.toISOString().slice(0, 10);
+const defaultEnd = () => fmt(new Date());
+const defaultStart = () => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - 6);
+  return fmt(d);
+};
+
+function KpiCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: number;
+  icon: LucideIcon;
+}) {
+  return (
+    <Card className="border-0 shadow-sm">
+      <CardContent className="flex items-center justify-between p-5">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <p className="text-3xl font-bold text-card-foreground">
+            {value.toLocaleString("fr-FR")}
+          </p>
+        </div>
+        <div className="rounded-lg bg-primary/10 p-3 text-primary">
+          <Icon className="h-6 w-6" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function Indicateurs() {
+  const [startDate, setStartDate] = useState(defaultStart);
+  const [endDate, setEndDate] = useState(defaultEnd);
+
+  const country = localStorage.getItem("country") || "benin";
+  const countryLabel = country.charAt(0).toUpperCase() + country.slice(1);
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ["kpi", country, startDate, endDate],
+    queryFn: () => kpiService.getKpis(startDate, endDate),
+    enabled: !!startDate && !!endDate && startDate <= endDate,
+    staleTime: 30000,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Indicateurs</h1>
+        <p className="text-muted-foreground">
+          Indicateurs de suivi —{" "}
+          <span className="font-medium text-foreground">{countryLabel}</span> · période
+          du {startDate} au {endDate}
+        </p>
+      </div>
+
+      {/* Date-range picker */}
+      <Card className="border-0 shadow-sm">
+        <CardContent className="flex flex-wrap items-end gap-4 p-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="kpi-start">Date de début</Label>
+            <Input
+              id="kpi-start"
+              type="date"
+              value={startDate}
+              max={endDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-44"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="kpi-end">Date de fin</Label>
+            <Input
+              id="kpi-end"
+              type="date"
+              value={endDate}
+              min={startDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-44"
+            />
+          </div>
+          {isFetching && (
+            <span className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Actualisation…
+            </span>
+          )}
+        </CardContent>
+      </Card>
+
+      {startDate > endDate && (
+        <p className="text-sm text-destructive">
+          La date de début doit précéder la date de fin.
+        </p>
+      )}
+
+      {isError && (
+        <p className="text-sm text-destructive">
+          Impossible de charger les indicateurs. Réessayez.
+        </p>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center min-h-[300px]">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : data ? (
+        <div className="space-y-8">
+          {/* Section 2 — Utilisateurs */}
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-foreground">Utilisateurs</h2>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <KpiCard label="Total inscrits" value={data.utilisateurs.total} icon={Users} />
+              <KpiCard label="Âgés de 35 ans ou moins" value={data.utilisateurs.age_35_max} icon={Cake} />
+              <KpiCard label="Femmes" value={data.utilisateurs.femmes} icon={UserCircle} />
+              <KpiCard label="Femmes de 35 ans ou moins" value={data.utilisateurs.femmes_35_max} icon={UserCircle} />
+              <KpiCard label="En zone rurale" value={data.utilisateurs.zone_rurale} icon={MapPin} />
+              <KpiCard label="En situation de handicap" value={data.utilisateurs.situation_handicap} icon={Accessibility} />
+              <KpiCard label="Connectés sur la période" value={data.utilisateurs.connectes} icon={LogIn} />
+            </div>
+          </section>
+
+          {/* Section 3 — Apprenants / Inscription */}
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-foreground">Apprenants</h2>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <KpiCard label="Apprenants inscrits" value={data.apprenants.total} icon={UserCheck} />
+              <KpiCard label="Âgés de 35 ans ou moins" value={data.apprenants.age_35_max} icon={Cake} />
+              <KpiCard label="Femmes de 35 ans ou moins" value={data.apprenants.age_35_max_femmes} icon={UserCircle} />
+              <KpiCard label="Femmes" value={data.apprenants.femmes} icon={UserCircle} />
+              <KpiCard label="En zone rurale" value={data.apprenants.zone_rurale} icon={MapPin} />
+              <KpiCard label="En situation de handicap" value={data.apprenants.situation_handicap} icon={Accessibility} />
+            </div>
+          </section>
+
+          {/* Section 4 — Engagement */}
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-foreground">Engagement</h2>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <KpiCard
+                label="Apprenants connectés sur la période"
+                value={data.engagement.apprenants_connectes}
+                icon={LogIn}
+              />
+            </div>
+            <Card className="border-0 shadow-sm">
+              <CardHeader>
+                <CardTitle className="text-base">
+                  Apprenants ayant consulté une ressource (épreuve ou concours)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 sm:grid-cols-3">
+                <KpiCard label="Dernière semaine" value={data.engagement.apprenants_ressource.semaine} icon={Activity} />
+                <KpiCard label="Dernières 2 semaines" value={data.engagement.apprenants_ressource.deux_semaines} icon={Activity} />
+                <KpiCard label="Dernier mois" value={data.engagement.apprenants_ressource.mois} icon={Activity} />
+              </CardContent>
+            </Card>
+          </section>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/Indicateurs.tsx
+++ b/frontend/src/pages/Indicateurs.tsx
@@ -10,45 +10,192 @@ import {
   LogIn,
   Activity,
   Loader2,
+  BarChart3,
+  GraduationCap,
+  Zap,
+  TrendingUp,
   type LucideIcon,
 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
 import { kpiService } from "@/lib/services/kpi.service";
 
-// Default range: the trailing 6 months.
+// ---------- date helpers ----------
 const fmt = (d: Date) => d.toISOString().slice(0, 10);
-const defaultEnd = () => fmt(new Date());
-const defaultStart = () => {
+const daysAgo = (n: number) => {
   const d = new Date();
-  d.setMonth(d.getMonth() - 6);
+  d.setDate(d.getDate() - n);
   return fmt(d);
 };
+const monthsAgo = (n: number) => {
+  const d = new Date();
+  d.setMonth(d.getMonth() - n);
+  return fmt(d);
+};
+const defaultEnd = () => fmt(new Date());
+const defaultStart = () => monthsAgo(6);
 
-function KpiCard({
+const PRESETS: { label: string; start: () => string }[] = [
+  { label: "7 j", start: () => daysAgo(7) },
+  { label: "30 j", start: () => daysAgo(30) },
+  { label: "6 mois", start: () => monthsAgo(6) },
+  { label: "12 mois", start: () => monthsAgo(12) },
+];
+
+// ---------- accent palette (static strings for Tailwind JIT) ----------
+type Accent = "primary" | "emerald" | "violet" | "amber" | "sky" | "rose";
+const ACCENT_TILE: Record<Accent, string> = {
+  primary: "bg-primary/10 text-primary",
+  emerald: "bg-emerald-500/10 text-emerald-600",
+  violet: "bg-violet-500/10 text-violet-600",
+  amber: "bg-amber-500/10 text-amber-600",
+  sky: "bg-sky-500/10 text-sky-600",
+  rose: "bg-rose-500/10 text-rose-600",
+};
+const ACCENT_BAR: Record<Accent, string> = {
+  primary: "bg-primary",
+  emerald: "bg-emerald-500",
+  violet: "bg-violet-500",
+  amber: "bg-amber-500",
+  sky: "bg-sky-500",
+  rose: "bg-rose-500",
+};
+
+const nf = (v: number) => v.toLocaleString("fr-FR");
+
+// ---------- hero tile (top summary strip) ----------
+function HeroTile({
   label,
   value,
   icon: Icon,
+  accent,
+  sub,
 }: {
   label: string;
   value: number;
   icon: LucideIcon;
+  accent: Accent;
+  sub?: string;
 }) {
   return (
-    <Card className="border-0 shadow-sm">
-      <CardContent className="flex items-center justify-between p-5">
-        <div className="space-y-1">
+    <Card className="relative overflow-hidden border-0 shadow-md">
+      <span
+        className={cn("absolute inset-x-0 top-0 h-1", ACCENT_BAR[accent])}
+        aria-hidden
+      />
+      <CardContent className="p-5">
+        <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-muted-foreground">{label}</p>
-          <p className="text-3xl font-bold text-card-foreground">
-            {value.toLocaleString("fr-FR")}
-          </p>
+          <div className={cn("rounded-lg p-2", ACCENT_TILE[accent])}>
+            <Icon className="h-5 w-5" />
+          </div>
         </div>
-        <div className="rounded-lg bg-primary/10 p-3 text-primary">
-          <Icon className="h-6 w-6" />
-        </div>
+        <p className="mt-2 text-4xl font-bold tabular-nums tracking-tight text-card-foreground">
+          {nf(value)}
+        </p>
+        {sub && <p className="mt-1 text-xs text-muted-foreground">{sub}</p>}
       </CardContent>
     </Card>
+  );
+}
+
+// ---------- detail stat card with share-of-total bar ----------
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  accent = "primary",
+  base,
+  baseLabel = "part du total",
+}: {
+  label: string;
+  value: number;
+  icon: LucideIcon;
+  accent?: Accent;
+  base?: number;
+  baseLabel?: string;
+}) {
+  const pct =
+    base && base > 0 ? Math.min(100, Math.round((value / base) * 100)) : null;
+  return (
+    <Card className="shadow-sm transition-shadow hover:shadow-md">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <p className="text-sm font-medium leading-tight text-muted-foreground">
+            {label}
+          </p>
+          <div className={cn("shrink-0 rounded-lg p-2", ACCENT_TILE[accent])}>
+            <Icon className="h-5 w-5" />
+          </div>
+        </div>
+        <p className="mt-3 text-3xl font-bold tabular-nums text-card-foreground">
+          {nf(value)}
+        </p>
+        {pct !== null ? (
+          <div className="mt-3 space-y-1.5">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{baseLabel}</span>
+              <span className="font-semibold text-foreground">{pct}%</span>
+            </div>
+            <Progress value={pct} className="h-1.5" />
+          </div>
+        ) : (
+          <div className="mt-3 h-[1.375rem]" aria-hidden />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  description,
+  accent,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  accent: Accent;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className={cn("rounded-lg p-2", ACCENT_TILE[accent])}>
+        <Icon className="h-5 w-5" />
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function CardSkeletonGrid({ count }: { count: number }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i} className="shadow-sm">
+          <CardContent className="space-y-3 p-5">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-1.5 w-full" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
   );
 }
 
@@ -66,19 +213,38 @@ export default function Indicateurs() {
     staleTime: 30000,
   });
 
+  const activePreset = PRESETS.find(
+    (p) => p.start() === startDate && endDate === defaultEnd(),
+  )?.label;
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-foreground">Indicateurs</h1>
-        <p className="text-muted-foreground">
-          Indicateurs de suivi —{" "}
-          <span className="font-medium text-foreground">{countryLabel}</span> · période
-          du {startDate} au {endDate}
-        </p>
+      {/* Page header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-primary/10 p-2.5 text-primary">
+            <BarChart3 className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+              Indicateurs
+            </h1>
+            <p className="text-muted-foreground">
+              Suivi & reporting —{" "}
+              <span className="font-medium text-foreground">{countryLabel}</span> ·
+              du {startDate} au {endDate}
+            </p>
+          </div>
+        </div>
+        {isFetching && !isLoading && (
+          <span className="flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Actualisation…
+          </span>
+        )}
       </div>
 
-      {/* Date-range picker */}
-      <Card className="border-0 shadow-sm">
+      {/* Date-range controls */}
+      <Card className="shadow-sm">
         <CardContent className="flex flex-wrap items-end gap-4 p-5">
           <div className="space-y-1.5">
             <Label htmlFor="kpi-start">Date de début</Label>
@@ -102,79 +268,174 @@ export default function Indicateurs() {
               className="w-44"
             />
           </div>
-          {isFetching && (
-            <span className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" /> Actualisation…
-            </span>
-          )}
+          <Separator orientation="vertical" className="hidden h-10 sm:block" />
+          <div className="flex flex-wrap items-center gap-2">
+            {PRESETS.map((p) => (
+              <Button
+                key={p.label}
+                type="button"
+                size="sm"
+                variant={activePreset === p.label ? "default" : "outline"}
+                onClick={() => {
+                  setStartDate(p.start());
+                  setEndDate(defaultEnd());
+                }}
+              >
+                {p.label}
+              </Button>
+            ))}
+          </div>
         </CardContent>
       </Card>
 
       {startDate > endDate && (
-        <p className="text-sm text-destructive">
+        <p className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive">
           La date de début doit précéder la date de fin.
         </p>
       )}
-
       {isError && (
-        <p className="text-sm text-destructive">
+        <p className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive">
           Impossible de charger les indicateurs. Réessayez.
         </p>
       )}
 
       {isLoading ? (
-        <div className="flex items-center justify-center min-h-[300px]">
-          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <div className="space-y-8">
+          <CardSkeletonGrid count={4} />
+          <CardSkeletonGrid count={7} />
         </div>
       ) : data ? (
         <div className="space-y-8">
-          {/* Section 2 — Utilisateurs */}
-          <section className="space-y-3">
-            <h2 className="text-xl font-semibold text-foreground">Utilisateurs</h2>
+          {/* Hero summary strip */}
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <HeroTile
+              label="Utilisateurs inscrits"
+              value={data.utilisateurs.total}
+              icon={Users}
+              accent="primary"
+              sub="sur la période"
+            />
+            <HeroTile
+              label="Apprenants inscrits"
+              value={data.apprenants.total}
+              icon={GraduationCap}
+              accent="violet"
+              sub="rôle étudiant"
+            />
+            <HeroTile
+              label="Utilisateurs connectés"
+              value={data.utilisateurs.connectes}
+              icon={LogIn}
+              accent="emerald"
+              sub="au moins une connexion"
+            />
+            <HeroTile
+              label="Apprenants actifs"
+              value={data.engagement.apprenants_ressource.mois}
+              icon={Zap}
+              accent="amber"
+              sub="ressource consultée · 30 j"
+            />
+          </div>
+
+          {/* Section — Utilisateurs */}
+          <section className="space-y-4">
+            <SectionHeader
+              icon={Users}
+              title="Utilisateurs"
+              description="Population totale inscrite sur la période"
+              accent="primary"
+            />
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <KpiCard label="Total inscrits" value={data.utilisateurs.total} icon={Users} />
-              <KpiCard label="Âgés de 35 ans ou moins" value={data.utilisateurs.age_35_max} icon={Cake} />
-              <KpiCard label="Femmes" value={data.utilisateurs.femmes} icon={UserCircle} />
-              <KpiCard label="Femmes de 35 ans ou moins" value={data.utilisateurs.femmes_35_max} icon={UserCircle} />
-              <KpiCard label="En zone rurale" value={data.utilisateurs.zone_rurale} icon={MapPin} />
-              <KpiCard label="En situation de handicap" value={data.utilisateurs.situation_handicap} icon={Accessibility} />
-              <KpiCard label="Connectés sur la période" value={data.utilisateurs.connectes} icon={LogIn} />
+              <StatCard label="Total inscrits" value={data.utilisateurs.total} icon={Users} accent="primary" />
+              <StatCard label="Âgés de 35 ans ou moins" value={data.utilisateurs.age_35_max} icon={Cake} accent="sky" base={data.utilisateurs.total} />
+              <StatCard label="Femmes" value={data.utilisateurs.femmes} icon={UserCircle} accent="rose" base={data.utilisateurs.total} />
+              <StatCard label="Femmes de 35 ans ou moins" value={data.utilisateurs.femmes_35_max} icon={UserCircle} accent="rose" base={data.utilisateurs.total} />
+              <StatCard label="En zone rurale" value={data.utilisateurs.zone_rurale} icon={MapPin} accent="emerald" base={data.utilisateurs.total} />
+              <StatCard label="En situation de handicap" value={data.utilisateurs.situation_handicap} icon={Accessibility} accent="amber" base={data.utilisateurs.total} />
+              <StatCard label="Connectés sur la période" value={data.utilisateurs.connectes} icon={LogIn} accent="emerald" base={data.utilisateurs.total} baseLabel="taux de connexion" />
             </div>
           </section>
 
-          {/* Section 3 — Apprenants / Inscription */}
-          <section className="space-y-3">
-            <h2 className="text-xl font-semibold text-foreground">Apprenants</h2>
+          {/* Section — Apprenants */}
+          <section className="space-y-4">
+            <SectionHeader
+              icon={GraduationCap}
+              title="Apprenants"
+              description="Inscription — utilisateurs au rôle étudiant"
+              accent="violet"
+            />
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <KpiCard label="Apprenants inscrits" value={data.apprenants.total} icon={UserCheck} />
-              <KpiCard label="Âgés de 35 ans ou moins" value={data.apprenants.age_35_max} icon={Cake} />
-              <KpiCard label="Femmes de 35 ans ou moins" value={data.apprenants.age_35_max_femmes} icon={UserCircle} />
-              <KpiCard label="Femmes" value={data.apprenants.femmes} icon={UserCircle} />
-              <KpiCard label="En zone rurale" value={data.apprenants.zone_rurale} icon={MapPin} />
-              <KpiCard label="En situation de handicap" value={data.apprenants.situation_handicap} icon={Accessibility} />
+              <StatCard label="Apprenants inscrits" value={data.apprenants.total} icon={UserCheck} accent="violet" />
+              <StatCard label="Âgés de 35 ans ou moins" value={data.apprenants.age_35_max} icon={Cake} accent="sky" base={data.apprenants.total} />
+              <StatCard label="Femmes de 35 ans ou moins" value={data.apprenants.age_35_max_femmes} icon={UserCircle} accent="rose" base={data.apprenants.total} />
+              <StatCard label="Femmes" value={data.apprenants.femmes} icon={UserCircle} accent="rose" base={data.apprenants.total} />
+              <StatCard label="En zone rurale" value={data.apprenants.zone_rurale} icon={MapPin} accent="emerald" base={data.apprenants.total} />
+              <StatCard label="En situation de handicap" value={data.apprenants.situation_handicap} icon={Accessibility} accent="amber" base={data.apprenants.total} />
             </div>
           </section>
 
-          {/* Section 4 — Engagement */}
-          <section className="space-y-3">
-            <h2 className="text-xl font-semibold text-foreground">Engagement</h2>
+          {/* Section — Engagement */}
+          <section className="space-y-4">
+            <SectionHeader
+              icon={Activity}
+              title="Engagement"
+              description="Connexion & consultation de ressources par les apprenants"
+              accent="amber"
+            />
             <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <KpiCard
+              <StatCard
                 label="Apprenants connectés sur la période"
                 value={data.engagement.apprenants_connectes}
                 icon={LogIn}
+                accent="emerald"
+                base={data.apprenants.total}
+                baseLabel="des apprenants"
               />
             </div>
-            <Card className="border-0 shadow-sm">
-              <CardHeader>
-                <CardTitle className="text-base">
-                  Apprenants ayant consulté une ressource (épreuve ou concours)
-                </CardTitle>
+
+            <Card className="shadow-sm">
+              <CardHeader className="flex flex-row items-center gap-3 space-y-0">
+                <div className="rounded-lg bg-amber-500/10 p-2 text-amber-600">
+                  <TrendingUp className="h-5 w-5" />
+                </div>
+                <div>
+                  <CardTitle className="text-base">
+                    Apprenants ayant consulté une ressource
+                  </CardTitle>
+                  <CardDescription>
+                    Épreuve ou concours — apprenants distincts, fenêtres glissantes
+                  </CardDescription>
+                </div>
               </CardHeader>
               <CardContent className="grid gap-4 sm:grid-cols-3">
-                <KpiCard label="Dernière semaine" value={data.engagement.apprenants_ressource.semaine} icon={Activity} />
-                <KpiCard label="Dernières 2 semaines" value={data.engagement.apprenants_ressource.deux_semaines} icon={Activity} />
-                <KpiCard label="Dernier mois" value={data.engagement.apprenants_ressource.mois} icon={Activity} />
+                {[
+                  { label: "Dernière semaine", value: data.engagement.apprenants_ressource.semaine },
+                  { label: "Dernières 2 semaines", value: data.engagement.apprenants_ressource.deux_semaines },
+                  { label: "Dernier mois", value: data.engagement.apprenants_ressource.mois },
+                ].map((w) => {
+                  const pct =
+                    data.apprenants.total > 0
+                      ? Math.min(100, Math.round((w.value / data.apprenants.total) * 100))
+                      : null;
+                  return (
+                    <div key={w.label} className="rounded-lg border bg-muted/30 p-4">
+                      <p className="text-sm font-medium text-muted-foreground">{w.label}</p>
+                      <p className="mt-1.5 text-3xl font-bold tabular-nums text-card-foreground">
+                        {nf(w.value)}
+                      </p>
+                      {pct !== null && (
+                        <div className="mt-3 space-y-1.5">
+                          <div className="flex items-center justify-between text-xs text-muted-foreground">
+                            <span>des apprenants</span>
+                            <span className="font-semibold text-foreground">{pct}%</span>
+                          </div>
+                          <Progress value={pct} className="h-1.5" />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </CardContent>
             </Card>
           </section>


### PR DESCRIPTION
## What

Adds an **Indicateurs** admin dashboard exposing 15 Mastercard-Foundation-style KPIs, period- and country-scoped, under **Utilisateurs → Indicateurs**.

- **Section 2 — Utilisateurs** (2–8): total inscrits, ≤35 ans, femmes, femmes ≤35, zone rurale, situation de handicap, connectés.
- **Section 3 — Apprenants** (9–14): inscrits, ≤35, femmes ≤35, femmes, rurale, handicap (apprenant = rôle `étudiant`).
- **Section 4 — Engagement** (15–16): apprenants connectés; **distinct learners who consulted an épreuve/concours** in the trailing week / 2 weeks / month.

## How

- **`GET /kpi?startDate=&endDate=`** (`@CurrentCountry`) → structured payload grouped by section. Logins via the existing `refresh_tokens` proxy; KPI 16 via a new `resource_access` log.
- **`resource_access` instrumentation** on the épreuve + concours download endpoints (`GET /:id/telechargement`) — best-effort append-only insert; never breaks a download.
- **3 optional/nullable demographic columns** on `utilisateurs` (`date_naissance`, `zone_residence`, `situation_handicap`) — accepted by signup/profile DTOs, captured by mobile later; existing rows stay NULL and are excluded from demographic KPIs.
- **Frontend**: `Indicateurs.tsx` (hero KPI strip, share-of-total progress bars, date presets, skeleton loading) + `kpi.service.ts` + sidebar/route wiring.

## ⚠️ Requires migration 013 FIRST

Depends on **`013_kpi_demographics_and_resource_access.sql`** (edukia-db) — additive + idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, guarded constraints; no DROP, no data mutation). **Apply it to prod Neon before merging this PR**, per house rules.

## Notes
- Independent of the épreuves/concours submission PRs — but touches the two download controllers, so **merge this before them** to avoid a conflict (or resolve the small conflict if they land first).
- Verified live on edukia-dev: `GET /kpi` → 200; page renders; demographic KPIs correctly read 0 until real demographic data exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)