### PR TITLE
feat(geo): Département/Ville entities (cascade under pays) + user-profile location + consistent complete user JSON

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -43,6 +43,8 @@ import { StructureModule } from './structure/structure.module';
 import { Structure } from './structure/entities/structure.entity';
 import { TitreModule } from './titre/titre.module';
 import { Titre } from './titre/entities/titre.entity';
+import { DepartementModule } from './departements/departement.module';
+import { VilleModule } from './villes/ville.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { FirebaseModule } from './firebase/firebase.module';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -135,6 +137,8 @@ import { CountryMiddleware } from './config/country.middleware';
     CategoriesModule,
     StructureModule,
     TitreModule,
+    DepartementModule,
+    VilleModule,
     NotificationsModule,
     NotificationEmailModule,
     FirebaseModule,

--- a/backend/src/common/interfaces/import-summary.interface.ts
+++ b/backend/src/common/interfaces/import-summary.interface.ts
@@ -1,0 +1,10 @@
+export interface ImportError {
+  line: number;
+  reason: string;
+}
+
+export interface ImportSummary {
+  created: number;
+  skipped: number;
+  errors: ImportError[];
+}

--- a/backend/src/common/utils/csv.util.ts
+++ b/backend/src/common/utils/csv.util.ts
@@ -1,0 +1,35 @@
+// Minimal CSV parsing — house rules forbid adding a heavy csv dep for the two
+// admin import endpoints, so we split by lines and commas manually. Handles
+// CRLF/LF, blank lines, and simple double-quoted fields (with "" escaping).
+// Not a full RFC-4180 parser: quoted fields spanning multiple physical lines
+// are not supported (admin geo CSVs are one record per line).
+
+export function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+  out.push(field);
+  return out.map((f) => f.trim());
+}

--- a/backend/src/common/utils/csv.util.ts
+++ b/backend/src/common/utils/csv.util.ts
@@ -4,11 +4,17 @@
 // Not a full RFC-4180 parser: quoted fields spanning multiple physical lines
 // are not supported (admin geo CSVs are one record per line).
 
+// A single département/ville record is a handful of short columns; anything past
+// this is not a legitimate row. Bounding the scan defends against loop-bound
+// injection / DoS from an attacker-controlled (uploaded) line (CodeQL js/loop-bound-injection).
+const MAX_LINE_LENGTH = 10_000;
+
 export function parseCsvLine(line: string): string[] {
   const out: string[] = [];
   let field = '';
   let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
+  const len = Math.min(line.length, MAX_LINE_LENGTH);
+  for (let i = 0; i < len; i++) {
     const ch = line[i];
     if (inQuotes) {
       if (ch === '"') {

--- a/backend/src/departements/departement.controller.ts
+++ b/backend/src/departements/departement.controller.ts
@@ -38,7 +38,7 @@ export class DepartementController {
   }
 
   @Post('import-csv')
-  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage() }))
+  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } }))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Importer des départements via CSV (colonnes: nom,code). Scope via ?country=' })
   async importCsv(

--- a/backend/src/departements/departement.controller.ts
+++ b/backend/src/departements/departement.controller.ts
@@ -1,0 +1,82 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import * as multer from 'multer';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
+import { DepartementService } from './departement.service';
+import { CreerDepartementDto } from './dto/creer-departement.dto';
+import { MajDepartementDto } from './dto/maj-departement.dto';
+import { FilterDepartementDto } from './dto/filter-departement.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+
+@ApiTags('departements')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('departements')
+export class DepartementController {
+  constructor(private readonly departementService: DepartementService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Créer un département' })
+  async create(
+    @CurrentCountry() pays: string,
+    @Body() dto: CreerDepartementDto,
+  ) {
+    return this.departementService.create(pays, dto);
+  }
+
+  @Post('import-csv')
+  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage() }))
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: 'Importer des départements via CSV (colonnes: nom,code). Scope via ?country=' })
+  async importCsv(
+    @CurrentCountry() pays: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    return this.departementService.importCsv(pays, file);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Lister les départements' })
+  @ApiResponse({ status: 200, description: 'Liste récupérée avec succès' })
+  async findAll(
+    @CurrentCountry() pays: string,
+    @Query() filterDto: FilterDepartementDto,
+  ) {
+    return this.departementService.findAll(pays, filterDto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un département par son ID' })
+  async findOne(@CurrentCountry() pays: string, @Param('id') id: string) {
+    return this.departementService.findOne(pays, id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Mettre à jour un département' })
+  async update(
+    @CurrentCountry() pays: string,
+    @Param('id') id: string,
+    @Body() dto: MajDepartementDto,
+  ) {
+    return this.departementService.update(pays, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Supprimer un département' })
+  async remove(@CurrentCountry() pays: string, @Param('id') id: string) {
+    return this.departementService.remove(pays, id);
+  }
+}

--- a/backend/src/departements/departement.module.ts
+++ b/backend/src/departements/departement.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DepartementController } from './departement.controller';
+import { DepartementService } from './departement.service';
+import { Departement } from './entities/departement.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Departement])],
+  controllers: [DepartementController],
+  providers: [DepartementService],
+  exports: [DepartementService],
+})
+export class DepartementModule {}

--- a/backend/src/departements/departement.service.ts
+++ b/backend/src/departements/departement.service.ts
@@ -77,7 +77,7 @@ export class DepartementService {
 
   async findOne(pays: string, id: string): Promise<Departement> {
     const departement = await this.departementRepository.findOne({
-      where: { id: parseInt(id, 10), pays },
+      where: { id, pays },
     });
     if (!departement) {
       throw new NotFoundException('Département non trouvé');

--- a/backend/src/departements/departement.service.ts
+++ b/backend/src/departements/departement.service.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Brackets } from 'typeorm';
+import { Departement } from './entities/departement.entity';
+import { CreerDepartementDto } from './dto/creer-departement.dto';
+import { MajDepartementDto } from './dto/maj-departement.dto';
+import { FilterDepartementDto } from './dto/filter-departement.dto';
+import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
+import { ImportSummary } from '../common/interfaces/import-summary.interface';
+import { parseCsvLine } from '../common/utils/csv.util';
+
+@Injectable()
+export class DepartementService {
+  private readonly logger = new Logger(DepartementService.name);
+
+  constructor(
+    @InjectRepository(Departement)
+    private readonly departementRepository: Repository<Departement>,
+  ) {}
+
+  async create(pays: string, dto: CreerDepartementDto): Promise<Departement> {
+    const existing = await this.departementRepository.findOne({
+      where: { nom: dto.nom, pays },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Un département nommé "${dto.nom}" existe déjà pour ce pays.`,
+      );
+    }
+    const departement = this.departementRepository.create({ ...dto, pays });
+    const saved = await this.departementRepository.save(departement);
+    this.logger.log(`Département créé: ${saved.nom} (ID: ${saved.id}, pays: ${saved.pays})`);
+    return saved;
+  }
+
+  async findAll(
+    pays: string,
+    filterDto: FilterDepartementDto,
+  ): Promise<PaginationResponse<Departement>> {
+    const { page = 1, limit = 10, search, sort_order = 'ASC' } = filterDto;
+
+    const queryBuilder = this.departementRepository
+      .createQueryBuilder('departement')
+      .where('departement.pays = :pays', { pays })
+      .orderBy('departement.nom', sort_order)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (search) {
+      queryBuilder.andWhere(
+        new Brackets((qb) => {
+          qb.where('unaccent(departement.nom) ILIKE unaccent(:search)', {
+            search: `%${search}%`,
+          }).orWhere('unaccent(departement.code) ILIKE unaccent(:search)', {
+            search: `%${search}%`,
+          });
+        }),
+      );
+    }
+
+    const [data, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async findOne(pays: string, id: string): Promise<Departement> {
+    const departement = await this.departementRepository.findOne({
+      where: { id: parseInt(id, 10), pays },
+    });
+    if (!departement) {
+      throw new NotFoundException('Département non trouvé');
+    }
+    return departement;
+  }
+
+  async update(
+    pays: string,
+    id: string,
+    dto: MajDepartementDto,
+  ): Promise<Departement> {
+    const departement = await this.findOne(pays, id);
+
+    if (dto.nom && dto.nom !== departement.nom) {
+      const duplicate = await this.departementRepository.findOne({
+        where: { nom: dto.nom, pays },
+      });
+      if (duplicate) {
+        throw new ConflictException(
+          `Un département nommé "${dto.nom}" existe déjà pour ce pays.`,
+        );
+      }
+    }
+
+    Object.assign(departement, dto);
+    return this.departementRepository.save(departement);
+  }
+
+  async remove(pays: string, id: string): Promise<{ message: string }> {
+    // Villes referencing this département are removed by the DB (FK ON DELETE
+    // CASCADE); utilisateurs.departement_id is set NULL (ON DELETE SET NULL).
+    const departement = await this.findOne(pays, id);
+    await this.departementRepository.remove(departement);
+    return { message: 'Département supprimé avec succès' };
+  }
+
+  // CSV columns: `nom,code` (code optional). An optional header row (first
+  // token === 'nom') is skipped. Duplicates (nom+pays) are skipped, not errored.
+  async importCsv(pays: string, file: Express.Multer.File): Promise<ImportSummary> {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('Aucun fichier CSV fourni');
+    }
+
+    const summary: ImportSummary = { created: 0, skipped: 0, errors: [] };
+    const rawLines = file.buffer.toString('utf-8').split(/\r?\n/);
+    let headerChecked = false;
+
+    for (let i = 0; i < rawLines.length; i++) {
+      const lineNo = i + 1;
+      const line = rawLines[i].trim();
+      if (!line) continue;
+
+      const cols = parseCsvLine(line);
+
+      if (!headerChecked) {
+        headerChecked = true;
+        if (cols[0]?.toLowerCase() === 'nom') continue;
+      }
+
+      const nom = cols[0]?.trim();
+      const code = cols[1]?.trim() || null;
+
+      if (!nom) {
+        summary.errors.push({ line: lineNo, reason: 'nom manquant' });
+        continue;
+      }
+
+      const existing = await this.departementRepository.findOne({
+        where: { nom, pays },
+      });
+      if (existing) {
+        summary.skipped++;
+        continue;
+      }
+
+      const departement = this.departementRepository.create({ nom, code, pays });
+      await this.departementRepository.save(departement);
+      summary.created++;
+    }
+
+    this.logger.log(
+      `Import CSV départements (pays=${pays}): ${summary.created} créé(s), ${summary.skipped} ignoré(s), ${summary.errors.length} erreur(s)`,
+    );
+    return summary;
+  }
+}

--- a/backend/src/departements/dto/creer-departement.dto.ts
+++ b/backend/src/departements/dto/creer-departement.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class CreerDepartementDto {
+  @ApiProperty({ example: 'Atlantique', description: 'Nom du département' })
+  @IsString()
+  nom: string;
+
+  @ApiProperty({ example: 'AT', description: 'Code du département', required: false })
+  @IsOptional()
+  @IsString()
+  code?: string;
+}

--- a/backend/src/departements/dto/filter-departement.dto.ts
+++ b/backend/src/departements/dto/filter-departement.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FilterDepartementDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/backend/src/departements/dto/maj-departement.dto.ts
+++ b/backend/src/departements/dto/maj-departement.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class MajDepartementDto {
+  @IsOptional()
+  @IsString()
+  nom?: string;
+
+  @IsOptional()
+  @IsString()
+  code?: string;
+}

--- a/backend/src/departements/entities/departement.entity.ts
+++ b/backend/src/departements/entities/departement.entity.ts
@@ -4,8 +4,8 @@ import { ApiProperty } from '@nestjs/swagger';
 @Entity('departements')
 export class Departement {
   @ApiProperty()
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column({ type: 'varchar', length: 50, default: 'benin' })
   pays: string;

--- a/backend/src/departements/entities/departement.entity.ts
+++ b/backend/src/departements/entities/departement.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('departements')
+export class Departement {
+  @ApiProperty()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'benin' })
+  pays: string;
+
+  @ApiProperty()
+  @Column()
+  nom: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  code: string | null;
+
+  @ApiProperty()
+  @CreateDateColumn({ type: 'timestamp with time zone', name: 'date_creation' })
+  date_creation: Date;
+}

--- a/backend/src/utilisateurs/dto/filter-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/filter-utilisateur.dto.ts
@@ -1,10 +1,21 @@
-import { IsOptional, IsString, IsEnum, IsBoolean } from 'class-validator';
+import { IsOptional, IsString, IsEnum, IsBoolean, IsInt, Min, Max } from 'class-validator';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { RoleType } from '../entities/utilisateur.entity';
-import { Transform } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class FilterUtilisateurDto extends PaginationDto {
+    // Cap page size for the admin user list: enrichUserComplete runs per-user
+    // lookups, so an unbounded limit would be an N+1 slow-query vector. Scoped
+    // here (not on the shared PaginationDto) so other endpoints are unaffected.
+    @ApiPropertyOptional({ description: 'Nombre d\'éléments par page (max 100)', default: 10 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt({ message: 'La limite doit être un nombre entier' })
+    @Min(1, { message: 'La limite doit être supérieure ou égale à 1' })
+    @Max(100, { message: 'La limite ne peut pas dépasser 100' })
+    limit?: number = 10;
+
     @IsOptional()
     @IsString()
     search?: string;

--- a/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsEnum, IsNumber, IsDateString, IsIn } from 'class-validator';
+import { IsOptional, IsString, IsEnum, IsNumber, IsDateString, IsIn, IsUUID } from 'class-validator';
 import { RoleType, SexeType } from '../entities/utilisateur.entity';
 
 export class MajUtilisateurDto {
@@ -54,13 +54,13 @@ export class MajUtilisateurDto {
   @IsNumber()
   niveau_etude_id?: number;
 
-  // geo-profile: nullable cascade (null clears). Validation of the
+  // geo-profile: nullable uuid cascade (null clears). Validation of the
   // pays -> departement -> ville chain happens in UtilisateursService.update.
   @IsOptional()
-  @IsNumber()
-  departement_id?: number | null;
+  @IsUUID()
+  departement_id?: string | null;
 
   @IsOptional()
-  @IsNumber()
-  ville_id?: number | null;
+  @IsUUID()
+  ville_id?: string | null;
 }

--- a/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
@@ -53,4 +53,14 @@ export class MajUtilisateurDto {
   @IsOptional()
   @IsNumber()
   niveau_etude_id?: number;
+
+  // geo-profile: nullable cascade (null clears). Validation of the
+  // pays -> departement -> ville chain happens in UtilisateursService.update.
+  @IsOptional()
+  @IsNumber()
+  departement_id?: number | null;
+
+  @IsOptional()
+  @IsNumber()
+  ville_id?: number | null;
 }

--- a/backend/src/utilisateurs/dto/update-profil.dto.ts
+++ b/backend/src/utilisateurs/dto/update-profil.dto.ts
@@ -13,4 +13,6 @@ export class UpdateProfilDto extends PickType(MajUtilisateurDto, [
     'date_naissance',
     'zone_residence',
     'situation_handicap',
+    'departement_id',
+    'ville_id',
 ] as const) { }

--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -3,6 +3,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Etablissement } from '../../etablissements/entities/etablissement.entity';
 import { Filiere } from '../../filieres/entities/filiere.entity';
 import { NiveauEtude } from '../../niveau-etude/entities/niveau-etude.entity';
+import { Departement } from '../../departements/entities/departement.entity';
+import { Ville } from '../../villes/entities/ville.entity';
 import { Commentaire } from 'src/commentaires/entities/commentaire.entity';
 import { Exclude } from 'class-transformer';
 import { NotificationUtilisateur } from 'src/notifications/entities/notification-utilisateur.entity';
@@ -125,6 +127,21 @@ export class Utilisateur {
   @ManyToOne(() => NiveauEtude, { nullable: true })
   @JoinColumn({ name: 'niveau_etude_id' })
   niveau_etude: NiveauEtude;
+
+  // geo-profile: cascade pays -> departement -> ville (both nullable FKs)
+  @Column({ nullable: true })
+  departement_id: number;
+
+  @ManyToOne(() => Departement, { nullable: true })
+  @JoinColumn({ name: 'departement_id' })
+  departement: Departement;
+
+  @Column({ nullable: true })
+  ville_id: number;
+
+  @ManyToOne(() => Ville, { nullable: true })
+  @JoinColumn({ name: 'ville_id' })
+  ville: Ville;
 
   @OneToMany(() => Commentaire, commentaire => commentaire.utilisateur)
   commentaires: Commentaire[];

--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -128,16 +128,16 @@ export class Utilisateur {
   @JoinColumn({ name: 'niveau_etude_id' })
   niveau_etude: NiveauEtude;
 
-  // geo-profile: cascade pays -> departement -> ville (both nullable FKs)
-  @Column({ nullable: true })
-  departement_id: number;
+  // geo-profile: cascade pays -> departement -> ville (both nullable uuid FKs)
+  @Column({ type: 'uuid', nullable: true })
+  departement_id: string;
 
   @ManyToOne(() => Departement, { nullable: true })
   @JoinColumn({ name: 'departement_id' })
   departement: Departement;
 
-  @Column({ nullable: true })
-  ville_id: number;
+  @Column({ type: 'uuid', nullable: true })
+  ville_id: string;
 
   @ManyToOne(() => Ville, { nullable: true })
   @JoinColumn({ name: 'ville_id' })

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -58,9 +58,9 @@ export class UtilisateursController {
 
     return {
       ...profil,
-      // geo-profile: expose departement/ville as {id, nom} (raw ids kept via spread)
-      departement: profil.departement ? { id: profil.departement.id, nom: profil.departement.nom } : null,
-      ville: profil.ville ? { id: profil.ville.id, nom: profil.ville.nom } : null,
+      // geo-profile: expose departement/ville as {uuid, nom} (raw ids kept via spread)
+      departement: profil.departement ? { uuid: profil.departement.id, nom: profil.departement.nom } : null,
+      ville: profil.ville ? { uuid: profil.ville.id, nom: profil.ville.nom } : null,
       // geo-profile (D4): derived age from date_naissance (pays + raw fields come via spread)
       age: this.computeAge(profil.date_naissance),
       isEmailVerified,

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -61,10 +61,24 @@ export class UtilisateursController {
       // geo-profile: expose departement/ville as {id, nom} (raw ids kept via spread)
       departement: profil.departement ? { id: profil.departement.id, nom: profil.departement.nom } : null,
       ville: profil.ville ? { id: profil.ville.id, nom: profil.ville.nom } : null,
+      // geo-profile (D4): derived age from date_naissance (pays + raw fields come via spread)
+      age: this.computeAge(profil.date_naissance),
       isEmailVerified,
       isPrestataire,
       isRecruteur
     };
+  }
+
+  // geo-profile (D4): whole-years age from a 'YYYY-MM-DD' date_naissance; null if absent/invalid
+  private computeAge(dateNaissance?: string | null): number | null {
+    if (!dateNaissance) return null;
+    const dob = new Date(dateNaissance);
+    if (isNaN(dob.getTime())) return null;
+    const now = new Date();
+    let age = now.getFullYear() - dob.getFullYear();
+    const m = now.getMonth() - dob.getMonth();
+    if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--;
+    return age >= 0 ? age : null;
   }
 
   @UseGuards(JwtAuthGuard, RoleGuard)
@@ -251,6 +265,8 @@ export class UtilisateursController {
 
     return {
       ...profil,
+      // geo-profile (D4): derived age; pays + raw profile fields come via spread
+      age: this.computeAge(profil.date_naissance),
       isEmailVerified,
       isPrestataire,
       isRecruteur

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -58,6 +58,9 @@ export class UtilisateursController {
 
     return {
       ...profil,
+      // geo-profile: expose departement/ville as {id, nom} (raw ids kept via spread)
+      departement: profil.departement ? { id: profil.departement.id, nom: profil.departement.nom } : null,
+      ville: profil.ville ? { id: profil.ville.id, nom: profil.ville.nom } : null,
       isEmailVerified,
       isPrestataire,
       isRecruteur

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -49,36 +49,9 @@ export class UtilisateursController {
     const userId = req.user.utilisateurId.toString();
     const email = req.user.email;
     console.log(`[UtilisateursController] Récupération du profil pour l'utilisateur: ${email} (ID: ${userId})`);
+    // geo-profile: unified complete user shape (geo {uuid,nom} + age + booleans) via the service
     const profil = await this.utilisateursService.findOne(userId);
-    const userIdNum = parseInt(userId);
-
-    const { isVerified: isEmailVerified } = await this.utilisateursService.isEmailVerified(userIdNum);
-    const { isPrestataire } = await this.utilisateursService.isPrestataire(userIdNum);
-    const { isRecruteur } = await this.utilisateursService.isRecruteur(userIdNum);
-
-    return {
-      ...profil,
-      // geo-profile: expose departement/ville as {uuid, nom} (raw ids kept via spread)
-      departement: profil.departement ? { uuid: profil.departement.id, nom: profil.departement.nom } : null,
-      ville: profil.ville ? { uuid: profil.ville.id, nom: profil.ville.nom } : null,
-      // geo-profile (D4): derived age from date_naissance (pays + raw fields come via spread)
-      age: this.computeAge(profil.date_naissance),
-      isEmailVerified,
-      isPrestataire,
-      isRecruteur
-    };
-  }
-
-  // geo-profile (D4): whole-years age from a 'YYYY-MM-DD' date_naissance; null if absent/invalid
-  private computeAge(dateNaissance?: string | null): number | null {
-    if (!dateNaissance) return null;
-    const dob = new Date(dateNaissance);
-    if (isNaN(dob.getTime())) return null;
-    const now = new Date();
-    let age = now.getFullYear() - dob.getFullYear();
-    const m = now.getMonth() - dob.getMonth();
-    if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--;
-    return age >= 0 ? age : null;
+    return this.utilisateursService.enrichUserComplete(profil);
   }
 
   @UseGuards(JwtAuthGuard, RoleGuard)
@@ -256,20 +229,8 @@ export class UtilisateursController {
   @ApiResponse({ status: 200, description: 'Profil récupéré avec succès' })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
   async getByUuid(@Param('uuid') uuid: string) {
+    // geo-profile: same unified complete user shape as the list + /profil
     const profil = await this.utilisateursService.findByUuid(uuid);
-    const userIdNum = profil.id;
-
-    const { isVerified: isEmailVerified } = await this.utilisateursService.isEmailVerified(userIdNum);
-    const { isPrestataire } = await this.utilisateursService.isPrestataire(userIdNum);
-    const { isRecruteur } = await this.utilisateursService.isRecruteur(userIdNum);
-
-    return {
-      ...profil,
-      // geo-profile (D4): derived age; pays + raw profile fields come via spread
-      age: this.computeAge(profil.date_naissance),
-      isEmailVerified,
-      isPrestataire,
-      isRecruteur
-    };
+    return this.utilisateursService.enrichUserComplete(profil);
   }
 }

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -53,7 +53,7 @@ export class UtilisateursService {
   // actually present on the DTO, so unrelated profile updates are untouched.
   private async validateGeo(
     userPays: string,
-    dto: { departement_id?: number | null; ville_id?: number | null },
+    dto: { departement_id?: string | null; ville_id?: string | null },
     user: Utilisateur,
   ): Promise<void> {
     const hasDept = dto.departement_id !== undefined;

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -362,7 +362,9 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec ID: ${id}`);
     const user = await this.utilisateursRepository.findOne({
       where: { id: parseInt(id) },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id'],
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id',
+        // geo-profile (D4): previously-dropped profile fields
+        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation'],
       relations: ['etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'],
     });
 
@@ -379,7 +381,9 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec UUID: ${uuid}`);
     const user = await this.utilisateursRepository.findOne({
       where: { uuid },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage'],
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage',
+        // geo-profile (D4): previously-dropped profile fields
+        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation'],
       relations: ['etablissement', 'filiere', 'niveau_etude'],
     });
 

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -104,6 +104,41 @@ export class UtilisateursService {
     return Object.assign(user, { profil: user.profil_photo_path ?? '' });
   }
 
+  // geo-profile: whole-years age from a 'YYYY-MM-DD' date_naissance; null if absent/invalid
+  private computeAge(dateNaissance?: string | null): number | null {
+    if (!dateNaissance) return null;
+    const dob = new Date(dateNaissance);
+    if (isNaN(dob.getTime())) return null;
+    const now = new Date();
+    let age = now.getFullYear() - dob.getFullYear();
+    const m = now.getMonth() - dob.getMonth();
+    if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--;
+    return age >= 0 ? age : null;
+  }
+
+  // geo-profile: single source of truth for the complete user JSON shape returned by
+  // GET /utilisateurs (list), /utilisateurs/profil and /utilisateurs/:uuid — withProfil +
+  // geo {uuid,nom} + derived age + verify/prestataire/recruteur booleans. The caller must
+  // load the departement/ville relations (findOne/findByUuid/findAll all do).
+  // PERF NOTE: 3 boolean lookups per user (isEmailVerified/isPrestataire/isRecruteur) => N+1
+  // on the list (3 x page_size). Acceptable at the current default page size; batch if page size grows.
+  async enrichUserComplete<T extends Utilisateur>(user: T) {
+    const [{ isVerified }, { isPrestataire }, { isRecruteur }] = await Promise.all([
+      this.isEmailVerified(user.id),
+      this.isPrestataire(user.id),
+      this.isRecruteur(user.id),
+    ]);
+    return {
+      ...this.withProfil(user),
+      departement: user.departement ? { uuid: user.departement.id, nom: user.departement.nom } : null,
+      ville: user.ville ? { uuid: user.ville.id, nom: user.ville.nom } : null,
+      age: this.computeAge(user.date_naissance),
+      isEmailVerified: isVerified,
+      isPrestataire,
+      isRecruteur,
+    };
+  }
+
   async findByEmail(email: string) {
     this.logger.log(`Recherche de l'utilisateur par email: ${email}`);
     return this.utilisateursRepository.findOne({
@@ -303,7 +338,7 @@ export class UtilisateursService {
       .leftJoinAndSelect('utilisateur.departement', 'departement')
       .leftJoinAndSelect('utilisateur.ville', 'ville')
       .loadRelationCountAndMap('utilisateur.filleulsCount', 'utilisateur.filleuls')
-      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'utilisateur.departement_id', 'utilisateur.ville_id', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
+      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'utilisateur.departement_id', 'utilisateur.ville_id', 'utilisateur.date_naissance', 'utilisateur.zone_residence', 'utilisateur.situation_handicap', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
       .where('utilisateur.pays = :pays', { pays })
       .skip((page - 1) * limit)
       .take(limit);
@@ -352,13 +387,12 @@ export class UtilisateursService {
 
     this.logger.log(`${users.length} utilisateur(s) trouvé(s) sur ${total} total`);
 
+    // geo-profile: unify the list shape with /profil + /:uuid via enrichUserComplete
+    // (adds geo {uuid,nom}, age, and the 3 booleans). filleulsCount rides along via withProfil.
+    const data = await Promise.all(users.map((user) => this.enrichUserComplete(user)));
+
     return {
-      // geo-profile: expose departement/ville as {uuid, nom} (same shape as GET /utilisateurs/profil)
-      data: users.map((user) => ({
-        ...this.withProfil(user),
-        departement: user.departement ? { uuid: user.departement.id, nom: user.departement.nom } : null,
-        ville: user.ville ? { uuid: user.ville.id, nom: user.ville.nom } : null,
-      })) as any,
+      data: data as any,
       total,
       page,
       limit,
@@ -372,7 +406,9 @@ export class UtilisateursService {
       where: { id: parseInt(id) },
       select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id',
         // geo-profile (D4): previously-dropped profile fields
-        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation'],
+        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation',
+        // geo-profile: match the unified list shape (enrichUserComplete)
+        'est_desactive', 'date_suppression_prevue'],
       relations: ['etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'],
     });
 
@@ -389,10 +425,12 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec UUID: ${uuid}`);
     const user = await this.utilisateursRepository.findOne({
       where: { uuid },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage',
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id',
         // geo-profile (D4): previously-dropped profile fields
-        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation'],
-      relations: ['etablissement', 'filiere', 'niveau_etude'],
+        'pays', 'date_naissance', 'zone_residence', 'situation_handicap', 'date_creation',
+        // geo-profile: match the unified list shape (enrichUserComplete)
+        'est_desactive', 'date_suppression_prevue'],
+      relations: ['etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'],
     });
 
     if (!user) {

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -299,8 +299,11 @@ export class UtilisateursService {
       .leftJoinAndSelect('utilisateur.etablissement', 'etablissement')
       .leftJoinAndSelect('utilisateur.filiere', 'filiere')
       .leftJoinAndSelect('utilisateur.niveau_etude', 'niveau_etude')
+      // geo-profile: join dept/ville so the list can expose them (shaped {id,nom} below)
+      .leftJoinAndSelect('utilisateur.departement', 'departement')
+      .leftJoinAndSelect('utilisateur.ville', 'ville')
       .loadRelationCountAndMap('utilisateur.filleulsCount', 'utilisateur.filleuls')
-      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'etablissement', 'filiere', 'niveau_etude'])
+      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
       .where('utilisateur.pays = :pays', { pays })
       .skip((page - 1) * limit)
       .take(limit);
@@ -350,7 +353,12 @@ export class UtilisateursService {
     this.logger.log(`${users.length} utilisateur(s) trouvé(s) sur ${total} total`);
 
     return {
-      data: users.map((user) => this.withProfil(user)),
+      // geo-profile: expose departement/ville as {id, nom} (same shape as GET /utilisateurs/profil)
+      data: users.map((user) => ({
+        ...this.withProfil(user),
+        departement: user.departement ? { id: user.departement.id, nom: user.departement.nom } : null,
+        ville: user.ville ? { id: user.ville.id, nom: user.ville.nom } : null,
+      })) as any,
       total,
       page,
       limit,

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -3,6 +3,8 @@ import { Repository, Brackets, LessThan, IsNull } from 'typeorm';
 import { Utilisateur } from './entities/utilisateur.entity';
 import { Prestataire } from '../prestataires/entities/prestataire.entity';
 import { Recruteur } from '../recruteurs/entities/recruteur.entity';
+import { Departement } from '../departements/entities/departement.entity';
+import { Ville } from '../villes/entities/ville.entity';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
 import { CountryContextService } from '../config/country-context.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -36,6 +38,57 @@ export class UtilisateursService {
 
   private get utilisateursRepository(): Repository<Utilisateur> {
     return this.resolver.getRepository(Utilisateur);
+  }
+
+  // geo-profile: repos for validating the profile pays -> departement -> ville cascade
+  private get departementRepository(): Repository<Departement> {
+    return this.resolver.getRepository(Departement);
+  }
+  private get villeRepository(): Repository<Ville> {
+    return this.resolver.getRepository(Ville);
+  }
+
+  // geo-profile: validate departement_id/ville_id against the user's pays before save.
+  // Throws 400 (not 404). Accepts explicit null to clear. Only runs for keys
+  // actually present on the DTO, so unrelated profile updates are untouched.
+  private async validateGeo(
+    userPays: string,
+    dto: { departement_id?: number | null; ville_id?: number | null },
+    user: Utilisateur,
+  ): Promise<void> {
+    const hasDept = dto.departement_id !== undefined;
+    const hasVille = dto.ville_id !== undefined;
+    if (!hasDept && !hasVille) return;
+
+    const finalDeptId = hasDept ? dto.departement_id : user.departement_id;
+    const finalVilleId = hasVille ? dto.ville_id : user.ville_id;
+
+    if (finalDeptId != null) {
+      const departement = await this.departementRepository.findOne({
+        where: { id: finalDeptId, pays: userPays },
+      });
+      if (!departement) {
+        throw new BadRequestException(
+          `Le département ${finalDeptId} n'existe pas pour ce pays`,
+        );
+      }
+    }
+
+    if (finalVilleId != null) {
+      if (finalDeptId == null) {
+        throw new BadRequestException(
+          'Une ville ne peut être définie sans département',
+        );
+      }
+      const ville = await this.villeRepository.findOne({
+        where: { id: finalVilleId },
+      });
+      if (!ville || ville.departement_id !== finalDeptId) {
+        throw new BadRequestException(
+          `La ville ${finalVilleId} n'appartient pas au département ${finalDeptId}`,
+        );
+      }
+    }
   }
 
   /**
@@ -309,8 +362,8 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec ID: ${id}`);
     const user = await this.utilisateursRepository.findOne({
       where: { id: parseInt(id) },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage'],
-      relations: ['etablissement', 'filiere', 'niveau_etude'],
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id'],
+      relations: ['etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'],
     });
 
     if (!user) {
@@ -349,6 +402,9 @@ export class UtilisateursService {
       this.logger.warn(`Mise à jour échouée: utilisateur ID ${id} introuvable`);
       throw new NotFoundException('Utilisateur non trouvé');
     }
+
+    // geo-profile: enforce the pays -> departement -> ville cascade
+    await this.validateGeo(user.pays, majUtilisateurDto, user);
 
     // Update user
     Object.assign(user, majUtilisateurDto);

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -128,7 +128,7 @@ export class UtilisateursService {
       this.isPrestataire(user.id),
       this.isRecruteur(user.id),
     ]);
-    return {
+    const result: any = {
       ...this.withProfil(user),
       departement: user.departement ? { uuid: user.departement.id, nom: user.departement.nom } : null,
       ville: user.ville ? { uuid: user.ville.id, nom: user.ville.nom } : null,
@@ -137,6 +137,13 @@ export class UtilisateursService {
       isPrestataire,
       isRecruteur,
     };
+    // geo-profile: raw ids are redundant in the RESPONSE now that departement/ville are {uuid,nom}.
+    // Strip them from the returned object ONLY — the spread above is a fresh copy, so the entity
+    // is untouched and the columns stay in the select lists (updateProfil validation reads
+    // user.departement_id / user.ville_id off the entity, not this response).
+    delete result.departement_id;
+    delete result.ville_id;
+    return result;
   }
 
   async findByEmail(email: string) {

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -303,7 +303,7 @@ export class UtilisateursService {
       .leftJoinAndSelect('utilisateur.departement', 'departement')
       .leftJoinAndSelect('utilisateur.ville', 'ville')
       .loadRelationCountAndMap('utilisateur.filleulsCount', 'utilisateur.filleuls')
-      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
+      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'utilisateur.departement_id', 'utilisateur.ville_id', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
       .where('utilisateur.pays = :pays', { pays })
       .skip((page - 1) * limit)
       .take(limit);
@@ -353,11 +353,11 @@ export class UtilisateursService {
     this.logger.log(`${users.length} utilisateur(s) trouvé(s) sur ${total} total`);
 
     return {
-      // geo-profile: expose departement/ville as {id, nom} (same shape as GET /utilisateurs/profil)
+      // geo-profile: expose departement/ville as {uuid, nom} (same shape as GET /utilisateurs/profil)
       data: users.map((user) => ({
         ...this.withProfil(user),
-        departement: user.departement ? { id: user.departement.id, nom: user.departement.nom } : null,
-        ville: user.ville ? { id: user.ville.id, nom: user.ville.nom } : null,
+        departement: user.departement ? { uuid: user.departement.id, nom: user.departement.nom } : null,
+        ville: user.ville ? { uuid: user.ville.id, nom: user.ville.nom } : null,
       })) as any,
       total,
       page,

--- a/backend/src/villes/dto/creer-ville.dto.ts
+++ b/backend/src/villes/dto/creer-ville.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNumber } from 'class-validator';
+
+export class CreerVilleDto {
+  @ApiProperty({ example: 'Cotonou', description: 'Nom de la ville' })
+  @IsString()
+  nom: string;
+
+  @ApiProperty({ example: 1, description: 'ID du département parent (scopé au pays courant)' })
+  @IsNumber()
+  departement_id: number;
+}

--- a/backend/src/villes/dto/creer-ville.dto.ts
+++ b/backend/src/villes/dto/creer-ville.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNumber } from 'class-validator';
+import { IsString, IsUUID } from 'class-validator';
 
 export class CreerVilleDto {
   @ApiProperty({ example: 'Cotonou', description: 'Nom de la ville' })
   @IsString()
   nom: string;
 
-  @ApiProperty({ example: 1, description: 'ID du département parent (scopé au pays courant)' })
-  @IsNumber()
-  departement_id: number;
+  @ApiProperty({ example: 'a1b2c3d4-...', description: 'UUID du département parent (scopé au pays courant)' })
+  @IsUUID()
+  departement_id: string;
 }

--- a/backend/src/villes/dto/filter-ville.dto.ts
+++ b/backend/src/villes/dto/filter-ville.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, IsInt } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FilterVilleDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  departement_id?: number;
+}

--- a/backend/src/villes/dto/filter-ville.dto.ts
+++ b/backend/src/villes/dto/filter-ville.dto.ts
@@ -1,5 +1,4 @@
-import { IsOptional, IsString, IsInt } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 
 export class FilterVilleDto extends PaginationDto {
@@ -7,8 +6,8 @@ export class FilterVilleDto extends PaginationDto {
   @IsString()
   search?: string;
 
+  // geo uuid: the villes list filters by the parent département's uuid
   @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  departement_id?: number;
+  @IsUUID()
+  departement_id?: string;
 }

--- a/backend/src/villes/dto/maj-ville.dto.ts
+++ b/backend/src/villes/dto/maj-ville.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { IsString, IsOptional, IsUUID } from 'class-validator';
 
 export class MajVilleDto {
   @IsOptional()
@@ -6,6 +6,6 @@ export class MajVilleDto {
   nom?: string;
 
   @IsOptional()
-  @IsNumber()
-  departement_id?: number;
+  @IsUUID()
+  departement_id?: string;
 }

--- a/backend/src/villes/dto/maj-ville.dto.ts
+++ b/backend/src/villes/dto/maj-ville.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+
+export class MajVilleDto {
+  @IsOptional()
+  @IsString()
+  nom?: string;
+
+  @IsOptional()
+  @IsNumber()
+  departement_id?: number;
+}

--- a/backend/src/villes/entities/ville.entity.ts
+++ b/backend/src/villes/entities/ville.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { Departement } from '../../departements/entities/departement.entity';
+
+@Entity('villes')
+export class Ville {
+  @ApiProperty()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'benin' })
+  pays: string;
+
+  @ApiProperty()
+  @Column()
+  nom: string;
+
+  @ApiProperty()
+  @Column()
+  departement_id: number;
+
+  @ApiProperty({ type: () => Departement })
+  @ManyToOne(() => Departement, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'departement_id' })
+  departement: Departement;
+
+  @ApiProperty()
+  @CreateDateColumn({ type: 'timestamp with time zone', name: 'date_creation' })
+  date_creation: Date;
+}

--- a/backend/src/villes/entities/ville.entity.ts
+++ b/backend/src/villes/entities/ville.entity.ts
@@ -12,8 +12,8 @@ import { Departement } from '../../departements/entities/departement.entity';
 @Entity('villes')
 export class Ville {
   @ApiProperty()
-  @PrimaryGeneratedColumn()
-  id: number;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
   @Column({ type: 'varchar', length: 50, default: 'benin' })
   pays: string;
@@ -23,8 +23,8 @@ export class Ville {
   nom: string;
 
   @ApiProperty()
-  @Column()
-  departement_id: number;
+  @Column('uuid')
+  departement_id: string;
 
   @ApiProperty({ type: () => Departement })
   @ManyToOne(() => Departement, { nullable: false, onDelete: 'CASCADE' })

--- a/backend/src/villes/ville.controller.ts
+++ b/backend/src/villes/ville.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import * as multer from 'multer';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiConsumes, ApiQuery } from '@nestjs/swagger';
+import { VilleService } from './ville.service';
+import { CreerVilleDto } from './dto/creer-ville.dto';
+import { MajVilleDto } from './dto/maj-ville.dto';
+import { FilterVilleDto } from './dto/filter-ville.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+
+@ApiTags('villes')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('villes')
+export class VilleController {
+  constructor(private readonly villeService: VilleService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Créer une ville (scopée au département parent)' })
+  async create(@CurrentCountry() pays: string, @Body() dto: CreerVilleDto) {
+    return this.villeService.create(pays, dto);
+  }
+
+  @Post('import-csv')
+  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage() }))
+  @ApiConsumes('multipart/form-data')
+  @ApiOperation({ summary: 'Importer des villes via CSV (colonnes: departement_nom,ville_nom). Scope via ?country=' })
+  async importCsv(
+    @CurrentCountry() pays: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    return this.villeService.importCsv(pays, file);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Lister les villes (filtre optionnel ?departement_id=)' })
+  @ApiResponse({ status: 200, description: 'Liste récupérée avec succès' })
+  @ApiQuery({ name: 'departement_id', required: false, type: Number, description: 'Filtrer par département' })
+  async findAll(
+    @CurrentCountry() pays: string,
+    @Query() filterDto: FilterVilleDto,
+  ) {
+    return this.villeService.findAll(pays, filterDto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer une ville par son ID' })
+  async findOne(@CurrentCountry() pays: string, @Param('id') id: string) {
+    return this.villeService.findOne(pays, id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Mettre à jour une ville' })
+  async update(
+    @CurrentCountry() pays: string,
+    @Param('id') id: string,
+    @Body() dto: MajVilleDto,
+  ) {
+    return this.villeService.update(pays, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Supprimer une ville' })
+  async remove(@CurrentCountry() pays: string, @Param('id') id: string) {
+    return this.villeService.remove(pays, id);
+  }
+}

--- a/backend/src/villes/ville.controller.ts
+++ b/backend/src/villes/ville.controller.ts
@@ -35,7 +35,7 @@ export class VilleController {
   }
 
   @Post('import-csv')
-  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage() }))
+  @UseInterceptors(FileInterceptor('file', { storage: multer.memoryStorage(), limits: { fileSize: 5 * 1024 * 1024 } }))
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Importer des villes via CSV (colonnes: departement_nom,ville_nom). Scope via ?country=' })
   async importCsv(

--- a/backend/src/villes/ville.module.ts
+++ b/backend/src/villes/ville.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VilleController } from './ville.controller';
+import { VilleService } from './ville.service';
+import { Ville } from './entities/ville.entity';
+import { Departement } from '../departements/entities/departement.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Ville, Departement])],
+  controllers: [VilleController],
+  providers: [VilleService],
+  exports: [VilleService],
+})
+export class VilleModule {}

--- a/backend/src/villes/ville.service.ts
+++ b/backend/src/villes/ville.service.ts
@@ -98,7 +98,7 @@ export class VilleService {
 
   async findOne(pays: string, id: string): Promise<Ville> {
     const ville = await this.villeRepository.findOne({
-      where: { id: parseInt(id, 10), pays },
+      where: { id, pays },
       relations: ['departement'],
     });
     if (!ville) {

--- a/backend/src/villes/ville.service.ts
+++ b/backend/src/villes/ville.service.ts
@@ -1,0 +1,221 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ville } from './entities/ville.entity';
+import { Departement } from '../departements/entities/departement.entity';
+import { CreerVilleDto } from './dto/creer-ville.dto';
+import { MajVilleDto } from './dto/maj-ville.dto';
+import { FilterVilleDto } from './dto/filter-ville.dto';
+import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
+import { ImportSummary } from '../common/interfaces/import-summary.interface';
+import { parseCsvLine } from '../common/utils/csv.util';
+
+@Injectable()
+export class VilleService {
+  private readonly logger = new Logger(VilleService.name);
+
+  constructor(
+    @InjectRepository(Ville)
+    private readonly villeRepository: Repository<Ville>,
+    @InjectRepository(Departement)
+    private readonly departementRepository: Repository<Departement>,
+  ) {}
+
+  // pays is DERIVED from the parent département (validated to belong to the
+  // request country) — never taken from the request/DTO. This enforces the
+  // cascade pays → département → ville.
+  async create(pays: string, dto: CreerVilleDto): Promise<Ville> {
+    const departement = await this.departementRepository.findOne({
+      where: { id: dto.departement_id, pays },
+    });
+    if (!departement) {
+      throw new NotFoundException(
+        `Département ${dto.departement_id} introuvable pour ce pays`,
+      );
+    }
+
+    const existing = await this.villeRepository.findOne({
+      where: { nom: dto.nom, departement_id: dto.departement_id },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Une ville nommée "${dto.nom}" existe déjà dans ce département.`,
+      );
+    }
+
+    const ville = this.villeRepository.create({
+      nom: dto.nom,
+      departement_id: dto.departement_id,
+      pays: departement.pays,
+    });
+    const saved = await this.villeRepository.save(ville);
+    this.logger.log(
+      `Ville créée: ${saved.nom} (ID: ${saved.id}, dept: ${saved.departement_id}, pays: ${saved.pays})`,
+    );
+    return saved;
+  }
+
+  async findAll(
+    pays: string,
+    filterDto: FilterVilleDto,
+  ): Promise<PaginationResponse<Ville>> {
+    const { page = 1, limit = 10, search, sort_order = 'ASC', departement_id } = filterDto;
+
+    const queryBuilder = this.villeRepository
+      .createQueryBuilder('ville')
+      .leftJoinAndSelect('ville.departement', 'departement')
+      .where('ville.pays = :pays', { pays })
+      .orderBy('ville.nom', sort_order)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (departement_id) {
+      queryBuilder.andWhere('ville.departement_id = :departement_id', { departement_id });
+    }
+
+    if (search) {
+      queryBuilder.andWhere('unaccent(ville.nom) ILIKE unaccent(:search)', {
+        search: `%${search}%`,
+      });
+    }
+
+    const [data, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async findOne(pays: string, id: string): Promise<Ville> {
+    const ville = await this.villeRepository.findOne({
+      where: { id: parseInt(id, 10), pays },
+      relations: ['departement'],
+    });
+    if (!ville) {
+      throw new NotFoundException('Ville non trouvée');
+    }
+    return ville;
+  }
+
+  async update(pays: string, id: string, dto: MajVilleDto): Promise<Ville> {
+    const ville = await this.findOne(pays, id);
+
+    let departement_id = ville.departement_id;
+    let derivedPays = ville.pays;
+    if (dto.departement_id && dto.departement_id !== ville.departement_id) {
+      const departement = await this.departementRepository.findOne({
+        where: { id: dto.departement_id, pays },
+      });
+      if (!departement) {
+        throw new NotFoundException(
+          `Département ${dto.departement_id} introuvable pour ce pays`,
+        );
+      }
+      departement_id = dto.departement_id;
+      derivedPays = departement.pays;
+    }
+
+    const nom = dto.nom ?? ville.nom;
+    if (nom !== ville.nom || departement_id !== ville.departement_id) {
+      const duplicate = await this.villeRepository.findOne({
+        where: { nom, departement_id },
+      });
+      if (duplicate && duplicate.id !== ville.id) {
+        throw new ConflictException(
+          `Une ville nommée "${nom}" existe déjà dans ce département.`,
+        );
+      }
+    }
+
+    ville.nom = nom;
+    ville.departement_id = departement_id;
+    ville.pays = derivedPays;
+    return this.villeRepository.save(ville);
+  }
+
+  async remove(pays: string, id: string): Promise<{ message: string }> {
+    const ville = await this.findOne(pays, id);
+    await this.villeRepository.remove(ville);
+    return { message: 'Ville supprimée avec succès' };
+  }
+
+  // CSV columns: `departement_nom,ville_nom`. The département is resolved by
+  // nom+pays; rows whose département does not exist are SKIPPED and reported
+  // (never auto-created). Duplicates (ville nom + departement) are skipped.
+  async importCsv(pays: string, file: Express.Multer.File): Promise<ImportSummary> {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('Aucun fichier CSV fourni');
+    }
+
+    const summary: ImportSummary = { created: 0, skipped: 0, errors: [] };
+    const rawLines = file.buffer.toString('utf-8').split(/\r?\n/);
+    let headerChecked = false;
+
+    for (let i = 0; i < rawLines.length; i++) {
+      const lineNo = i + 1;
+      const line = rawLines[i].trim();
+      if (!line) continue;
+
+      const cols = parseCsvLine(line);
+
+      if (!headerChecked) {
+        headerChecked = true;
+        const first = cols[0]?.toLowerCase();
+        if (first === 'departement_nom' || first === 'departement') continue;
+      }
+
+      const departementNom = cols[0]?.trim();
+      const villeNom = cols[1]?.trim();
+
+      if (!departementNom || !villeNom) {
+        summary.errors.push({
+          line: lineNo,
+          reason: 'departement_nom ou ville_nom manquant',
+        });
+        continue;
+      }
+
+      const departement = await this.departementRepository.findOne({
+        where: { nom: departementNom, pays },
+      });
+      if (!departement) {
+        summary.errors.push({
+          line: lineNo,
+          reason: `département "${departementNom}" introuvable pour ce pays`,
+        });
+        continue;
+      }
+
+      const existing = await this.villeRepository.findOne({
+        where: { nom: villeNom, departement_id: departement.id },
+      });
+      if (existing) {
+        summary.skipped++;
+        continue;
+      }
+
+      const ville = this.villeRepository.create({
+        nom: villeNom,
+        departement_id: departement.id,
+        pays: departement.pays,
+      });
+      await this.villeRepository.save(ville);
+      summary.created++;
+    }
+
+    this.logger.log(
+      `Import CSV villes (pays=${pays}): ${summary.created} créé(s), ${summary.skipped} ignoré(s), ${summary.errors.length} erreur(s)`,
+    );
+    return summary;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,8 @@ import Parcours from "./pages/Parcours";
 import Categories from "./pages/Categories";
 import Structures from "./pages/Structures";
 import Titres from "./pages/Titres";
+import Departements from "./pages/Departements";
+import Villes from "./pages/Villes";
 import Settings from "./pages/Settings";
 import ServicesAdmin from "./pages/ServicesAdmin";
 import EpreuvesApprobation from "./pages/EpreuvesApprobation";
@@ -84,6 +86,8 @@ const App = () => (
                       <Route path="/categories" element={<Categories />} />
                       <Route path="/structures" element={<Structures />} />
                       <Route path="/titres" element={<Titres />} />
+                      <Route path="/departements" element={<Departements />} />
+                      <Route path="/villes" element={<Villes />} />
                       <Route path="/contacts-professionnels" element={<ContactsProfessionnels />} />
                       <Route path="/settings" element={<Settings />} />
                       <Route path="/notifications" element={<Notifications />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -154,15 +154,15 @@ const navTree: NavItem[] = [
       { title: "Utilisateurs", icon: User, url: "/users" },
       { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Parrainage", icon: UserPlus, url: "/parrainages" },
-    ],
-  },
-  {
-    // geo-profile: Géographie group (départements + villes)
-    title: "Géographie",
-    icon: Map,
-    children: [
-      { title: "Départements", icon: MapPin, url: "/departements" },
-      { title: "Villes", icon: MapPin, url: "/villes" },
+      {
+        // geo-profile: Géographie subgroup, nested under Utilisateurs
+        title: "Géographie",
+        icon: Map,
+        children: [
+          { title: "Départements", icon: MapPin, url: "/departements" },
+          { title: "Villes", icon: MapPin, url: "/villes" },
+        ],
+      },
     ],
   },
   {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -37,6 +37,8 @@ import {
   ClipboardCheck,
   Wallet,
   Banknote,
+  Map,
+  MapPin,
   type LucideIcon,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -152,6 +154,15 @@ const navTree: NavItem[] = [
       { title: "Utilisateurs", icon: User, url: "/users" },
       { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Parrainage", icon: UserPlus, url: "/parrainages" },
+    ],
+  },
+  {
+    // geo-profile: Géographie group (départements + villes)
+    title: "Géographie",
+    icon: Map,
+    children: [
+      { title: "Départements", icon: MapPin, url: "/departements" },
+      { title: "Villes", icon: MapPin, url: "/villes" },
     ],
   },
   {

--- a/frontend/src/lib/services/departements.service.ts
+++ b/frontend/src/lib/services/departements.service.ts
@@ -3,7 +3,7 @@ import type { PaginationResponse, PaginationParams } from '../types/pagination';
 import { buildPaginationQuery } from '../types/pagination';
 
 export interface Departement {
-  id: number;
+  id: string; // uuid
   nom: string;
   code?: string | null;
   pays?: string;
@@ -24,7 +24,7 @@ export const departementsService = {
     return api.get<PaginationResponse<Departement>>(`/departements${buildPaginationQuery(params)}`);
   },
 
-  async getById(id: number): Promise<Departement> {
+  async getById(id: string): Promise<Departement> {
     return api.get<Departement>(`/departements/${id}`);
   },
 
@@ -32,11 +32,11 @@ export const departementsService = {
     return api.post<Departement>('/departements', data);
   },
 
-  async update(id: number, data: Partial<{ nom: string; code: string }>): Promise<Departement> {
+  async update(id: string, data: Partial<{ nom: string; code: string }>): Promise<Departement> {
     return api.put<Departement>(`/departements/${id}`, data);
   },
 
-  async delete(id: number): Promise<{ message: string }> {
+  async delete(id: string): Promise<{ message: string }> {
     // remove() is country-scoped server-side; DELETE carries no body and
     // api.delete doesn't auto-append ?country=, so pass it explicitly.
     const country = api.getCountry();

--- a/frontend/src/lib/services/departements.service.ts
+++ b/frontend/src/lib/services/departements.service.ts
@@ -1,0 +1,52 @@
+import { api } from '../api';
+import type { PaginationResponse, PaginationParams } from '../types/pagination';
+import { buildPaginationQuery } from '../types/pagination';
+
+export interface Departement {
+  id: number;
+  nom: string;
+  code?: string | null;
+  pays?: string;
+  date_creation?: string;
+}
+
+// Summary returned by the CSV import endpoints
+export interface ImportSummary {
+  created: number;
+  skipped: number;
+  errors: { line: number; reason: string }[];
+}
+
+export const departementsService = {
+  async getAll(
+    params?: PaginationParams & { search?: string },
+  ): Promise<PaginationResponse<Departement>> {
+    return api.get<PaginationResponse<Departement>>(`/departements${buildPaginationQuery(params)}`);
+  },
+
+  async getById(id: number): Promise<Departement> {
+    return api.get<Departement>(`/departements/${id}`);
+  },
+
+  async create(data: { nom: string; code?: string }): Promise<Departement> {
+    return api.post<Departement>('/departements', data);
+  },
+
+  async update(id: number, data: Partial<{ nom: string; code: string }>): Promise<Departement> {
+    return api.put<Departement>(`/departements/${id}`, data);
+  },
+
+  async delete(id: number): Promise<{ message: string }> {
+    // remove() is country-scoped server-side; DELETE carries no body and
+    // api.delete doesn't auto-append ?country=, so pass it explicitly.
+    const country = api.getCountry();
+    return api.delete(`/departements/${id}?country=${encodeURIComponent(country)}`);
+  },
+
+  async importCsv(file: File): Promise<ImportSummary> {
+    // multipart → api.post falls back to ?country= (middleware runs before multer)
+    const formData = new FormData();
+    formData.append('file', file);
+    return api.post<ImportSummary>('/departements/import-csv', formData);
+  },
+};

--- a/frontend/src/lib/services/villes.service.ts
+++ b/frontend/src/lib/services/villes.service.ts
@@ -4,9 +4,9 @@ import { buildPaginationQuery } from '../types/pagination';
 import type { Departement, ImportSummary } from './departements.service';
 
 export interface Ville {
-  id: number;
+  id: string; // uuid
   nom: string;
-  departement_id: number;
+  departement_id: string; // uuid
   pays?: string;
   departement?: Departement;
   date_creation?: string;
@@ -14,24 +14,24 @@ export interface Ville {
 
 export const villesService = {
   async getAll(
-    params?: PaginationParams & { search?: string; departement_id?: number },
+    params?: PaginationParams & { search?: string; departement_id?: string },
   ): Promise<PaginationResponse<Ville>> {
     return api.get<PaginationResponse<Ville>>(`/villes${buildPaginationQuery(params)}`);
   },
 
-  async getById(id: number): Promise<Ville> {
+  async getById(id: string): Promise<Ville> {
     return api.get<Ville>(`/villes/${id}`);
   },
 
-  async create(data: { nom: string; departement_id: number }): Promise<Ville> {
+  async create(data: { nom: string; departement_id: string }): Promise<Ville> {
     return api.post<Ville>('/villes', data);
   },
 
-  async update(id: number, data: Partial<{ nom: string; departement_id: number }>): Promise<Ville> {
+  async update(id: string, data: Partial<{ nom: string; departement_id: string }>): Promise<Ville> {
     return api.put<Ville>(`/villes/${id}`, data);
   },
 
-  async delete(id: number): Promise<{ message: string }> {
+  async delete(id: string): Promise<{ message: string }> {
     // country-scoped server-side; append ?country= explicitly (see departements.service)
     const country = api.getCountry();
     return api.delete(`/villes/${id}?country=${encodeURIComponent(country)}`);

--- a/frontend/src/lib/services/villes.service.ts
+++ b/frontend/src/lib/services/villes.service.ts
@@ -1,0 +1,45 @@
+import { api } from '../api';
+import type { PaginationResponse, PaginationParams } from '../types/pagination';
+import { buildPaginationQuery } from '../types/pagination';
+import type { Departement, ImportSummary } from './departements.service';
+
+export interface Ville {
+  id: number;
+  nom: string;
+  departement_id: number;
+  pays?: string;
+  departement?: Departement;
+  date_creation?: string;
+}
+
+export const villesService = {
+  async getAll(
+    params?: PaginationParams & { search?: string; departement_id?: number },
+  ): Promise<PaginationResponse<Ville>> {
+    return api.get<PaginationResponse<Ville>>(`/villes${buildPaginationQuery(params)}`);
+  },
+
+  async getById(id: number): Promise<Ville> {
+    return api.get<Ville>(`/villes/${id}`);
+  },
+
+  async create(data: { nom: string; departement_id: number }): Promise<Ville> {
+    return api.post<Ville>('/villes', data);
+  },
+
+  async update(id: number, data: Partial<{ nom: string; departement_id: number }>): Promise<Ville> {
+    return api.put<Ville>(`/villes/${id}`, data);
+  },
+
+  async delete(id: number): Promise<{ message: string }> {
+    // country-scoped server-side; append ?country= explicitly (see departements.service)
+    const country = api.getCountry();
+    return api.delete(`/villes/${id}?country=${encodeURIComponent(country)}`);
+  },
+
+  async importCsv(file: File): Promise<ImportSummary> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return api.post<ImportSummary>('/villes/import-csv', formData);
+  },
+};

--- a/frontend/src/pages/Departements.tsx
+++ b/frontend/src/pages/Departements.tsx
@@ -1,0 +1,297 @@
+import { useState, useRef } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { MapPin, Plus, Pencil, Trash2, Loader2, Search, ChevronLeft, ChevronRight, Upload } from "lucide-react";
+import { departementsService, type Departement, type ImportSummary } from "@/lib/services/departements.service";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useDebounce } from "@/hooks/use-debounce";
+
+interface DepartementFormData {
+    nom: string;
+    code: string;
+}
+
+// Toast the {created, skipped, errors} summary; surface the first few error lines.
+function toastImportSummary(toast: ReturnType<typeof useToast>["toast"], summary: ImportSummary) {
+    toast({
+        title: "Import terminé",
+        description: `${summary.created} créé(s), ${summary.skipped} ignoré(s), ${summary.errors.length} erreur(s)`,
+    });
+    if (summary.errors.length > 0) {
+        const preview = summary.errors.slice(0, 5).map((e) => `Ligne ${e.line}: ${e.reason}`).join("\n");
+        const more = summary.errors.length > 5 ? `\n… +${summary.errors.length - 5} autre(s)` : "";
+        toast({ title: "Lignes ignorées", description: preview + more, variant: "destructive" });
+    }
+}
+
+export default function Departements() {
+    const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [editing, setEditing] = useState<Departement | null>(null);
+    const [formData, setFormData] = useState<DepartementFormData>({ nom: "", code: "" });
+    const [search, setSearch] = useState("");
+    const debouncedSearch = useDebounce(search, 500);
+    const [page, setPage] = useState(1);
+    const [limit] = useState(10);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+
+    const { data: response, isLoading } = useQuery({
+        queryKey: ["departements", debouncedSearch, page, limit],
+        queryFn: () => departementsService.getAll({ search: debouncedSearch, page, limit }),
+    });
+    const departements = response?.data || [];
+    const totalPages = response?.totalPages || 1;
+
+    const createMutation = useMutation({
+        mutationFn: (data: DepartementFormData) => departementsService.create({ nom: data.nom, code: data.code || undefined }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["departements"] });
+            setIsCreateDialogOpen(false);
+            setFormData({ nom: "", code: "" });
+            toast({ title: "Succès", description: "Département créé avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la création", variant: "destructive" });
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }: { id: number; data: Partial<DepartementFormData> }) => departementsService.update(id, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["departements"] });
+            setIsEditDialogOpen(false);
+            setEditing(null);
+            toast({ title: "Succès", description: "Département mis à jour avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la mise à jour", variant: "destructive" });
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (id: number) => departementsService.delete(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["departements"] });
+            setDeleteId(null);
+            toast({ title: "Succès", description: "Département supprimé avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la suppression", variant: "destructive" });
+        },
+    });
+
+    const importMutation = useMutation({
+        mutationFn: (file: File) => departementsService.importCsv(file),
+        onSuccess: (summary) => {
+            queryClient.invalidateQueries({ queryKey: ["departements"] });
+            toastImportSummary(toast, summary);
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de l'import CSV", variant: "destructive" });
+        },
+    });
+
+    const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) importMutation.mutate(file);
+        e.target.value = ""; // allow re-selecting the same file
+    };
+
+    const handleCreate = (e: React.FormEvent) => {
+        e.preventDefault();
+        createMutation.mutate(formData);
+    };
+
+    const handleEdit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!editing) return;
+        updateMutation.mutate({ id: editing.id, data: { nom: editing.nom, code: editing.code || "" } });
+    };
+
+    const openEditDialog = (item: Departement) => {
+        setEditing(item);
+        setIsEditDialogOpen(true);
+    };
+
+    const openCreateDialog = () => {
+        setFormData({ nom: "", code: "" });
+        setIsCreateDialogOpen(true);
+    };
+
+    if (isLoading) {
+        return <div className="flex h-[400px] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-3xl font-bold text-foreground flex items-center gap-2">
+                        <MapPin className="h-8 w-8" />
+                        Départements
+                    </h1>
+                    <p className="text-muted-foreground">Gérer les départements (par pays)</p>
+                </div>
+                <div className="flex items-center gap-4">
+                    <div className="relative">
+                        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                        <Input
+                            placeholder="Rechercher..."
+                            className="pl-8 w-[250px]"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                    </div>
+                    <input ref={fileInputRef} type="file" accept=".csv,text/csv" className="hidden" onChange={handleFileSelected} />
+                    <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()} disabled={importMutation.isPending}>
+                        {importMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />} Importer CSV
+                    </Button>
+                    <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+                        <DialogTrigger asChild>
+                            <Button className="gap-2" onClick={openCreateDialog}><Plus className="h-4 w-4" /> Ajouter</Button>
+                        </DialogTrigger>
+                        <DialogContent className="max-w-[500px]">
+                            <form onSubmit={handleCreate}>
+                                <DialogHeader>
+                                    <DialogTitle>Créer un département</DialogTitle>
+                                    <DialogDescription>Ajouter un nouveau département</DialogDescription>
+                                </DialogHeader>
+                                <div className="grid gap-4 py-4">
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="nom">Nom *</Label>
+                                        <Input id="nom" value={formData.nom} onChange={(e) => setFormData({ ...formData, nom: e.target.value })} required />
+                                    </div>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="code">Code</Label>
+                                        <Input id="code" value={formData.code} onChange={(e) => setFormData({ ...formData, code: e.target.value })} />
+                                    </div>
+                                </div>
+                                <DialogFooter>
+                                    <Button type="submit" disabled={createMutation.isPending}>{createMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Créer"}</Button>
+                                </DialogFooter>
+                            </form>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Liste des départements</CardTitle>
+                    <CardDescription>{departements.length} département{departements.length > 1 ? "s" : ""} sur cette page</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {departements.length === 0 ? <div className="text-center py-8 text-muted-foreground">Aucun département trouvé.</div> :
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Nom</TableHead>
+                                    <TableHead>Code</TableHead>
+                                    <TableHead className="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {departements.map((item) => (
+                                    <TableRow key={item.id}>
+                                        <TableCell className="font-medium">{item.nom}</TableCell>
+                                        <TableCell className="text-muted-foreground text-sm">{item.code || "—"}</TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-2">
+                                                <Button variant="ghost" size="icon" onClick={() => openEditDialog(item)}><Pencil className="h-4 w-4" /></Button>
+                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.id)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    }
+                </CardContent>
+            </Card>
+
+            {totalPages > 1 && (
+                <div className="flex items-center justify-center space-x-2 py-4">
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
+                        <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground">Page {page} sur {totalPages}</div>
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+                        <ChevronRight className="h-4 w-4" />
+                    </Button>
+                </div>
+            )}
+
+            <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+                <DialogContent className="max-w-[500px]">
+                    <form onSubmit={handleEdit}>
+                        <DialogHeader>
+                            <DialogTitle>Modifier le département</DialogTitle>
+                        </DialogHeader>
+                        {editing && (
+                            <div className="grid gap-4 py-4">
+                                <div className="grid gap-2">
+                                    <Label>Nom</Label>
+                                    <Input value={editing.nom} onChange={(e) => setEditing({ ...editing, nom: e.target.value })} required />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label>Code</Label>
+                                    <Input value={editing.code || ''} onChange={(e) => setEditing({ ...editing, code: e.target.value })} />
+                                </div>
+                            </div>
+                        )}
+                        <DialogFooter>
+                            <Button type="submit" disabled={updateMutation.isPending}>{updateMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Mettre à jour"}</Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <AlertDialog open={deleteId !== null} onOpenChange={(open) => !open && setDeleteId(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Confirmer la suppression</AlertDialogTitle>
+                        <AlertDialogDescription>Supprimer ce département supprimera aussi ses villes. Cette action est irréversible.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Annuler</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => deleteId && deleteMutation.mutate(deleteId)} className="bg-destructive text-destructive-foreground">Supprimer</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    );
+}

--- a/frontend/src/pages/Departements.tsx
+++ b/frontend/src/pages/Departements.tsx
@@ -57,7 +57,7 @@ function toastImportSummary(toast: ReturnType<typeof useToast>["toast"], summary
 export default function Departements() {
     const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-    const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [deleteId, setDeleteId] = useState<string | null>(null);
     const [editing, setEditing] = useState<Departement | null>(null);
     const [formData, setFormData] = useState<DepartementFormData>({ nom: "", code: "" });
     const [search, setSearch] = useState("");
@@ -90,7 +90,7 @@ export default function Departements() {
     });
 
     const updateMutation = useMutation({
-        mutationFn: ({ id, data }: { id: number; data: Partial<DepartementFormData> }) => departementsService.update(id, data),
+        mutationFn: ({ id, data }: { id: string; data: Partial<DepartementFormData> }) => departementsService.update(id, data),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["departements"] });
             setIsEditDialogOpen(false);
@@ -103,7 +103,7 @@ export default function Departements() {
     });
 
     const deleteMutation = useMutation({
-        mutationFn: (id: number) => departementsService.delete(id),
+        mutationFn: (id: string) => departementsService.delete(id),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["departements"] });
             setDeleteId(null);

--- a/frontend/src/pages/Villes.tsx
+++ b/frontend/src/pages/Villes.tsx
@@ -62,7 +62,7 @@ const ALL = "all";
 export default function Villes() {
     const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-    const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [deleteId, setDeleteId] = useState<string | null>(null);
     const [editing, setEditing] = useState<Ville | null>(null);
     const [createNom, setCreateNom] = useState("");
     const [createDeptId, setCreateDeptId] = useState<string>("");
@@ -83,7 +83,7 @@ export default function Villes() {
     });
     const departements = deptResponse?.data || [];
 
-    const departementId = filterDeptId === ALL ? undefined : Number(filterDeptId);
+    const departementId = filterDeptId === ALL ? undefined : filterDeptId;
     const { data: response, isLoading } = useQuery({
         queryKey: ["villes", debouncedSearch, page, limit, departementId],
         queryFn: () => villesService.getAll({ search: debouncedSearch, page, limit, departement_id: departementId }),
@@ -92,7 +92,7 @@ export default function Villes() {
     const totalPages = response?.totalPages || 1;
 
     const createMutation = useMutation({
-        mutationFn: (data: { nom: string; departement_id: number }) => villesService.create(data),
+        mutationFn: (data: { nom: string; departement_id: string }) => villesService.create(data),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["villes"] });
             setIsCreateDialogOpen(false);
@@ -106,7 +106,7 @@ export default function Villes() {
     });
 
     const updateMutation = useMutation({
-        mutationFn: ({ id, data }: { id: number; data: Partial<{ nom: string; departement_id: number }> }) => villesService.update(id, data),
+        mutationFn: ({ id, data }: { id: string; data: Partial<{ nom: string; departement_id: string }> }) => villesService.update(id, data),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["villes"] });
             setIsEditDialogOpen(false);
@@ -119,7 +119,7 @@ export default function Villes() {
     });
 
     const deleteMutation = useMutation({
-        mutationFn: (id: number) => villesService.delete(id),
+        mutationFn: (id: string) => villesService.delete(id),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["villes"] });
             setDeleteId(null);
@@ -153,7 +153,7 @@ export default function Villes() {
             toast({ title: "Erreur", description: "Veuillez choisir un département", variant: "destructive" });
             return;
         }
-        createMutation.mutate({ nom: createNom, departement_id: Number(createDeptId) });
+        createMutation.mutate({ nom: createNom, departement_id: createDeptId });
     };
 
     const handleEdit = (e: React.FormEvent) => {
@@ -169,7 +169,7 @@ export default function Villes() {
 
     const openCreateDialog = () => {
         setCreateNom("");
-        setCreateDeptId(departementId ? String(departementId) : "");
+        setCreateDeptId(departementId ?? "");
         setIsCreateDialogOpen(true);
     };
 
@@ -195,7 +195,7 @@ export default function Villes() {
                         <SelectContent>
                             <SelectItem value={ALL}>Tous les départements</SelectItem>
                             {departements.map((d) => (
-                                <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                                <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
                             ))}
                         </SelectContent>
                     </Select>
@@ -231,7 +231,7 @@ export default function Villes() {
                                             </SelectTrigger>
                                             <SelectContent>
                                                 {departements.map((d) => (
-                                                    <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                                                    <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
                                                 ))}
                                             </SelectContent>
                                         </Select>
@@ -306,13 +306,13 @@ export default function Villes() {
                             <div className="grid gap-4 py-4">
                                 <div className="grid gap-2">
                                     <Label>Département *</Label>
-                                    <Select value={String(editing.departement_id)} onValueChange={(v) => setEditing({ ...editing, departement_id: Number(v) })}>
+                                    <Select value={editing.departement_id} onValueChange={(v) => setEditing({ ...editing, departement_id: v })}>
                                         <SelectTrigger>
                                             <SelectValue placeholder="Choisir un département" />
                                         </SelectTrigger>
                                         <SelectContent>
                                             {departements.map((d) => (
-                                                <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                                                <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
                                             ))}
                                         </SelectContent>
                                     </Select>

--- a/frontend/src/pages/Villes.tsx
+++ b/frontend/src/pages/Villes.tsx
@@ -1,0 +1,347 @@
+import { useState, useRef } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { MapPin, Plus, Pencil, Trash2, Loader2, Search, ChevronLeft, ChevronRight, Upload } from "lucide-react";
+import { villesService, type Ville } from "@/lib/services/villes.service";
+import { departementsService, type ImportSummary } from "@/lib/services/departements.service";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useDebounce } from "@/hooks/use-debounce";
+
+// Toast the {created, skipped, errors} summary; surface the first few error lines.
+function toastImportSummary(toast: ReturnType<typeof useToast>["toast"], summary: ImportSummary) {
+    toast({
+        title: "Import terminé",
+        description: `${summary.created} créé(s), ${summary.skipped} ignoré(s), ${summary.errors.length} erreur(s)`,
+    });
+    if (summary.errors.length > 0) {
+        const preview = summary.errors.slice(0, 5).map((e) => `Ligne ${e.line}: ${e.reason}`).join("\n");
+        const more = summary.errors.length > 5 ? `\n… +${summary.errors.length - 5} autre(s)` : "";
+        toast({ title: "Lignes ignorées", description: preview + more, variant: "destructive" });
+    }
+}
+
+const ALL = "all";
+
+export default function Villes() {
+    const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
+    const [editing, setEditing] = useState<Ville | null>(null);
+    const [createNom, setCreateNom] = useState("");
+    const [createDeptId, setCreateDeptId] = useState<string>("");
+    const [filterDeptId, setFilterDeptId] = useState<string>(ALL);
+    const [search, setSearch] = useState("");
+    const debouncedSearch = useDebounce(search, 500);
+    const [page, setPage] = useState(1);
+    const [limit] = useState(10);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+
+    // Départements for the filter + create selects (scoped to current country by api)
+    const { data: deptResponse } = useQuery({
+        queryKey: ["departements", "all-for-select"],
+        queryFn: () => departementsService.getAll({ page: 1, limit: 1000 }),
+    });
+    const departements = deptResponse?.data || [];
+
+    const departementId = filterDeptId === ALL ? undefined : Number(filterDeptId);
+    const { data: response, isLoading } = useQuery({
+        queryKey: ["villes", debouncedSearch, page, limit, departementId],
+        queryFn: () => villesService.getAll({ search: debouncedSearch, page, limit, departement_id: departementId }),
+    });
+    const villes = response?.data || [];
+    const totalPages = response?.totalPages || 1;
+
+    const createMutation = useMutation({
+        mutationFn: (data: { nom: string; departement_id: number }) => villesService.create(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["villes"] });
+            setIsCreateDialogOpen(false);
+            setCreateNom("");
+            setCreateDeptId("");
+            toast({ title: "Succès", description: "Ville créée avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la création", variant: "destructive" });
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }: { id: number; data: Partial<{ nom: string; departement_id: number }> }) => villesService.update(id, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["villes"] });
+            setIsEditDialogOpen(false);
+            setEditing(null);
+            toast({ title: "Succès", description: "Ville mise à jour avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la mise à jour", variant: "destructive" });
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (id: number) => villesService.delete(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["villes"] });
+            setDeleteId(null);
+            toast({ title: "Succès", description: "Ville supprimée avec succès" });
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de la suppression", variant: "destructive" });
+        },
+    });
+
+    const importMutation = useMutation({
+        mutationFn: (file: File) => villesService.importCsv(file),
+        onSuccess: (summary) => {
+            queryClient.invalidateQueries({ queryKey: ["villes"] });
+            toastImportSummary(toast, summary);
+        },
+        onError: (error: any) => {
+            toast({ title: "Erreur", description: error.message || "Échec de l'import CSV", variant: "destructive" });
+        },
+    });
+
+    const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) importMutation.mutate(file);
+        e.target.value = "";
+    };
+
+    const handleCreate = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!createDeptId) {
+            toast({ title: "Erreur", description: "Veuillez choisir un département", variant: "destructive" });
+            return;
+        }
+        createMutation.mutate({ nom: createNom, departement_id: Number(createDeptId) });
+    };
+
+    const handleEdit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!editing) return;
+        updateMutation.mutate({ id: editing.id, data: { nom: editing.nom, departement_id: editing.departement_id } });
+    };
+
+    const openEditDialog = (item: Ville) => {
+        setEditing(item);
+        setIsEditDialogOpen(true);
+    };
+
+    const openCreateDialog = () => {
+        setCreateNom("");
+        setCreateDeptId(departementId ? String(departementId) : "");
+        setIsCreateDialogOpen(true);
+    };
+
+    if (isLoading) {
+        return <div className="flex h-[400px] items-center justify-center"><Loader2 className="h-8 w-8 animate-spin text-primary" /></div>;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-3xl font-bold text-foreground flex items-center gap-2">
+                        <MapPin className="h-8 w-8" />
+                        Villes
+                    </h1>
+                    <p className="text-muted-foreground">Gérer les villes (rattachées à un département)</p>
+                </div>
+                <div className="flex items-center gap-4">
+                    <Select value={filterDeptId} onValueChange={(v) => { setFilterDeptId(v); setPage(1); }}>
+                        <SelectTrigger className="w-[220px]">
+                            <SelectValue placeholder="Filtrer par département" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value={ALL}>Tous les départements</SelectItem>
+                            {departements.map((d) => (
+                                <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <div className="relative">
+                        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                        <Input
+                            placeholder="Rechercher..."
+                            className="pl-8 w-[200px]"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                        />
+                    </div>
+                    <input ref={fileInputRef} type="file" accept=".csv,text/csv" className="hidden" onChange={handleFileSelected} />
+                    <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()} disabled={importMutation.isPending}>
+                        {importMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />} Importer CSV
+                    </Button>
+                    <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+                        <DialogTrigger asChild>
+                            <Button className="gap-2" onClick={openCreateDialog}><Plus className="h-4 w-4" /> Ajouter</Button>
+                        </DialogTrigger>
+                        <DialogContent className="max-w-[500px]">
+                            <form onSubmit={handleCreate}>
+                                <DialogHeader>
+                                    <DialogTitle>Créer une ville</DialogTitle>
+                                    <DialogDescription>Choisir le département puis nommer la ville</DialogDescription>
+                                </DialogHeader>
+                                <div className="grid gap-4 py-4">
+                                    <div className="grid gap-2">
+                                        <Label>Département *</Label>
+                                        <Select value={createDeptId} onValueChange={setCreateDeptId}>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Choisir un département" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {departements.map((d) => (
+                                                    <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="nom">Nom de la ville *</Label>
+                                        <Input id="nom" value={createNom} onChange={(e) => setCreateNom(e.target.value)} required />
+                                    </div>
+                                </div>
+                                <DialogFooter>
+                                    <Button type="submit" disabled={createMutation.isPending}>{createMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Créer"}</Button>
+                                </DialogFooter>
+                            </form>
+                        </DialogContent>
+                    </Dialog>
+                </div>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Liste des villes</CardTitle>
+                    <CardDescription>{villes.length} ville{villes.length > 1 ? "s" : ""} sur cette page</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {villes.length === 0 ? <div className="text-center py-8 text-muted-foreground">Aucune ville trouvée.</div> :
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Ville</TableHead>
+                                    <TableHead>Département</TableHead>
+                                    <TableHead className="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {villes.map((item) => (
+                                    <TableRow key={item.id}>
+                                        <TableCell className="font-medium">{item.nom}</TableCell>
+                                        <TableCell className="text-muted-foreground text-sm">{item.departement?.nom || "—"}</TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-2">
+                                                <Button variant="ghost" size="icon" onClick={() => openEditDialog(item)}><Pencil className="h-4 w-4" /></Button>
+                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.id)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    }
+                </CardContent>
+            </Card>
+
+            {totalPages > 1 && (
+                <div className="flex items-center justify-center space-x-2 py-4">
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
+                        <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground">Page {page} sur {totalPages}</div>
+                    <Button variant="outline" size="sm" onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+                        <ChevronRight className="h-4 w-4" />
+                    </Button>
+                </div>
+            )}
+
+            <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+                <DialogContent className="max-w-[500px]">
+                    <form onSubmit={handleEdit}>
+                        <DialogHeader>
+                            <DialogTitle>Modifier la ville</DialogTitle>
+                        </DialogHeader>
+                        {editing && (
+                            <div className="grid gap-4 py-4">
+                                <div className="grid gap-2">
+                                    <Label>Département *</Label>
+                                    <Select value={String(editing.departement_id)} onValueChange={(v) => setEditing({ ...editing, departement_id: Number(v) })}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Choisir un département" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {departements.map((d) => (
+                                                <SelectItem key={d.id} value={String(d.id)}>{d.nom}</SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label>Nom de la ville</Label>
+                                    <Input value={editing.nom} onChange={(e) => setEditing({ ...editing, nom: e.target.value })} required />
+                                </div>
+                            </div>
+                        )}
+                        <DialogFooter>
+                            <Button type="submit" disabled={updateMutation.isPending}>{updateMutation.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : "Mettre à jour"}</Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <AlertDialog open={deleteId !== null} onOpenChange={(open) => !open && setDeleteId(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Confirmer la suppression</AlertDialogTitle>
+                        <AlertDialogDescription>Êtes-vous sûr de vouloir supprimer cette ville ? Cette action est irréversible.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Annuler</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => deleteId && deleteMutation.mutate(deleteId)} className="bg-destructive text-destructive-foreground">Supprimer</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    );
+}


### PR DESCRIPTION
## What
Adds **Département** and **Ville** reference entities that cascade under `pays` (pays → départements → villes), wires them into the user profile, and makes the user-JSON endpoints return a single consistent, complete shape.

## Backend
- **`departements` + `villes`** modules — country-scoped CRUD (row-by-row) **+ CSV import** (`/departements/import-csv`, `/villes/import-csv`). **UUID** primary keys.
- **User profile**: `utilisateurs` gains nullable `departement_id` + `ville_id` (uuid FKs), validated as a cascade (ville ∈ département ∈ user's pays).
- **Consistent complete user shape** — one shared `enrichUserComplete()` used by `GET /utilisateurs`, `GET /utilisateurs/profil`, and get-by-uuid, so all three return identical info:
  - `departement` / `ville` as `{ uuid, nom }` (raw `departement_id`/`ville_id` **removed** — redundant),
  - `age` (from `date_naissance`) + previously-dropped fields (`pays`, `date_naissance`, `zone_residence`, `situation_handicap`),
  - `isEmailVerified` / `isPrestataire` / `isRecruteur`.
- `@Max(100)` on the **admin** user-list page size (scoped to `FilterUtilisateurDto`) — the list is admin-guarded and now does per-user lookups, so this bounds an N+1 vector.

## Frontend (admin)
- Départements + Villes pages (CRUD + CSV import + département→ville cascade).
- Sidebar: **Géographie nested under Utilisateurs**.

## Mobile safety
- `GET /utilisateurs` is **ADMIN-only** → the list changes + `@Max` cannot affect mobile.
- `GET /utilisateurs/profil` (mobile-facing) changes are **additive** (new keys); the only removed keys (`departement_id`/`ville_id`) are brand-new and never existed pre-feature. Backward-compatible for standard JSON parsers.

## Requires before merge
- **edukia-db migrations 030–032** applied to **prod** (currently dev-only; prod is missing the tables/columns). Separate edukia-db PR.

## Notes
- The **type-profil** branch also edits `utilisateurs` + `AppSidebar` → expect an additive merge conflict; merge one, rebase the other.
- Follow-up (optional): batch the 3 boolean lookups to remove the list N+1 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)