### PR TITLE
ui: move Statistiques from Système to Approbations menu

### DIFF
--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -102,6 +102,7 @@ const navTree: NavItem[] = [
     children: [
       { title: "Épreuves en attente", icon: FileText, url: "/approbations/epreuves" },
       { title: "Concours en attente", icon: FileText, url: "/approbations/concours" },
+      { title: "Statistiques", icon: BarChart3, url: "/statistiques-approbations" },
     ],
   },
   {
@@ -155,7 +156,6 @@ const navTree: NavItem[] = [
     title: "Système",
     icon: Settings,
     children: [
-      { title: "Statistiques", icon: BarChart3, url: "/statistiques-approbations" },
       { title: "Paramètres", icon: SlidersHorizontal },
       { title: "Contacts Pro", icon: Contact, url: "/contacts-professionnels" },
       { title: "Notifications", icon: Bell, url: "/notifications" },


### PR DESCRIPTION
## What
Moves the **Statistiques** nav entry (submission-approval stats page, `/statistiques-approbations`) out of **Système** and into the **Approbations** group, so it sits alongside *Épreuves en attente* and *Concours en attente*.

The stats page shipped (#149) with its entry under Système because it was branched off `main` before the Approbations group existed; this puts it in its logical home.

One-line sidebar change, no behaviour/route change. Frontend type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)