### PR TITLE
hotfix(etablissements): default GET /etablissements to those with épreuves (all=true escape hatch)

### DIFF
--- a/backend/src/etablissements/dto/filter-etablissement.dto.ts
+++ b/backend/src/etablissements/dto/filter-etablissement.dto.ts
@@ -1,8 +1,18 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 
 export class FilterEtablissementDto extends PaginationDto {
     @IsOptional()
     @IsString()
     search?: string;
+
+    // GET /etablissements defaults to établissements that have at least one
+    // épreuve (chain épreuve→matière→niveau→filière→établissement), so the
+    // mobile list never surfaces empty établissements. Pass all=true to include
+    // établissements without any épreuve (admin management, parent pickers).
+    @IsOptional()
+    @Transform(({ value }) => value === true || value === 'true')
+    @IsBoolean()
+    all?: boolean;
 }

--- a/backend/src/etablissements/etablissements.service.ts
+++ b/backend/src/etablissements/etablissements.service.ts
@@ -45,11 +45,27 @@ export class EtablissementsService {
   }
 
   async findAll(pays: string, filterDto: FilterEtablissementDto): Promise<PaginationResponse<Etablissement>> {
-    const { page = 1, limit = 10, search } = filterDto;
-    this.logger.log(`Récupération des établissements (pays=${pays}) - Page: ${page}, Limite: ${limit}, Search: ${search}`);
+    const { page = 1, limit = 10, search, all } = filterDto;
+    this.logger.log(`Récupération des établissements (pays=${pays}) - Page: ${page}, Limite: ${limit}, Search: ${search}, All: ${all}`);
 
     const queryBuilder = this.etablissementsRepository.createQueryBuilder('etablissement')
       .where('etablissement.pays = :pays', { pays });
+
+    // Default: only établissements that have at least one épreuve reachable
+    // through the chain épreuve→matière→niveau→filière→établissement, so the
+    // mobile list never surfaces empty établissements. all=true lifts the
+    // filter (admin management / parent pickers need every établissement).
+    if (!all) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM epreuves ep
+          INNER JOIN matieres m ON m.id = ep.matiere_id
+          INNER JOIN niveau_etude n ON n.id = m.niveau_etude_id
+          INNER JOIN filieres f ON f.id = n.filiere_id
+          WHERE f.etablissement_id = etablissement.id
+        )`,
+      );
+    }
 
     if (search) {
       queryBuilder.andWhere(

--- a/frontend/src/lib/services/etablissements.service.ts
+++ b/frontend/src/lib/services/etablissements.service.ts
@@ -4,9 +4,14 @@ import type { PaginationResponse, PaginationParams } from '../types/pagination';
 import { buildPaginationQuery } from '../types/pagination';
 
 export const etablissementsService = {
-  async getAll(params?: PaginationParams & { search?: string }): Promise<PaginationResponse<Etablissement>> {
+  async getAll(params?: PaginationParams & { search?: string; all?: boolean }): Promise<PaginationResponse<Etablissement>> {
     const query = buildPaginationQuery(params);
-    return api.get<PaginationResponse<Etablissement>>(`/etablissements${query}`);
+    // Admin must see every établissement (incl. those without épreuves), unlike
+    // the mobile default which hides empty ones. Opt out explicitly with all:false.
+    const includeAll = params?.all !== false;
+    const sep = query ? '&' : '?';
+    const suffix = includeAll ? `${sep}all=true` : '';
+    return api.get<PaginationResponse<Etablissement>>(`/etablissements${query}${suffix}`);
   },
 
   async getById(id: number): Promise<Etablissement> {


### PR DESCRIPTION
## Problem (prod)

Some établissements listed on the mobile app have **no épreuves** attached, giving users a dead-end when they tap in. We want the default listing to only show établissements that actually have content.

## Change

`GET /etablissements` now **defaults** to établissements that have **at least one épreuve** reachable through the chain `épreuve → matière → niveau_étude → filière → établissement` (SQL `EXISTS`, applied before pagination so totals stay correct).

- **`?all=true`** — escape hatch to return every établissement, including those without épreuves.
- **Admin frontend** (`etablissementsService.getAll`) now sends `all=true`, so the dashboard still lists/manages every établissement and parent-pickers keep working.
- Mobile keeps calling `GET /etablissements` (no param) → gets only content-bearing établissements.

## Implementation
- `filter-etablissement.dto.ts`: `all?: boolean` (`@Transform` `'true'`→`true`; whitelisted so the ValidationPipe accepts it).
- `etablissements.service.ts`: `EXISTS` subquery on the épreuve chain when `!all`.
- `etablissements.service.ts` (frontend): appends `all=true`.

## Verified on edukia-dev (benin)
- `GET /etablissements` → **15** (with épreuves)
- `GET /etablissements?all=true` → **22** (all) — 7 empty ones correctly hidden by default.
- backend + frontend type-checks pass.

## Notes
- No migration. Country scoping unchanged (`@CurrentCountry`, `?country=` on GET).
- Behavior change is intentional and shared with mobile — mobile gets the filtered list automatically; admin opts into `all=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)