### PR TITLE
feat(submissions): user self-service endpoints — GET /{epreuves,concours}/submissions/mine

### DIFF
--- a/backend/src/concours/concours-submissions.controller.ts
+++ b/backend/src/concours/concours-submissions.controller.ts
@@ -32,6 +32,23 @@ export class ConcoursSubmissionsController {
         return this.submissionsService.createSubmission(pays, userId, dto);
     }
 
+    // Registered BEFORE the admin @Get() so 'mine' is never captured as a param.
+    // JwtAuthGuard only (any authenticated user, NOT admin) — returns ONLY the
+    // caller's own submissions, pays-scoped, all statuses unless ?status given.
+    @UseGuards(JwtAuthGuard)
+    @Get('mine')
+    @ApiOperation({ summary: 'Mes soumissions de concours — les soumissions de l\'utilisateur connecté, structure/titre résolus ou proposés' })
+    @ApiQuery({ name: 'status', required: false, description: 'Filtrer par statut (défaut: tous)' })
+    @ApiQuery({ name: 'page', required: false, type: Number })
+    @ApiQuery({ name: 'limit', required: false, type: Number })
+    findMine(
+        @CurrentCountry() pays: string,
+        @Request() req,
+        @Query() query: SubmissionsQueryDto,
+    ) {
+        return this.submissionsService.findMine(pays, req.user.utilisateurId, query.status, query);
+    }
+
     @UseGuards(JwtAuthGuard, RoleGuard)
     @Roles(RoleType.ADMIN)
     @Get()

--- a/backend/src/concours/concours-submissions.service.ts
+++ b/backend/src/concours/concours-submissions.service.ts
@@ -170,6 +170,40 @@ export class ConcoursSubmissionsService {
         };
     }
 
+    // Self-service: the caller's OWN concours submissions, pays-scoped, newest
+    // first, paginated, optional status filter. Unlike the admin findAll, there
+    // is NO forced pending_approval default — with no ?status the user sees ALL
+    // their submissions (approved/declined/pending). structure/titre_ref are
+    // joined so resolved names show; soumis_par is NOT joined (the caller owns
+    // the rows), so withMissingFlags serializes soumis_par as null and no
+    // uploader row — hence no password — is ever returned.
+    async findMine(pays: string, soumisParId: number, status: string | undefined, paginationDto: PaginationDto): Promise<PaginationResponse<any>> {
+        const { page = 1, limit = 10 } = paginationDto;
+        this.logger.log(`Mes soumissions concours (pays=${pays}, soumis_par=${soumisParId}, status=${status ?? 'tous'}, page=${page}, limit=${limit})`);
+
+        const qb = this.submissionRepository.createQueryBuilder('submission')
+            .leftJoinAndSelect('submission.structure', 'structure')
+            .leftJoinAndSelect('submission.titre_ref', 'titre_ref')
+            .where('submission.pays = :pays', { pays })
+            .andWhere('submission.soumis_par_id = :soumisParId', { soumisParId })
+            .orderBy('submission.date_creation', 'DESC')
+            .skip((page - 1) * limit)
+            .take(limit);
+
+        if (status) {
+            qb.andWhere('submission.status = :status', { status });
+        }
+
+        const [rows, total] = await qb.getManyAndCount();
+        return {
+            data: rows.map(r => this.withMissingFlags(r)),
+            total,
+            page,
+            limit,
+            totalPages: Math.ceil(total / limit),
+        };
+    }
+
     // Admin: bind a resolved structure/titre id onto a PENDING submission and
     // clear the matching proposed name — PERSISTED, so the "à résoudre" prompt
     // disappears for everyone and the same missing entity can't be re-created.

--- a/backend/src/epreuves/submissions/epreuve-submissions.controller.ts
+++ b/backend/src/epreuves/submissions/epreuve-submissions.controller.ts
@@ -27,6 +27,29 @@ export class EpreuveSubmissionsController {
     return this.submissionsService.createSubmission(pays, dto, req.user.utilisateurId);
   }
 
+  // Registered BEFORE the admin @Get() so 'mine' is never captured as a param.
+  // JwtAuthGuard only (any authenticated user, NOT admin) — returns ONLY the
+  // caller's own submissions, pays-scoped.
+  @UseGuards(JwtAuthGuard)
+  @Get('mine')
+  @ApiOperation({ summary: 'Mes soumissions d\'épreuves — les soumissions de l\'utilisateur connecté, infos associées résolues/proposées' })
+  @ApiQuery({ name: 'status', required: false, enum: ServiceStatusEnum, description: 'Filtrer par statut (défaut: tous)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async findMine(
+    @CurrentCountry() pays: string,
+    @Request() req,
+    @Query('status') status?: ServiceStatusEnum,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.submissionsService.findMine(pays, req.user.utilisateurId, {
+      status,
+      page: page ? parseInt(page) : 1,
+      limit: limit ? parseInt(limit) : 10,
+    });
+  }
+
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(RoleType.ADMIN)
   @Get()

--- a/backend/src/epreuves/submissions/epreuve-submissions.service.ts
+++ b/backend/src/epreuves/submissions/epreuve-submissions.service.ts
@@ -203,14 +203,11 @@ export class EpreuveSubmissionsService {
     };
   }
 
-  // Admin queue: list submissions (optional status filter), with parents resolved
-  // and missing ones flagged.
-  async findAllForAdmin(
-    pays: string,
-    opts: { status?: ServiceStatusEnum; page?: number; limit?: number },
-  ): Promise<PaginationResponse<ReturnType<EpreuveSubmissionsService['toSubmissionResponse']>>> {
-    const { status, page = 1, limit = 10 } = opts;
-    const qb = this.submissionsRepository.createQueryBuilder('submission')
+  // Shared parent-join chain: eager-loads every ancestor path so
+  // toSubmissionResponse can derive a level from its deepest resolved
+  // descendant. Does NOT join soumis_par — callers add it only when needed.
+  private baseSubmissionQuery() {
+    return this.submissionsRepository.createQueryBuilder('submission')
       .leftJoinAndSelect('submission.etablissement', 'etablissement')
       .leftJoinAndSelect('submission.filiere', 'filiere')
       .leftJoinAndSelect('filiere.etablissement', 'f_etab')
@@ -220,9 +217,52 @@ export class EpreuveSubmissionsService {
       .leftJoinAndSelect('submission.matiere', 'matiere')
       .leftJoinAndSelect('matiere.niveau_etude', 'm_niveau')
       .leftJoinAndSelect('m_niveau.filiere', 'm_filiere')
-      .leftJoinAndSelect('m_filiere.etablissement', 'm_etab')
+      .leftJoinAndSelect('m_filiere.etablissement', 'm_etab');
+  }
+
+  // Admin queue: list submissions (optional status filter), with parents resolved
+  // and missing ones flagged.
+  async findAllForAdmin(
+    pays: string,
+    opts: { status?: ServiceStatusEnum; page?: number; limit?: number },
+  ): Promise<PaginationResponse<ReturnType<EpreuveSubmissionsService['toSubmissionResponse']>>> {
+    const { status, page = 1, limit = 10 } = opts;
+    const qb = this.baseSubmissionQuery()
       .leftJoinAndSelect('submission.soumis_par', 'soumis_par')
       .where('submission.pays = :pays', { pays })
+      .orderBy('submission.date_creation', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (status) {
+      qb.andWhere('submission.status = :status', { status });
+    }
+
+    const [rows, total] = await qb.getManyAndCount();
+    return {
+      data: rows.map(r => this.toSubmissionResponse(r)),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  // Self-service: the caller's OWN épreuve submissions, pays-scoped, newest
+  // first, paginated, optional status filter. Same rich rows as the admin list
+  // (resolved/proposed parents + missing flags + file/status/date), but scoped
+  // to soumis_par_id so a user never sees another user's rows. soumis_par is not
+  // joined — the caller already knows it's theirs, and omitting it guarantees no
+  // uploader row (hence no password) is ever serialized.
+  async findMine(
+    pays: string,
+    soumisParId: number,
+    opts: { status?: ServiceStatusEnum; page?: number; limit?: number },
+  ): Promise<PaginationResponse<ReturnType<EpreuveSubmissionsService['toSubmissionResponse']>>> {
+    const { status, page = 1, limit = 10 } = opts;
+    const qb = this.baseSubmissionQuery()
+      .where('submission.pays = :pays', { pays })
+      .andWhere('submission.soumis_par_id = :soumisParId', { soumisParId })
       .orderBy('submission.date_creation', 'DESC')
       .skip((page - 1) * limit)
       .take(limit);


### PR DESCRIPTION
## What
Two self-service endpoints so a user can list the épreuve/concours submissions **they** created, with all associated info + status. Closes the gap noted in the mobile integration guide (submission list was admin-only; users were only notified by email).

- **`GET /epreuves/submissions/mine`** — the caller's own épreuve submissions: établissement / filière / niveau d'étude / matière (resolved name, or the *proposed* name + missing flag), titre, année, section, status, file-attached flag, date.
- **`GET /concours/submissions/mine`** — structure / titre (resolved-or-proposed + missing flag), année, lieu, status, file flag, date.

## How
- `JwtAuthGuard` only (any authenticated user, **not** admin), `@CurrentCountry`, filtered to `soumis_par_id = req.user.utilisateurId`, newest-first, paginated (`?page=&limit=`), optional `?status=`.
- Reuses the existing rich response builders (`toSubmissionResponse` / `withMissingFlags`).
- `@Get('mine')` registered **before** the admin `@Get()` list so it isn't captured as a param.
- **No migration.** Admin endpoints unchanged.

## Verified on edukia-dev
- Owner sees only their own rows (all statuses), with full associated info; `?status=` filter works.
- A different user sees none of them; admin list still **403** for non-admins.
- **No `mot_de_passe`** (or fcm_token/digit_code) in any response — `soumis_par` omitted for /mine.
- Backend type-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)