### PR TITLE
fix(geo): départements/villes expose uuid (not id); villes carry only { departement }

### DIFF
--- a/backend/src/departements/departement.controller.ts
+++ b/backend/src/departements/departement.controller.ts
@@ -28,13 +28,20 @@ import { CurrentCountry } from '../common/decorators/current-country.decorator';
 export class DepartementController {
   constructor(private readonly departementService: DepartementService) {}
 
+  // Expose the identifier as `uuid` (the PK is a uuid) in the API response.
+  private toResponse(d: any) {
+    return d
+      ? { uuid: d.id, nom: d.nom, code: d.code, pays: d.pays, date_creation: d.date_creation }
+      : d;
+  }
+
   @Post()
   @ApiOperation({ summary: 'Créer un département' })
   async create(
     @CurrentCountry() pays: string,
     @Body() dto: CreerDepartementDto,
   ) {
-    return this.departementService.create(pays, dto);
+    return this.toResponse(await this.departementService.create(pays, dto));
   }
 
   @Post('import-csv')
@@ -55,13 +62,14 @@ export class DepartementController {
     @CurrentCountry() pays: string,
     @Query() filterDto: FilterDepartementDto,
   ) {
-    return this.departementService.findAll(pays, filterDto);
+    const res = await this.departementService.findAll(pays, filterDto);
+    return { ...res, data: res.data.map((d) => this.toResponse(d)) };
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer un département par son ID' })
   async findOne(@CurrentCountry() pays: string, @Param('id') id: string) {
-    return this.departementService.findOne(pays, id);
+    return this.toResponse(await this.departementService.findOne(pays, id));
   }
 
   @Put(':id')
@@ -71,7 +79,7 @@ export class DepartementController {
     @Param('id') id: string,
     @Body() dto: MajDepartementDto,
   ) {
-    return this.departementService.update(pays, id, dto);
+    return this.toResponse(await this.departementService.update(pays, id, dto));
   }
 
   @Delete(':id')

--- a/backend/src/villes/ville.controller.ts
+++ b/backend/src/villes/ville.controller.ts
@@ -28,10 +28,26 @@ import { CurrentCountry } from '../common/decorators/current-country.decorator';
 export class VilleController {
   constructor(private readonly villeService: VilleService) {}
 
+  // Expose `uuid` (the PK is a uuid) and only the nested `departement` object
+  // ({ uuid, nom }); the raw `departement_id` is dropped (redundant).
+  private toResponse(v: any) {
+    return v
+      ? {
+          uuid: v.id,
+          nom: v.nom,
+          pays: v.pays,
+          date_creation: v.date_creation,
+          departement: v.departement
+            ? { uuid: v.departement.id, nom: v.departement.nom }
+            : null,
+        }
+      : v;
+  }
+
   @Post()
   @ApiOperation({ summary: 'Créer une ville (scopée au département parent)' })
   async create(@CurrentCountry() pays: string, @Body() dto: CreerVilleDto) {
-    return this.villeService.create(pays, dto);
+    return this.toResponse(await this.villeService.create(pays, dto));
   }
 
   @Post('import-csv')
@@ -53,13 +69,14 @@ export class VilleController {
     @CurrentCountry() pays: string,
     @Query() filterDto: FilterVilleDto,
   ) {
-    return this.villeService.findAll(pays, filterDto);
+    const res = await this.villeService.findAll(pays, filterDto);
+    return { ...res, data: res.data.map((v) => this.toResponse(v)) };
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer une ville par son ID' })
   async findOne(@CurrentCountry() pays: string, @Param('id') id: string) {
-    return this.villeService.findOne(pays, id);
+    return this.toResponse(await this.villeService.findOne(pays, id));
   }
 
   @Put(':id')
@@ -69,7 +86,7 @@ export class VilleController {
     @Param('id') id: string,
     @Body() dto: MajVilleDto,
   ) {
-    return this.villeService.update(pays, id, dto);
+    return this.toResponse(await this.villeService.update(pays, id, dto));
   }
 
   @Delete(':id')

--- a/backend/src/villes/ville.service.ts
+++ b/backend/src/villes/ville.service.ts
@@ -58,7 +58,8 @@ export class VilleService {
     this.logger.log(
       `Ville créée: ${saved.nom} (ID: ${saved.id}, dept: ${saved.departement_id}, pays: ${saved.pays})`,
     );
-    return saved;
+    // reload with the departement relation so the response carries { departement }
+    return this.findOne(pays, saved.id);
   }
 
   async findAll(
@@ -140,7 +141,9 @@ export class VilleService {
     ville.nom = nom;
     ville.departement_id = departement_id;
     ville.pays = derivedPays;
-    return this.villeRepository.save(ville);
+    const saved = await this.villeRepository.save(ville);
+    // reload with the (possibly changed) departement relation for the response
+    return this.findOne(pays, saved.id);
   }
 
   async remove(pays: string, id: string): Promise<{ message: string }> {

--- a/frontend/src/lib/services/departements.service.ts
+++ b/frontend/src/lib/services/departements.service.ts
@@ -3,7 +3,7 @@ import type { PaginationResponse, PaginationParams } from '../types/pagination';
 import { buildPaginationQuery } from '../types/pagination';
 
 export interface Departement {
-  id: string; // uuid
+  uuid: string;
   nom: string;
   code?: string | null;
   pays?: string;

--- a/frontend/src/lib/services/villes.service.ts
+++ b/frontend/src/lib/services/villes.service.ts
@@ -4,11 +4,10 @@ import { buildPaginationQuery } from '../types/pagination';
 import type { Departement, ImportSummary } from './departements.service';
 
 export interface Ville {
-  id: string; // uuid
+  uuid: string;
   nom: string;
-  departement_id: string; // uuid
   pays?: string;
-  departement?: Departement;
+  departement?: Departement; // { uuid, nom }
   date_creation?: string;
 }
 

--- a/frontend/src/pages/Departements.tsx
+++ b/frontend/src/pages/Departements.tsx
@@ -139,7 +139,7 @@ export default function Departements() {
     const handleEdit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!editing) return;
-        updateMutation.mutate({ id: editing.id, data: { nom: editing.nom, code: editing.code || "" } });
+        updateMutation.mutate({ id: editing.uuid, data: { nom: editing.nom, code: editing.code || "" } });
     };
 
     const openEditDialog = (item: Departement) => {
@@ -226,13 +226,13 @@ export default function Departements() {
                             </TableHeader>
                             <TableBody>
                                 {departements.map((item) => (
-                                    <TableRow key={item.id}>
+                                    <TableRow key={item.uuid}>
                                         <TableCell className="font-medium">{item.nom}</TableCell>
                                         <TableCell className="text-muted-foreground text-sm">{item.code || "—"}</TableCell>
                                         <TableCell className="text-right">
                                             <div className="flex justify-end gap-2">
                                                 <Button variant="ghost" size="icon" onClick={() => openEditDialog(item)}><Pencil className="h-4 w-4" /></Button>
-                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.id)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.uuid)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
                                             </div>
                                         </TableCell>
                                     </TableRow>

--- a/frontend/src/pages/Villes.tsx
+++ b/frontend/src/pages/Villes.tsx
@@ -64,6 +64,7 @@ export default function Villes() {
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
     const [deleteId, setDeleteId] = useState<string | null>(null);
     const [editing, setEditing] = useState<Ville | null>(null);
+    const [editDeptId, setEditDeptId] = useState<string>("");
     const [createNom, setCreateNom] = useState("");
     const [createDeptId, setCreateDeptId] = useState<string>("");
     const [filterDeptId, setFilterDeptId] = useState<string>(ALL);
@@ -159,11 +160,12 @@ export default function Villes() {
     const handleEdit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!editing) return;
-        updateMutation.mutate({ id: editing.id, data: { nom: editing.nom, departement_id: editing.departement_id } });
+        updateMutation.mutate({ id: editing.uuid, data: { nom: editing.nom, departement_id: editDeptId } });
     };
 
     const openEditDialog = (item: Ville) => {
         setEditing(item);
+        setEditDeptId(item.departement?.uuid ?? "");
         setIsEditDialogOpen(true);
     };
 
@@ -195,7 +197,7 @@ export default function Villes() {
                         <SelectContent>
                             <SelectItem value={ALL}>Tous les départements</SelectItem>
                             {departements.map((d) => (
-                                <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
+                                <SelectItem key={d.uuid} value={d.uuid}>{d.nom}</SelectItem>
                             ))}
                         </SelectContent>
                     </Select>
@@ -231,7 +233,7 @@ export default function Villes() {
                                             </SelectTrigger>
                                             <SelectContent>
                                                 {departements.map((d) => (
-                                                    <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
+                                                    <SelectItem key={d.uuid} value={d.uuid}>{d.nom}</SelectItem>
                                                 ))}
                                             </SelectContent>
                                         </Select>
@@ -267,13 +269,13 @@ export default function Villes() {
                             </TableHeader>
                             <TableBody>
                                 {villes.map((item) => (
-                                    <TableRow key={item.id}>
+                                    <TableRow key={item.uuid}>
                                         <TableCell className="font-medium">{item.nom}</TableCell>
                                         <TableCell className="text-muted-foreground text-sm">{item.departement?.nom || "—"}</TableCell>
                                         <TableCell className="text-right">
                                             <div className="flex justify-end gap-2">
                                                 <Button variant="ghost" size="icon" onClick={() => openEditDialog(item)}><Pencil className="h-4 w-4" /></Button>
-                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.id)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
+                                                <Button variant="ghost" size="icon" onClick={() => setDeleteId(item.uuid)}><Trash2 className="h-4 w-4 text-destructive" /></Button>
                                             </div>
                                         </TableCell>
                                     </TableRow>
@@ -306,13 +308,13 @@ export default function Villes() {
                             <div className="grid gap-4 py-4">
                                 <div className="grid gap-2">
                                     <Label>Département *</Label>
-                                    <Select value={editing.departement_id} onValueChange={(v) => setEditing({ ...editing, departement_id: v })}>
+                                    <Select value={editDeptId} onValueChange={setEditDeptId}>
                                         <SelectTrigger>
                                             <SelectValue placeholder="Choisir un département" />
                                         </SelectTrigger>
                                         <SelectContent>
                                             {departements.map((d) => (
-                                                <SelectItem key={d.id} value={d.id}>{d.nom}</SelectItem>
+                                                <SelectItem key={d.uuid} value={d.uuid}>{d.nom}</SelectItem>
                                             ))}
                                         </SelectContent>
                                     </Select>


### PR DESCRIPTION
Follow-up to #155 (merged).

## What
- **`GET /departements` and `GET /villes`** now expose the identifier as **`uuid`** instead of `id` (the PK is a uuid). Applies to list, detail, create and update responses.
- **`GET /villes`** responses now carry **only the nested `departement` object** (`{ uuid, nom }`) — the redundant `departement_id` is dropped.
- Ville `create`/`update` reload the départment relation so their responses are complete (not just the list/detail reads).

## How
- Mapped at the controller boundary (`toResponse`) so the service entities stay intact for internal callers (update/remove read the entity's `id`).
- Frontend départements/villes services + admin pages updated to read `uuid`; the ville edit dialog tracks the selected département uuid separately.

## Mobile / compat
- These are **admin** endpoints (behind `JwtAuthGuard`); the change is a field rename in their own responses. The `create`/`update` **requests** still accept `departement_id` (the selected département's uuid) — unchanged.
- No schema change; no migration.

Verified on dev: départements → `{uuid, nom, code, pays, date_creation}`; villes → `{uuid, nom, pays, date_creation, departement:{uuid,nom}}`; create/update/delete round-trip by uuid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)