### PR TITLE
feat(forms): admin-built satisfaction survey campaigns + KPI (mobile-served)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { TitreModule } from './titre/titre.module';
 import { Titre } from './titre/entities/titre.entity';
 import { DepartementModule } from './departements/departement.module';
 import { VilleModule } from './villes/ville.module';
+import { FormsModule } from './forms/forms.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { FirebaseModule } from './firebase/firebase.module';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -139,6 +140,7 @@ import { CountryMiddleware } from './config/country.middleware';
     TitreModule,
     DepartementModule,
     VilleModule,
+    FormsModule,
     NotificationsModule,
     NotificationEmailModule,
     FirebaseModule,

--- a/backend/src/forms/dto/creer-campaign.dto.ts
+++ b/backend/src/forms/dto/creer-campaign.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsString,
+  IsOptional,
+  IsIn,
+  IsInt,
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
+
+export class CreerQuestionDto {
+  @ApiProperty({ example: 'Le contenu était-il utile ?' })
+  @IsString()
+  libelle: string;
+
+  @ApiProperty({ enum: ['rating', 'text'] })
+  @IsIn(['rating', 'text'])
+  type: 'rating' | 'text';
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsOptional()
+  @IsInt()
+  ordre?: number;
+}
+
+export class CreerSectionDto {
+  @ApiProperty({ example: 'Contenu pédagogique' })
+  @IsString()
+  titre: string;
+
+  @ApiProperty({ required: false, example: '📚' })
+  @IsOptional()
+  @IsString()
+  icone?: string;
+
+  @ApiProperty({ required: false, default: 0 })
+  @IsOptional()
+  @IsInt()
+  ordre?: number;
+
+  @ApiProperty({ type: [CreerQuestionDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreerQuestionDto)
+  questions: CreerQuestionDto[];
+}
+
+export class CreerCampaignDto {
+  @ApiProperty({ example: 'Enquête de satisfaction — Juillet' })
+  @IsString()
+  titre: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, default: 'app_open' })
+  @IsOptional()
+  @IsString()
+  trigger_type?: string;
+
+  @ApiProperty({ type: [CreerSectionDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreerSectionDto)
+  sections: CreerSectionDto[];
+}

--- a/backend/src/forms/dto/filter-campaign.dto.ts
+++ b/backend/src/forms/dto/filter-campaign.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsIn } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class FilterCampaignDto extends PaginationDto {
+  @IsOptional()
+  @IsIn(['draft', 'active', 'archived'])
+  statut?: 'draft' | 'active' | 'archived';
+}

--- a/backend/src/forms/dto/maj-campaign.dto.ts
+++ b/backend/src/forms/dto/maj-campaign.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+// Metadata-only update (titre/description). Structure is edited via PUT (frozen
+// once responses exist); statut via PATCH /:uuid/statut.
+export class MajCampaignDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  titre?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/backend/src/forms/dto/maj-statut.dto.ts
+++ b/backend/src/forms/dto/maj-statut.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+
+export class MajStatutDto {
+  @ApiProperty({ enum: ['draft', 'active', 'archived'] })
+  @IsIn(['draft', 'active', 'archived'])
+  statut: 'draft' | 'active' | 'archived';
+}

--- a/backend/src/forms/dto/soumettre-reponse.dto.ts
+++ b/backend/src/forms/dto/soumettre-reponse.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsUUID,
+  IsOptional,
+  IsInt,
+  Min,
+  Max,
+  IsString,
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
+
+export class SoumettreAnswerDto {
+  @ApiProperty()
+  @IsUUID()
+  question_id: string;
+
+  @ApiProperty({ required: false, minimum: 1, maximum: 4 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(4)
+  rating?: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  texte?: string;
+}
+
+export class SoumettreReponseDto {
+  @ApiProperty({ type: [SoumettreAnswerDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SoumettreAnswerDto)
+  answers: SoumettreAnswerDto[];
+}

--- a/backend/src/forms/entities/form-answer.entity.ts
+++ b/backend/src/forms/entities/form-answer.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { FormResponse } from './form-response.entity';
+import { FormQuestion } from './form-question.entity';
+
+@Entity('form_answers')
+export class FormAnswer {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  response_id: string;
+
+  @Column('uuid')
+  question_id: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'smallint', nullable: true })
+  rating: number | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'text', nullable: true })
+  texte: string | null;
+
+  @ManyToOne(() => FormResponse, (response) => response.answers, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'response_id' })
+  response: FormResponse;
+
+  @ManyToOne(() => FormQuestion, (question) => question.answers, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'question_id' })
+  question: FormQuestion;
+}

--- a/backend/src/forms/entities/form-campaign.entity.ts
+++ b/backend/src/forms/entities/form-campaign.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  OneToMany,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { FormSection } from './form-section.entity';
+
+export type CampaignStatut = 'draft' | 'active' | 'archived';
+
+@Entity('form_campaigns')
+export class FormCampaign {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty()
+  @Column()
+  titre: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @ApiProperty({ enum: ['draft', 'active', 'archived'] })
+  @Column({ type: 'varchar', length: 20, default: 'draft' })
+  statut: CampaignStatut;
+
+  @ApiProperty()
+  @Column({ type: 'varchar', length: 30, default: 'app_open' })
+  trigger_type: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  date_debut: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  date_fin: Date | null;
+
+  @Column({ type: 'varchar', length: 50, default: 'benin' })
+  pays: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'integer', nullable: true })
+  created_by: number | null;
+
+  @ApiProperty()
+  @CreateDateColumn({ type: 'timestamp with time zone', name: 'date_creation' })
+  date_creation: Date;
+
+  @OneToMany(() => FormSection, (section) => section.campaign)
+  sections: FormSection[];
+}

--- a/backend/src/forms/entities/form-question.entity.ts
+++ b/backend/src/forms/entities/form-question.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  OneToMany,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { FormSection } from './form-section.entity';
+import { FormAnswer } from './form-answer.entity';
+
+export type QuestionType = 'rating' | 'text';
+
+@Entity('form_questions')
+export class FormQuestion {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  section_id: string;
+
+  @ApiProperty()
+  @Column()
+  libelle: string;
+
+  @ApiProperty({ enum: ['rating', 'text'] })
+  @Column({ type: 'varchar', length: 20 })
+  type: QuestionType;
+
+  @ApiProperty()
+  @Column({ type: 'int', default: 0 })
+  ordre: number;
+
+  @ManyToOne(() => FormSection, (section) => section.questions, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'section_id' })
+  section: FormSection;
+
+  @OneToMany(() => FormAnswer, (answer) => answer.question)
+  answers: FormAnswer[];
+}

--- a/backend/src/forms/entities/form-response.entity.ts
+++ b/backend/src/forms/entities/form-response.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  OneToMany,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { FormCampaign } from './form-campaign.entity';
+import { FormAnswer } from './form-answer.entity';
+
+@Entity('form_responses')
+export class FormResponse {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  campaign_id: string;
+
+  @ApiProperty()
+  @Column({ type: 'integer' })
+  user_id: number;
+
+  @Column({ type: 'varchar', length: 50, default: 'benin' })
+  pays: string;
+
+  @ApiProperty()
+  @CreateDateColumn({ type: 'timestamp with time zone', name: 'submitted_at' })
+  submitted_at: Date;
+
+  @ManyToOne(() => FormCampaign, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'campaign_id' })
+  campaign: FormCampaign;
+
+  @OneToMany(() => FormAnswer, (answer) => answer.response)
+  answers: FormAnswer[];
+}

--- a/backend/src/forms/entities/form-section.entity.ts
+++ b/backend/src/forms/entities/form-section.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  OneToMany,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { FormCampaign } from './form-campaign.entity';
+import { FormQuestion } from './form-question.entity';
+
+@Entity('form_sections')
+export class FormSection {
+  @ApiProperty()
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  campaign_id: string;
+
+  @ApiProperty()
+  @Column()
+  titre: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  icone: string | null;
+
+  @ApiProperty()
+  @Column({ type: 'int', default: 0 })
+  ordre: number;
+
+  @ManyToOne(() => FormCampaign, (campaign) => campaign.sections, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'campaign_id' })
+  campaign: FormCampaign;
+
+  @OneToMany(() => FormQuestion, (question) => question.section)
+  questions: FormQuestion[];
+}

--- a/backend/src/forms/forms-user.controller.ts
+++ b/backend/src/forms/forms-user.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { FormsService } from './forms.service';
+import { SoumettreReponseDto } from './dto/soumettre-reponse.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+
+// User-facing form endpoints (any authenticated user, no admin role).
+// Mounted on /forms; declared BEFORE FormsController so the literal
+// `/forms/active` route is matched ahead of the admin `/forms/:uuid`.
+@ApiTags('forms')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('forms')
+export class FormsUserController {
+  constructor(private readonly formsService: FormsService) {}
+
+  @Get('active')
+  @ApiOperation({
+    summary:
+      "Campagne active du pays non encore répondue par l'utilisateur (null sinon)",
+  })
+  getActive(@CurrentCountry() pays: string, @Request() req: any) {
+    return this.formsService.getActive(pays, req.user.utilisateurId);
+  }
+
+  @Post(':uuid/responses')
+  @ApiOperation({ summary: 'Soumettre une réponse à une campagne' })
+  submit(
+    @CurrentCountry() pays: string,
+    @Param('uuid') uuid: string,
+    @Body() dto: SoumettreReponseDto,
+    @Request() req: any,
+  ) {
+    return this.formsService.submitResponse(
+      pays,
+      uuid,
+      req.user.utilisateurId,
+      dto,
+    );
+  }
+}

--- a/backend/src/forms/forms.controller.ts
+++ b/backend/src/forms/forms.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { FormsService } from './forms.service';
+import { CreerCampaignDto } from './dto/creer-campaign.dto';
+import { MajStatutDto } from './dto/maj-statut.dto';
+import { FilterCampaignDto } from './dto/filter-campaign.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+
+@ApiTags('forms')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(RoleType.ADMIN)
+@Controller('forms')
+export class FormsController {
+  constructor(private readonly formsService: FormsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Créer une campagne (arbre sections + questions)' })
+  create(
+    @CurrentCountry() pays: string,
+    @Body() dto: CreerCampaignDto,
+    @Request() req: any,
+  ) {
+    return this.formsService.create(pays, dto, req.user?.utilisateurId ?? null);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Lister les campagnes' })
+  findAll(
+    @CurrentCountry() pays: string,
+    @Query() filterDto: FilterCampaignDto,
+  ) {
+    return this.formsService.findAll(pays, filterDto);
+  }
+
+  @Get(':uuid')
+  @ApiOperation({ summary: "Récupérer une campagne (arbre complet)" })
+  findOne(@CurrentCountry() pays: string, @Param('uuid') uuid: string) {
+    return this.formsService.findOne(pays, uuid);
+  }
+
+  @Get(':uuid/results')
+  @ApiOperation({ summary: 'KPI / résultats agrégés d\'une campagne' })
+  getResults(@CurrentCountry() pays: string, @Param('uuid') uuid: string) {
+    return this.formsService.getResults(pays, uuid);
+  }
+
+  @Put(':uuid')
+  @ApiOperation({ summary: "Remplacer l'arbre complet d'une campagne" })
+  update(
+    @CurrentCountry() pays: string,
+    @Param('uuid') uuid: string,
+    @Body() dto: CreerCampaignDto,
+  ) {
+    return this.formsService.update(pays, uuid, dto);
+  }
+
+  @Patch(':uuid/statut')
+  @ApiOperation({ summary: 'Changer le statut (draft/active/archived)' })
+  updateStatut(
+    @CurrentCountry() pays: string,
+    @Param('uuid') uuid: string,
+    @Body() dto: MajStatutDto,
+  ) {
+    return this.formsService.updateStatut(pays, uuid, dto);
+  }
+
+  @Delete(':uuid')
+  @ApiOperation({ summary: 'Supprimer une campagne' })
+  remove(@CurrentCountry() pays: string, @Param('uuid') uuid: string) {
+    return this.formsService.remove(pays, uuid);
+  }
+}

--- a/backend/src/forms/forms.controller.ts
+++ b/backend/src/forms/forms.controller.ts
@@ -15,6 +15,7 @@ import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { FormsService } from './forms.service';
 import { CreerCampaignDto } from './dto/creer-campaign.dto';
 import { MajStatutDto } from './dto/maj-statut.dto';
+import { MajCampaignDto } from './dto/maj-campaign.dto';
 import { FilterCampaignDto } from './dto/filter-campaign.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -69,6 +70,18 @@ export class FormsController {
     @Body() dto: CreerCampaignDto,
   ) {
     return this.formsService.update(pays, uuid, dto);
+  }
+
+  @Patch(':uuid')
+  @ApiOperation({
+    summary: 'Modifier les métadonnées (titre/description) — sans toucher à la structure',
+  })
+  updateMeta(
+    @CurrentCountry() pays: string,
+    @Param('uuid') uuid: string,
+    @Body() dto: MajCampaignDto,
+  ) {
+    return this.formsService.updateMeta(pays, uuid, dto);
   }
 
   @Patch(':uuid/statut')

--- a/backend/src/forms/forms.module.ts
+++ b/backend/src/forms/forms.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FormsController } from './forms.controller';
+import { FormsUserController } from './forms-user.controller';
+import { FormsService } from './forms.service';
+import { FormCampaign } from './entities/form-campaign.entity';
+import { FormSection } from './entities/form-section.entity';
+import { FormQuestion } from './entities/form-question.entity';
+import { FormResponse } from './entities/form-response.entity';
+import { FormAnswer } from './entities/form-answer.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      FormCampaign,
+      FormSection,
+      FormQuestion,
+      FormResponse,
+      FormAnswer,
+    ]),
+  ],
+  // FormsUserController first: its literal `/forms/active` route must be
+  // registered before the admin `/forms/:uuid` param route.
+  controllers: [FormsUserController, FormsController],
+  providers: [FormsService],
+  exports: [FormsService],
+})
+export class FormsModule {}

--- a/backend/src/forms/forms.service.ts
+++ b/backend/src/forms/forms.service.ts
@@ -1,0 +1,420 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
+import { Repository, DataSource, EntityManager, QueryFailedError } from 'typeorm';
+import { FormCampaign } from './entities/form-campaign.entity';
+import { FormSection } from './entities/form-section.entity';
+import { FormQuestion } from './entities/form-question.entity';
+import { FormResponse } from './entities/form-response.entity';
+import { FormAnswer } from './entities/form-answer.entity';
+import { CreerCampaignDto, CreerSectionDto } from './dto/creer-campaign.dto';
+import { MajStatutDto } from './dto/maj-statut.dto';
+import { FilterCampaignDto } from './dto/filter-campaign.dto';
+import { SoumettreReponseDto } from './dto/soumettre-reponse.dto';
+import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
+
+const PG_UNIQUE_VIOLATION = '23505';
+
+@Injectable()
+export class FormsService {
+  private readonly logger = new Logger(FormsService.name);
+
+  constructor(
+    @InjectRepository(FormCampaign)
+    private readonly campaignRepository: Repository<FormCampaign>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ── Serialization (ids exposed as `uuid`; no internal FK id columns leak) ──
+
+  private serializeCampaign(c: FormCampaign) {
+    return {
+      uuid: c.id,
+      titre: c.titre,
+      description: c.description,
+      statut: c.statut,
+      trigger_type: c.trigger_type,
+      date_debut: c.date_debut,
+      date_fin: c.date_fin,
+      pays: c.pays,
+      created_by: c.created_by,
+      date_creation: c.date_creation,
+    };
+  }
+
+  private serializeTree(c: FormCampaign) {
+    const sections = [...(c.sections ?? [])].sort((a, b) => a.ordre - b.ordre);
+    return {
+      ...this.serializeCampaign(c),
+      sections: sections.map((s) => ({
+        uuid: s.id,
+        titre: s.titre,
+        icone: s.icone,
+        ordre: s.ordre,
+        questions: [...(s.questions ?? [])]
+          .sort((a, b) => a.ordre - b.ordre)
+          .map((q) => ({
+            uuid: q.id,
+            libelle: q.libelle,
+            type: q.type,
+            ordre: q.ordre,
+          })),
+      })),
+    };
+  }
+
+  // ── Admin CRUD ──
+
+  async create(pays: string, dto: CreerCampaignDto, createdBy: number | null) {
+    const campaignId = await this.dataSource.transaction(async (manager) => {
+      const campaign = await manager.save(
+        manager.create(FormCampaign, {
+          titre: dto.titre,
+          description: dto.description ?? null,
+          trigger_type: dto.trigger_type ?? 'app_open',
+          statut: 'draft',
+          pays,
+          created_by: createdBy,
+        }),
+      );
+      await this.saveTree(manager, campaign.id, dto.sections);
+      return campaign.id;
+    });
+
+    this.logger.log(`Campagne créée: ${dto.titre} (${campaignId}, pays: ${pays})`);
+    return this.findOne(pays, campaignId);
+  }
+
+  async update(pays: string, uuid: string, dto: CreerCampaignDto) {
+    await this.dataSource.transaction(async (manager) => {
+      const campaign = await manager.findOne(FormCampaign, {
+        where: { id: uuid, pays },
+      });
+      if (!campaign) {
+        throw new NotFoundException('Campagne non trouvée');
+      }
+      campaign.titre = dto.titre;
+      campaign.description = dto.description ?? null;
+      if (dto.trigger_type) campaign.trigger_type = dto.trigger_type;
+      await manager.save(campaign);
+
+      // Replace the whole tree — the builder always sends the full structure.
+      // Deleting sections cascades to questions (and their answers) via the DB.
+      await manager.delete(FormSection, { campaign_id: uuid });
+      await this.saveTree(manager, uuid, dto.sections);
+    });
+
+    return this.findOne(pays, uuid);
+  }
+
+  private async saveTree(
+    manager: EntityManager,
+    campaignId: string,
+    sections: CreerSectionDto[],
+  ) {
+    for (let i = 0; i < sections.length; i++) {
+      const sec = sections[i];
+      const section = await manager.save(
+        manager.create(FormSection, {
+          campaign_id: campaignId,
+          titre: sec.titre,
+          icone: sec.icone ?? null,
+          ordre: sec.ordre ?? i,
+        }),
+      );
+      const questions = (sec.questions ?? []).map((q, j) =>
+        manager.create(FormQuestion, {
+          section_id: section.id,
+          libelle: q.libelle,
+          type: q.type,
+          ordre: q.ordre ?? j,
+        }),
+      );
+      if (questions.length) await manager.save(questions);
+    }
+  }
+
+  async findAll(pays: string, filterDto: FilterCampaignDto) {
+    const { page = 1, limit = 10, statut, search } = filterDto;
+
+    const qb = this.campaignRepository
+      .createQueryBuilder('c')
+      .where('c.pays = :pays', { pays })
+      .orderBy('c.date_creation', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (statut) qb.andWhere('c.statut = :statut', { statut });
+    if (search) {
+      qb.andWhere('unaccent(c.titre) ILIKE unaccent(:search)', {
+        search: `%${search}%`,
+      });
+    }
+
+    const [campaigns, total] = await qb.getManyAndCount();
+
+    // Response counts for the listed page in one grouped query.
+    const counts = new Map<string, number>();
+    if (campaigns.length) {
+      const rows = await this.dataSource.query(
+        `SELECT campaign_id, COUNT(*)::int AS n
+           FROM form_responses
+          WHERE campaign_id = ANY($1)
+          GROUP BY campaign_id`,
+        [campaigns.map((c) => c.id)],
+      );
+      for (const r of rows) counts.set(r.campaign_id, r.n);
+    }
+
+    const data = campaigns.map((c) => ({
+      ...this.serializeCampaign(c),
+      nb_reponses: counts.get(c.id) ?? 0,
+    }));
+
+    const result: PaginationResponse<any> = {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+    return result;
+  }
+
+  async findOne(pays: string, uuid: string) {
+    const campaign = await this.loadTree(this.dataSource.manager, pays, uuid);
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+    return this.serializeTree(campaign);
+  }
+
+  private loadTree(manager: EntityManager, pays: string, uuid: string) {
+    return manager.findOne(FormCampaign, {
+      where: { id: uuid, pays },
+      relations: ['sections', 'sections.questions'],
+    });
+  }
+
+  async updateStatut(pays: string, uuid: string, dto: MajStatutDto) {
+    const campaign = await this.campaignRepository.findOne({
+      where: { id: uuid, pays },
+    });
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+    campaign.statut = dto.statut;
+    if (dto.statut === 'active' && !campaign.date_debut) {
+      campaign.date_debut = new Date();
+    }
+    if (dto.statut === 'archived' && !campaign.date_fin) {
+      campaign.date_fin = new Date();
+    }
+    await this.campaignRepository.save(campaign);
+    return this.serializeCampaign(campaign);
+  }
+
+  async remove(pays: string, uuid: string) {
+    const campaign = await this.campaignRepository.findOne({
+      where: { id: uuid, pays },
+    });
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+    // Sections/questions/responses/answers are removed by the DB (FK CASCADE).
+    await this.campaignRepository.remove(campaign);
+    return { message: 'Campagne supprimée avec succès' };
+  }
+
+  // ── Results / KPI aggregation (raw SQL, pays-scoped) ──
+
+  async getResults(pays: string, uuid: string) {
+    // Ensures the campaign exists in this pays (404 otherwise) + gives the tree.
+    const campaign = await this.loadTree(this.dataSource.manager, pays, uuid);
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+
+    const [{ total }] = await this.dataSource.query(
+      `SELECT COUNT(*)::int AS total FROM form_responses WHERE campaign_id = $1`,
+      [uuid],
+    );
+
+    const ratingRows = await this.dataSource.query(
+      `SELECT q.id AS question_id,
+              q.libelle,
+              q.ordre,
+              q.section_id,
+              COUNT(a.rating) FILTER (WHERE a.rating = 1)::int AS c1,
+              COUNT(a.rating) FILTER (WHERE a.rating = 2)::int AS c2,
+              COUNT(a.rating) FILTER (WHERE a.rating = 3)::int AS c3,
+              COUNT(a.rating) FILTER (WHERE a.rating = 4)::int AS c4,
+              COUNT(a.rating)::int AS total_reponses,
+              AVG(a.rating)::float AS moyenne
+         FROM form_questions q
+         JOIN form_sections s ON s.id = q.section_id
+         LEFT JOIN form_answers a
+                ON a.question_id = q.id AND a.rating IS NOT NULL
+        WHERE s.campaign_id = $1 AND q.type = 'rating'
+        GROUP BY q.id, q.libelle, q.ordre, q.section_id
+        ORDER BY q.ordre`,
+      [uuid],
+    );
+
+    const textRows = await this.dataSource.query(
+      `SELECT q.id AS question_id,
+              a.texte,
+              r.submitted_at
+         FROM form_questions q
+         JOIN form_sections s ON s.id = q.section_id
+         JOIN form_answers a ON a.question_id = q.id
+         JOIN form_responses r ON r.id = a.response_id
+        WHERE s.campaign_id = $1 AND q.type = 'text'
+          AND a.texte IS NOT NULL AND a.texte <> ''
+        ORDER BY q.ordre, r.submitted_at DESC`,
+      [uuid],
+    );
+
+    const overTime = await this.dataSource.query(
+      `SELECT to_char(date_trunc('day', submitted_at), 'YYYY-MM-DD') AS jour,
+              COUNT(*)::int AS n
+         FROM form_responses
+        WHERE campaign_id = $1
+        GROUP BY 1
+        ORDER BY 1`,
+      [uuid],
+    );
+
+    // Section titles for grouping context in the response.
+    const sectionTitre = new Map(
+      (campaign.sections ?? []).map((s) => [s.id, s.titre]),
+    );
+
+    const rating_questions = ratingRows.map((r: any) => ({
+      uuid: r.question_id,
+      libelle: r.libelle,
+      section_titre: sectionTitre.get(r.section_id) ?? null,
+      distribution: { 1: r.c1, 2: r.c2, 3: r.c3, 4: r.c4 },
+      total_reponses: r.total_reponses,
+      moyenne: r.moyenne === null ? null : Number(r.moyenne.toFixed(2)),
+    }));
+
+    // All text questions (even those with zero answers) with their answer list.
+    const textAnswers = new Map<string, { texte: string; submitted_at: Date }[]>();
+    for (const row of textRows) {
+      const list = textAnswers.get(row.question_id) ?? [];
+      list.push({ texte: row.texte, submitted_at: row.submitted_at });
+      textAnswers.set(row.question_id, list);
+    }
+    const text_questions: any[] = [];
+    for (const s of campaign.sections ?? []) {
+      for (const q of s.questions ?? []) {
+        if (q.type === 'text') {
+          text_questions.push({
+            uuid: q.id,
+            libelle: q.libelle,
+            section_titre: s.titre,
+            reponses: textAnswers.get(q.id) ?? [],
+          });
+        }
+      }
+    }
+
+    return {
+      campaign: this.serializeCampaign(campaign),
+      total_reponses: total,
+      rating_questions,
+      text_questions,
+      reponses_par_jour: overTime.map((r: any) => ({ jour: r.jour, count: r.n })),
+    };
+  }
+
+  // ── User-facing ──
+
+  async getActive(pays: string, userId: number) {
+    const active = await this.campaignRepository
+      .createQueryBuilder('c')
+      .where('c.pays = :pays', { pays })
+      .andWhere('c.statut = :statut', { statut: 'active' })
+      .andWhere(
+        `NOT EXISTS (SELECT 1 FROM form_responses r WHERE r.campaign_id = c.id AND r.user_id = :userId)`,
+        { userId },
+      )
+      .orderBy('c.date_creation', 'DESC')
+      .getOne();
+
+    if (!active) return null;
+
+    const campaign = await this.loadTree(this.dataSource.manager, pays, active.id);
+    return campaign ? this.serializeTree(campaign) : null;
+  }
+
+  async submitResponse(
+    pays: string,
+    uuid: string,
+    userId: number,
+    dto: SoumettreReponseDto,
+  ) {
+    const campaign = await this.campaignRepository.findOne({
+      where: { id: uuid, pays },
+    });
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+    if (campaign.statut !== 'active') {
+      throw new BadRequestException("Cette campagne n'est pas active");
+    }
+
+    // Answers must target questions that belong to THIS campaign.
+    const validRows = await this.dataSource.query(
+      `SELECT q.id
+         FROM form_questions q
+         JOIN form_sections s ON s.id = q.section_id
+        WHERE s.campaign_id = $1`,
+      [uuid],
+    );
+    const validIds = new Set(validRows.map((r: any) => r.id));
+    for (const a of dto.answers) {
+      if (!validIds.has(a.question_id)) {
+        throw new BadRequestException(
+          `Question ${a.question_id} n'appartient pas à cette campagne`,
+        );
+      }
+    }
+
+    try {
+      const response = await this.dataSource.transaction(async (manager) => {
+        const saved = await manager.save(
+          manager.create(FormResponse, {
+            campaign_id: uuid,
+            user_id: userId,
+            pays,
+          }),
+        );
+        const answers = dto.answers.map((a) =>
+          manager.create(FormAnswer, {
+            response_id: saved.id,
+            question_id: a.question_id,
+            rating: a.rating ?? null,
+            texte: a.texte ?? null,
+          }),
+        );
+        if (answers.length) await manager.save(answers);
+        return saved;
+      });
+
+      return { uuid: response.id, submitted_at: response.submitted_at };
+    } catch (e) {
+      if (e instanceof QueryFailedError && (e as any).code === PG_UNIQUE_VIOLATION) {
+        throw new ConflictException('Vous avez déjà répondu à cette campagne');
+      }
+      throw e;
+    }
+  }
+}

--- a/backend/src/forms/forms.service.ts
+++ b/backend/src/forms/forms.service.ts
@@ -14,6 +14,7 @@ import { FormResponse } from './entities/form-response.entity';
 import { FormAnswer } from './entities/form-answer.entity';
 import { CreerCampaignDto, CreerSectionDto } from './dto/creer-campaign.dto';
 import { MajStatutDto } from './dto/maj-statut.dto';
+import { MajCampaignDto } from './dto/maj-campaign.dto';
 import { FilterCampaignDto } from './dto/filter-campaign.dto';
 import { SoumettreReponseDto } from './dto/soumettre-reponse.dto';
 import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
@@ -98,6 +99,18 @@ export class FormsService {
       });
       if (!campaign) {
         throw new NotFoundException('Campagne non trouvée');
+      }
+      // Structural edits are frozen once responses exist — replacing the tree
+      // would cascade-delete collected answers. Title/description stay editable
+      // via updateMeta; statut via updateStatut.
+      const [{ count }] = await manager.query(
+        `SELECT COUNT(*)::int AS count FROM form_responses WHERE campaign_id = $1`,
+        [uuid],
+      );
+      if (count > 0) {
+        throw new ConflictException(
+          'Impossible de modifier la structure: des réponses existent déjà',
+        );
       }
       campaign.titre = dto.titre;
       campaign.description = dto.description ?? null;
@@ -216,6 +229,21 @@ export class FormsService {
     if (dto.statut === 'archived' && !campaign.date_fin) {
       campaign.date_fin = new Date();
     }
+    await this.campaignRepository.save(campaign);
+    return this.serializeCampaign(campaign);
+  }
+
+  // Metadata-only edit (titre/description) — always allowed, never touches the
+  // section/question tree, so it stays available after responses exist.
+  async updateMeta(pays: string, uuid: string, dto: MajCampaignDto) {
+    const campaign = await this.campaignRepository.findOne({
+      where: { id: uuid, pays },
+    });
+    if (!campaign) {
+      throw new NotFoundException('Campagne non trouvée');
+    }
+    if (dto.titre !== undefined) campaign.titre = dto.titre;
+    if (dto.description !== undefined) campaign.description = dto.description ?? null;
     await this.campaignRepository.save(campaign);
     return this.serializeCampaign(campaign);
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,9 @@ import Indicateurs from "./pages/Indicateurs";
 import StatistiquesApprobations from "./pages/StatistiquesApprobations";
 import RetraitsWallet from "./pages/RetraitsWallet";
 import ConfigurationWallet from "./pages/ConfigurationWallet";
+import EnquetesCampagnes from "./pages/EnquetesCampagnes";
+import EnquetesBuilder from "./pages/EnquetesBuilder";
+import EnquetesResultats from "./pages/EnquetesResultats";
 import Login from "./pages/Login";
 import ForgotPassword from "./pages/ForgotPassword";
 import ResetPassword from "./pages/ResetPassword";
@@ -102,6 +105,10 @@ const App = () => (
                       <Route path="/statistiques-approbations" element={<StatistiquesApprobations />} />
                       <Route path="/admin/retraits" element={<RetraitsWallet />} />
                       <Route path="/admin/wallet-configuration" element={<ConfigurationWallet />} />
+                      <Route path="/enquetes" element={<EnquetesCampagnes />} />
+                      <Route path="/enquetes/nouveau" element={<EnquetesBuilder />} />
+                      <Route path="/enquetes/:uuid/edition" element={<EnquetesBuilder />} />
+                      <Route path="/enquetes/:uuid/resultats" element={<EnquetesResultats />} />
                       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                       <Route path="*" element={<NotFound />} />
                     </Routes>

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -39,6 +39,7 @@ import {
   Banknote,
   Map,
   MapPin,
+  ClipboardList,
   type LucideIcon,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -144,6 +145,13 @@ const navTree: NavItem[] = [
       { title: "Avis", icon: Star },
       { title: "Types (Services, Offres)", icon: Layers, url: "/admin/service-types" },
       { title: "Compétences", icon: Cog, url: "/admin/competences" },
+    ],
+  },
+  {
+    title: "Enquêtes",
+    icon: ClipboardList,
+    children: [
+      { title: "Campagnes", icon: ClipboardList, url: "/enquetes" },
     ],
   },
   {

--- a/frontend/src/lib/services/forms.service.ts
+++ b/frontend/src/lib/services/forms.service.ts
@@ -1,0 +1,142 @@
+import { api } from '../api';
+import type { PaginationResponse, PaginationParams } from '../types/pagination';
+import { buildPaginationQuery } from '../types/pagination';
+
+export type CampaignStatut = 'draft' | 'active' | 'archived';
+export type QuestionType = 'rating' | 'text';
+
+export interface FormQuestion {
+  uuid: string;
+  libelle: string;
+  type: QuestionType;
+  ordre: number;
+}
+
+export interface FormSection {
+  uuid: string;
+  titre: string;
+  icone?: string | null;
+  ordre: number;
+  questions: FormQuestion[];
+}
+
+export interface FormCampaign {
+  uuid: string;
+  titre: string;
+  description?: string | null;
+  statut: CampaignStatut;
+  trigger_type: string;
+  date_debut?: string | null;
+  date_fin?: string | null;
+  pays?: string;
+  created_by?: number | null;
+  date_creation: string;
+}
+
+export interface FormCampaignTree extends FormCampaign {
+  sections: FormSection[];
+}
+
+export interface FormCampaignListItem extends FormCampaign {
+  nb_reponses: number;
+}
+
+// ── Builder payload (what the admin sends on save) ──
+export interface QuestionInput {
+  libelle: string;
+  type: QuestionType;
+  ordre?: number;
+}
+export interface SectionInput {
+  titre: string;
+  icone?: string;
+  ordre?: number;
+  questions: QuestionInput[];
+}
+export interface CampaignInput {
+  titre: string;
+  description?: string;
+  trigger_type?: string;
+  sections: SectionInput[];
+}
+
+// ── Results / KPI ──
+export interface RatingQuestionResult {
+  uuid: string;
+  libelle: string;
+  section_titre: string | null;
+  distribution: Record<1 | 2 | 3 | 4, number>;
+  total_reponses: number;
+  moyenne: number | null;
+}
+export interface TextQuestionResult {
+  uuid: string;
+  libelle: string;
+  section_titre: string;
+  reponses: { texte: string; submitted_at: string }[];
+}
+export interface CampaignResults {
+  campaign: FormCampaign;
+  total_reponses: number;
+  rating_questions: RatingQuestionResult[];
+  text_questions: TextQuestionResult[];
+  reponses_par_jour: { jour: string; count: number }[];
+}
+
+// The 4-point satisfaction scale — emoji/label mapping is frontend-only
+// (backend stores the smallint 1..4). Ordered best → worst for display.
+export const RATING_SCALE: { value: 1 | 2 | 3 | 4; emoji: string; label: string }[] = [
+  { value: 4, emoji: '😍', label: 'Top' },
+  { value: 3, emoji: '🙂', label: 'Utile' },
+  { value: 2, emoji: '😐', label: 'Moyen' },
+  { value: 1, emoji: '😞', label: 'Pas utile' },
+];
+
+export const STATUT_LABEL: Record<CampaignStatut, string> = {
+  draft: 'Brouillon',
+  active: 'Active',
+  archived: 'Archivée',
+};
+
+export const formsService = {
+  async getAll(
+    params?: PaginationParams & { statut?: CampaignStatut; search?: string },
+  ): Promise<PaginationResponse<FormCampaignListItem>> {
+    return api.get<PaginationResponse<FormCampaignListItem>>(
+      `/forms${buildPaginationQuery(params)}`,
+    );
+  },
+
+  async getById(uuid: string): Promise<FormCampaignTree> {
+    return api.get<FormCampaignTree>(`/forms/${uuid}`);
+  },
+
+  async getResults(uuid: string): Promise<CampaignResults> {
+    return api.get<CampaignResults>(`/forms/${uuid}/results`);
+  },
+
+  async create(data: CampaignInput): Promise<FormCampaignTree> {
+    return api.post<FormCampaignTree>('/forms', data);
+  },
+
+  async update(uuid: string, data: CampaignInput): Promise<FormCampaignTree> {
+    return api.put<FormCampaignTree>(`/forms/${uuid}`, data);
+  },
+
+  // Metadata-only edit (titre/description) — allowed even after responses exist.
+  async updateMeta(
+    uuid: string,
+    data: { titre?: string; description?: string },
+  ): Promise<FormCampaign> {
+    return api.patch<FormCampaign>(`/forms/${uuid}`, data);
+  },
+
+  async updateStatut(uuid: string, statut: CampaignStatut): Promise<FormCampaign> {
+    return api.patch<FormCampaign>(`/forms/${uuid}/statut`, { statut });
+  },
+
+  async delete(uuid: string): Promise<{ message: string }> {
+    const country = api.getCountry();
+    return api.delete(`/forms/${uuid}?country=${encodeURIComponent(country)}`);
+  },
+};

--- a/frontend/src/pages/EnquetesBuilder.tsx
+++ b/frontend/src/pages/EnquetesBuilder.tsx
@@ -1,0 +1,413 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Plus,
+  Trash2,
+  ChevronUp,
+  ChevronDown,
+  Loader2,
+  Save,
+  Lock,
+  GripVertical,
+  Star,
+  Type as TypeIcon,
+  Eye,
+} from "lucide-react";
+import {
+  formsService,
+  RATING_SCALE,
+  type QuestionType,
+  type CampaignInput,
+} from "@/lib/services/forms.service";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+// Local drafts use a stable client key (React key) separate from any server uuid.
+let _keySeq = 0;
+const nextKey = () => `k${++_keySeq}`;
+
+interface QDraft {
+  key: string;
+  libelle: string;
+  type: QuestionType;
+}
+interface SDraft {
+  key: string;
+  titre: string;
+  icone: string;
+  questions: QDraft[];
+}
+
+const EMOJI_QUICKPICK = ["📚", "⭐", "💬", "🎯", "🧑‍🏫", "📝", "🚀", "❤️", "👍", "🔔"];
+
+const newQuestion = (): QDraft => ({ key: nextKey(), libelle: "", type: "rating" });
+const newSection = (): SDraft => ({
+  key: nextKey(),
+  titre: "",
+  icone: "",
+  questions: [newQuestion()],
+});
+
+// move an item within an array by delta (-1 up / +1 down), returns a new array
+function move<T>(arr: T[], i: number, delta: number): T[] {
+  const j = i + delta;
+  if (j < 0 || j >= arr.length) return arr;
+  const copy = [...arr];
+  [copy[i], copy[j]] = [copy[j], copy[i]];
+  return copy;
+}
+
+export default function EnquetesBuilder() {
+  const { uuid } = useParams<{ uuid: string }>();
+  const isEdit = !!uuid;
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [titre, setTitre] = useState("");
+  const [description, setDescription] = useState("");
+  const [sections, setSections] = useState<SDraft[]>([newSection()]);
+  const loadedRef = useRef(false);
+
+  // On edit: load the tree + response count (structure freezes once answered).
+  const { data: tree, isLoading: loadingTree } = useQuery({
+    queryKey: ["form-campaign", uuid],
+    queryFn: () => formsService.getById(uuid!),
+    enabled: isEdit,
+  });
+  const { data: results } = useQuery({
+    queryKey: ["form-campaign-results", uuid],
+    queryFn: () => formsService.getResults(uuid!),
+    enabled: isEdit,
+  });
+  const hasResponses = (results?.total_reponses ?? 0) > 0;
+  const structureLocked = isEdit && hasResponses;
+
+  useEffect(() => {
+    if (tree && !loadedRef.current) {
+      loadedRef.current = true;
+      setTitre(tree.titre);
+      setDescription(tree.description ?? "");
+      setSections(
+        (tree.sections ?? []).map((s) => ({
+          key: nextKey(),
+          titre: s.titre,
+          icone: s.icone ?? "",
+          questions: (s.questions ?? []).map((q) => ({
+            key: nextKey(),
+            libelle: q.libelle,
+            type: q.type,
+          })),
+        })),
+      );
+    }
+  }, [tree]);
+
+  // ── section / question mutations on local state ──
+  const patchSection = (i: number, patch: Partial<SDraft>) =>
+    setSections((prev) => prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+  const patchQuestion = (si: number, qi: number, patch: Partial<QDraft>) =>
+    setSections((prev) =>
+      prev.map((s, idx) =>
+        idx === si
+          ? { ...s, questions: s.questions.map((q, j) => (j === qi ? { ...q, ...patch } : q)) }
+          : s,
+      ),
+    );
+
+  const addSection = () => setSections((p) => [...p, newSection()]);
+  const removeSection = (i: number) => setSections((p) => p.filter((_, idx) => idx !== i));
+  const moveSection = (i: number, d: number) => setSections((p) => move(p, i, d));
+
+  const addQuestion = (si: number) =>
+    setSections((p) =>
+      p.map((s, idx) => (idx === si ? { ...s, questions: [...s.questions, newQuestion()] } : s)),
+    );
+  const removeQuestion = (si: number, qi: number) =>
+    setSections((p) =>
+      p.map((s, idx) =>
+        idx === si ? { ...s, questions: s.questions.filter((_, j) => j !== qi) } : s,
+      ),
+    );
+  const moveQuestion = (si: number, qi: number, d: number) =>
+    setSections((p) =>
+      p.map((s, idx) => (idx === si ? { ...s, questions: move(s.questions, qi, d) } : s)),
+    );
+
+  // ── validation + payload ──
+  const validationError = useMemo(() => {
+    if (!titre.trim()) return "Le titre de la campagne est requis.";
+    if (sections.length === 0) return "Ajoutez au moins une section.";
+    for (const s of sections) {
+      if (!s.titre.trim()) return "Chaque section doit avoir un titre.";
+      if (s.questions.length === 0) return `La section « ${s.titre} » doit contenir au moins une question.`;
+      for (const q of s.questions) {
+        if (!q.libelle.trim()) return "Chaque question doit avoir un libellé.";
+      }
+    }
+    return null;
+  }, [titre, sections]);
+
+  const buildPayload = (): CampaignInput => ({
+    titre: titre.trim(),
+    description: description.trim() || undefined,
+    sections: sections.map((s, si) => ({
+      titre: s.titre.trim(),
+      icone: s.icone.trim() || undefined,
+      ordre: si,
+      questions: s.questions.map((q, qi) => ({
+        libelle: q.libelle.trim(),
+        type: q.type,
+        ordre: qi,
+      })),
+    })),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (structureLocked) {
+        // Structure is frozen — only metadata may change.
+        return formsService.updateMeta(uuid!, {
+          titre: titre.trim(),
+          description: description.trim(),
+        });
+      }
+      const payload = buildPayload();
+      return isEdit ? formsService.update(uuid!, payload) : formsService.create(payload);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["form-campaigns"] });
+      queryClient.invalidateQueries({ queryKey: ["form-campaign", uuid] });
+      toast({ title: "Enregistrée", description: "La campagne a été enregistrée." });
+      navigate("/enquetes");
+    },
+    onError: (e: any) =>
+      toast({
+        title: "Erreur",
+        description: e.message || "Échec de l'enregistrement",
+        variant: "destructive",
+      }),
+  });
+
+  const canSave = structureLocked ? !!titre.trim() : !validationError;
+
+  if (isEdit && loadingTree) {
+    return (
+      <div className="flex h-[400px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => navigate("/enquetes")}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+              {isEdit ? "Modifier la campagne" : "Nouvelle campagne"}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Composez les sections et questions ; l'aperçu montre le rendu mobile.
+            </p>
+          </div>
+        </div>
+        <Button className="gap-2" disabled={!canSave || saveMutation.isPending} onClick={() => saveMutation.mutate()}>
+          {saveMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          Enregistrer
+        </Button>
+      </div>
+
+      {structureLocked && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-700">
+          <Lock className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            Cette campagne a déjà reçu des réponses : la structure est verrouillée. Seuls le
+            titre et la description peuvent être modifiés.
+          </span>
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_minmax(320px,420px)]">
+        {/* ── Builder column ── */}
+        <div className="space-y-5">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Informations générales</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-2">
+                <Label htmlFor="titre">Titre *</Label>
+                <Input id="titre" value={titre} onChange={(e) => setTitre(e.target.value)} placeholder="Enquête de satisfaction — Juillet" />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="desc">Description</Label>
+                <Textarea id="desc" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Objet de l'enquête (optionnel)" />
+              </div>
+            </CardContent>
+          </Card>
+
+          {sections.map((s, si) => (
+            <Card key={s.key} className={cn(structureLocked && "opacity-70")}>
+              <CardHeader className="flex flex-row items-center gap-2 space-y-0 pb-3">
+                <GripVertical className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="flex-1 text-sm text-muted-foreground">
+                  Section {si + 1}
+                </CardTitle>
+                <div className="flex items-center gap-1">
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={structureLocked || si === 0} title="Monter" onClick={() => moveSection(si, -1)}>
+                    <ChevronUp className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={structureLocked || si === sections.length - 1} title="Descendre" onClick={() => moveSection(si, 1)}>
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" className="h-7 w-7" disabled={structureLocked || sections.length === 1} title="Supprimer la section" onClick={() => removeSection(si)}>
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex gap-3">
+                  <div className="grid w-20 gap-1.5">
+                    <Label className="text-xs">Icône</Label>
+                    <Input value={s.icone} maxLength={4} disabled={structureLocked} onChange={(e) => patchSection(si, { icone: e.target.value })} className="text-center text-lg" placeholder="🙂" />
+                  </div>
+                  <div className="grid flex-1 gap-1.5">
+                    <Label className="text-xs">Titre de la section *</Label>
+                    <Input value={s.titre} disabled={structureLocked} onChange={(e) => patchSection(si, { titre: e.target.value })} placeholder="Contenu pédagogique" />
+                  </div>
+                </div>
+                {!structureLocked && (
+                  <div className="flex flex-wrap gap-1">
+                    {EMOJI_QUICKPICK.map((em) => (
+                      <button key={em} type="button" className="rounded-md border px-2 py-1 text-base hover:bg-accent" onClick={() => patchSection(si, { icone: em })}>
+                        {em}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label className="text-xs">Questions</Label>
+                  {s.questions.map((q, qi) => (
+                    <div key={q.key} className="flex items-center gap-2 rounded-md border bg-muted/30 p-2">
+                      <div className="flex flex-col">
+                        <Button variant="ghost" size="icon" className="h-5 w-6" disabled={structureLocked || qi === 0} onClick={() => moveQuestion(si, qi, -1)}>
+                          <ChevronUp className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button variant="ghost" size="icon" className="h-5 w-6" disabled={structureLocked || qi === s.questions.length - 1} onClick={() => moveQuestion(si, qi, 1)}>
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                      <Input value={q.libelle} disabled={structureLocked} onChange={(e) => patchQuestion(si, qi, { libelle: e.target.value })} placeholder="Libellé de la question" className="flex-1" />
+                      <Select value={q.type} disabled={structureLocked} onValueChange={(v) => patchQuestion(si, qi, { type: v as QuestionType })}>
+                        <SelectTrigger className="w-[130px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="rating">
+                            <span className="flex items-center gap-1.5"><Star className="h-3.5 w-3.5" /> Note</span>
+                          </SelectItem>
+                          <SelectItem value="text">
+                            <span className="flex items-center gap-1.5"><TypeIcon className="h-3.5 w-3.5" /> Texte</span>
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Button variant="ghost" size="icon" className="h-7 w-7" disabled={structureLocked || s.questions.length === 1} onClick={() => removeQuestion(si, qi)}>
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  ))}
+                  {!structureLocked && (
+                    <Button variant="outline" size="sm" className="gap-2" onClick={() => addQuestion(si)}>
+                      <Plus className="h-3.5 w-3.5" /> Ajouter une question
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+
+          {!structureLocked && (
+            <Button variant="outline" className="w-full gap-2 border-dashed" onClick={addSection}>
+              <Plus className="h-4 w-4" /> Ajouter une section
+            </Button>
+          )}
+
+          {!structureLocked && validationError && (
+            <p className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive">
+              {validationError}
+            </p>
+          )}
+        </div>
+
+        {/* ── Live preview column ── */}
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          <Card className="border-primary/20 bg-muted/20">
+            <CardHeader className="flex flex-row items-center gap-2 space-y-0 pb-3">
+              <Eye className="h-4 w-4 text-primary" />
+              <CardTitle className="text-sm">Aperçu (rendu mobile)</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">{titre || "Titre de la campagne"}</h3>
+                {description && <p className="text-sm text-muted-foreground">{description}</p>}
+              </div>
+              {sections.map((s) => (
+                <div key={s.key} className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    {s.icone && <span className="text-lg">{s.icone}</span>}
+                    <h4 className="font-medium text-foreground">{s.titre || "Section sans titre"}</h4>
+                  </div>
+                  {s.questions.map((q) => (
+                    <div key={q.key} className="space-y-2 rounded-lg border bg-background p-3">
+                      <p className="text-sm font-medium text-foreground">{q.libelle || "Question…"}</p>
+                      {q.type === "rating" ? (
+                        <div className="flex justify-between gap-1">
+                          {RATING_SCALE.map((r) => (
+                            <div key={r.value} className="flex flex-1 flex-col items-center gap-1 rounded-md border py-2">
+                              <span className="text-xl">{r.emoji}</span>
+                              <span className="text-[10px] text-muted-foreground">{r.label}</span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <Textarea placeholder="Votre réponse…" disabled className="resize-none bg-muted/40" rows={2} />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ))}
+              {sections.length === 0 && (
+                <Badge variant="outline">Ajoutez une section pour voir l'aperçu</Badge>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/EnquetesCampagnes.tsx
+++ b/frontend/src/pages/EnquetesCampagnes.tsx
@@ -1,0 +1,318 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  ClipboardList,
+  Plus,
+  Pencil,
+  Trash2,
+  Loader2,
+  BarChart3,
+  Play,
+  Archive,
+  ChevronLeft,
+  ChevronRight,
+  MessageSquareText,
+} from "lucide-react";
+import {
+  formsService,
+  STATUT_LABEL,
+  type CampaignStatut,
+  type FormCampaignListItem,
+} from "@/lib/services/forms.service";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+const STATUT_BADGE: Record<CampaignStatut, string> = {
+  draft: "bg-muted text-muted-foreground",
+  active: "bg-emerald-500/10 text-emerald-600 border-emerald-500/20",
+  archived: "bg-slate-500/10 text-slate-500 border-slate-500/20",
+};
+
+const fmtDate = (d?: string | null) =>
+  d ? new Date(d).toLocaleDateString("fr-FR", { day: "2-digit", month: "short", year: "numeric" }) : "—";
+
+const STATUT_FILTERS: { value: CampaignStatut | "all"; label: string }[] = [
+  { value: "all", label: "Tous les statuts" },
+  { value: "draft", label: "Brouillons" },
+  { value: "active", label: "Actives" },
+  { value: "archived", label: "Archivées" },
+];
+
+export default function EnquetesCampagnes() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [statut, setStatut] = useState<CampaignStatut | "all">("all");
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["form-campaigns", statut, page, limit],
+    queryFn: () =>
+      formsService.getAll({
+        page,
+        limit,
+        ...(statut !== "all" ? { statut } : {}),
+      }),
+  });
+  const campaigns = data?.data ?? [];
+  const totalPages = data?.totalPages ?? 1;
+
+  const statutMutation = useMutation({
+    mutationFn: ({ uuid, next }: { uuid: string; next: CampaignStatut }) =>
+      formsService.updateStatut(uuid, next),
+    onSuccess: (_r, v) => {
+      queryClient.invalidateQueries({ queryKey: ["form-campaigns"] });
+      toast({
+        title: "Statut mis à jour",
+        description: `La campagne est désormais « ${STATUT_LABEL[v.next]} ».`,
+      });
+    },
+    onError: (e: any) =>
+      toast({ title: "Erreur", description: e.message || "Échec", variant: "destructive" }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (uuid: string) => formsService.delete(uuid),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["form-campaigns"] });
+      setDeleteId(null);
+      toast({ title: "Supprimée", description: "Campagne supprimée avec succès." });
+    },
+    onError: (e: any) =>
+      toast({ title: "Erreur", description: e.message || "Échec", variant: "destructive" }),
+  });
+
+  const StatutAction = ({ c }: { c: FormCampaignListItem }) => {
+    if (c.statut === "active") {
+      return (
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Archiver"
+          onClick={() => statutMutation.mutate({ uuid: c.uuid, next: "archived" })}
+        >
+          <Archive className="h-4 w-4 text-slate-500" />
+        </Button>
+      );
+    }
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        title={c.statut === "draft" ? "Activer" : "Réactiver"}
+        onClick={() => statutMutation.mutate({ uuid: c.uuid, next: "active" })}
+      >
+        <Play className="h-4 w-4 text-emerald-600" />
+      </Button>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-primary/10 p-2.5 text-primary">
+            <ClipboardList className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">Enquêtes</h1>
+            <p className="text-muted-foreground">
+              Campagnes de satisfaction servies à l'application mobile
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Select
+            value={statut}
+            onValueChange={(v) => {
+              setStatut(v as CampaignStatut | "all");
+              setPage(1);
+            }}
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUT_FILTERS.map((f) => (
+                <SelectItem key={f.value} value={f.value}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button className="gap-2" onClick={() => navigate("/enquetes/nouveau")}>
+            <Plus className="h-4 w-4" /> Nouvelle campagne
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Campagnes</CardTitle>
+          <CardDescription>
+            {data?.total ?? 0} campagne{(data?.total ?? 0) > 1 ? "s" : ""}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex h-48 items-center justify-center">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+          ) : campaigns.length === 0 ? (
+            <div className="py-12 text-center text-muted-foreground">
+              Aucune campagne. Créez-en une pour commencer.
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Titre</TableHead>
+                  <TableHead>Statut</TableHead>
+                  <TableHead className="text-center">Réponses</TableHead>
+                  <TableHead>Début</TableHead>
+                  <TableHead>Créée le</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {campaigns.map((c) => (
+                  <TableRow key={c.uuid}>
+                    <TableCell className="font-medium">
+                      <button
+                        className="text-left hover:underline"
+                        onClick={() => navigate(`/enquetes/${c.uuid}/resultats`)}
+                      >
+                        {c.titre}
+                      </button>
+                      {c.description && (
+                        <p className="text-xs text-muted-foreground line-clamp-1">
+                          {c.description}
+                        </p>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={cn("font-medium", STATUT_BADGE[c.statut])}>
+                        {STATUT_LABEL[c.statut]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <span className="inline-flex items-center gap-1 tabular-nums">
+                        <MessageSquareText className="h-3.5 w-3.5 text-muted-foreground" />
+                        {c.nb_reponses}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {fmtDate(c.date_debut)}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {fmtDate(c.date_creation)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="Résultats"
+                          onClick={() => navigate(`/enquetes/${c.uuid}/resultats`)}
+                        >
+                          <BarChart3 className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="Éditer"
+                          onClick={() => navigate(`/enquetes/${c.uuid}/edition`)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <StatutAction c={c} />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="Supprimer"
+                          onClick={() => setDeleteId(c.uuid)}
+                        >
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center space-x-2 py-2">
+          <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">Page {page} sur {totalPages}</span>
+          <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      <AlertDialog open={deleteId !== null} onOpenChange={(open) => !open && setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer la campagne ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Cette action est irréversible et supprime aussi les réponses déjà collectées.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteId && deleteMutation.mutate(deleteId)}
+              className="bg-destructive text-destructive-foreground"
+            >
+              Supprimer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/EnquetesResultats.tsx
+++ b/frontend/src/pages/EnquetesResultats.tsx
@@ -1,0 +1,331 @@
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Loader2,
+  MessageSquareText,
+  Star,
+  Users,
+  Gauge,
+  TrendingUp,
+  Quote,
+} from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  formsService,
+  RATING_SCALE,
+  STATUT_LABEL,
+  type CampaignStatut,
+} from "@/lib/services/forms.service";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+const STATUT_BADGE: Record<CampaignStatut, string> = {
+  draft: "bg-muted text-muted-foreground",
+  active: "bg-emerald-500/10 text-emerald-600 border-emerald-500/20",
+  archived: "bg-slate-500/10 text-slate-500 border-slate-500/20",
+};
+
+// Per-rating-value colours (1 worst → 4 best), reused by chart + legend.
+const VALUE_COLOR: Record<1 | 2 | 3 | 4, string> = {
+  1: "#f43f5e", // rose — Pas utile
+  2: "#f59e0b", // amber — Moyen
+  3: "#0ea5e9", // sky — Utile
+  4: "#10b981", // emerald — Top
+};
+
+const nf = (v: number) => v.toLocaleString("fr-FR");
+const fmtDay = (d: string) =>
+  new Date(d + "T00:00:00").toLocaleDateString("fr-FR", { day: "2-digit", month: "short" });
+
+// Static accent classes (Tailwind JIT can't see interpolated class names).
+type Accent = "primary" | "emerald" | "amber" | "violet";
+const ACCENT_TILE: Record<Accent, string> = {
+  primary: "bg-primary/10 text-primary",
+  emerald: "bg-emerald-500/10 text-emerald-600",
+  amber: "bg-amber-500/10 text-amber-600",
+  violet: "bg-violet-500/10 text-violet-600",
+};
+
+function StatTile({
+  label,
+  value,
+  icon: Icon,
+  sub,
+  accent = "primary",
+}: {
+  label: string;
+  value: string;
+  icon: any;
+  sub?: string;
+  accent?: Accent;
+}) {
+  return (
+    <Card className="shadow-sm">
+      <CardContent className="p-5">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-muted-foreground">{label}</p>
+          <div className={cn("rounded-lg p-2", ACCENT_TILE[accent])}>
+            <Icon className="h-5 w-5" />
+          </div>
+        </div>
+        <p className="mt-2 text-4xl font-bold tabular-nums tracking-tight text-card-foreground">{value}</p>
+        {sub && <p className="mt-1 text-xs text-muted-foreground">{sub}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function EnquetesResultats() {
+  const { uuid } = useParams<{ uuid: string }>();
+  const navigate = useNavigate();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["form-campaign-results", uuid],
+    queryFn: () => formsService.getResults(uuid!),
+    enabled: !!uuid,
+  });
+
+  // Overall satisfaction = mean rating across ALL rating answers (weighted).
+  const overall = useMemo(() => {
+    if (!data) return null;
+    let num = 0;
+    let den = 0;
+    for (const q of data.rating_questions) {
+      if (q.moyenne != null && q.total_reponses > 0) {
+        num += q.moyenne * q.total_reponses;
+        den += q.total_reponses;
+      }
+    }
+    return den > 0 ? num / den : null;
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[400px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+  if (isError || !data) {
+    return (
+      <div className="space-y-4">
+        <Button variant="ghost" size="sm" className="gap-2" onClick={() => navigate("/enquetes")}>
+          <ArrowLeft className="h-4 w-4" /> Retour
+        </Button>
+        <p className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-2 text-sm text-destructive">
+          Impossible de charger les résultats.
+        </p>
+      </div>
+    );
+  }
+
+  const { campaign } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => navigate("/enquetes")}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight text-foreground">{campaign.titre}</h1>
+              <Badge variant="outline" className={cn("font-medium", STATUT_BADGE[campaign.statut])}>
+                {STATUT_LABEL[campaign.statut]}
+              </Badge>
+            </div>
+            {campaign.description && <p className="text-sm text-muted-foreground">{campaign.description}</p>}
+          </div>
+        </div>
+      </div>
+
+      {/* Summary tiles */}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <StatTile label="Réponses totales" value={nf(data.total_reponses)} icon={Users} sub="utilisateurs ayant répondu" />
+        <StatTile
+          label="Satisfaction moyenne"
+          value={overall != null ? `${overall.toFixed(2)} / 4` : "—"}
+          icon={Gauge}
+          accent="emerald"
+          sub="toutes questions de notation"
+        />
+        <StatTile label="Questions de notation" value={nf(data.rating_questions.length)} icon={Star} accent="amber" />
+        <StatTile label="Questions ouvertes" value={nf(data.text_questions.length)} icon={MessageSquareText} accent="violet" />
+      </div>
+
+      {data.total_reponses === 0 && (
+        <p className="rounded-md border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          Aucune réponse pour l'instant. Les graphiques s'afficheront dès la première réponse.
+        </p>
+      )}
+
+      {/* Rating distributions */}
+      {data.rating_questions.length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-foreground">Notations</h2>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {data.rating_questions.map((q) => {
+              const chartData = [...RATING_SCALE]
+                .slice()
+                .reverse()
+                .map((r) => ({
+                  label: `${r.emoji} ${r.label}`,
+                  value: r.value,
+                  count: q.distribution[r.value] ?? 0,
+                }));
+              return (
+                <Card key={q.uuid} className="shadow-sm">
+                  <CardHeader className="pb-2">
+                    {q.section_titre && (
+                      <CardDescription className="text-xs uppercase tracking-wide">
+                        {q.section_titre}
+                      </CardDescription>
+                    )}
+                    <div className="flex items-start justify-between gap-3">
+                      <CardTitle className="text-base">{q.libelle}</CardTitle>
+                      <div className="shrink-0 text-right">
+                        <p className="text-2xl font-bold tabular-nums text-emerald-600">
+                          {q.moyenne != null ? q.moyenne.toFixed(2) : "—"}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground">moyenne / 4</p>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="mb-2 text-xs text-muted-foreground">
+                      {nf(q.total_reponses)} réponse{q.total_reponses > 1 ? "s" : ""}
+                    </p>
+                    <ResponsiveContainer width="100%" height={180}>
+                      <BarChart data={chartData} margin={{ top: 8, right: 8, left: -20, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
+                        <XAxis dataKey="label" tick={{ fontSize: 10 }} tickLine={false} axisLine={false} interval={0} />
+                        <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                        <Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} cursor={{ fill: "hsl(var(--muted))", opacity: 0.4 }} />
+                        <Bar dataKey="count" name="Réponses" radius={[4, 4, 0, 0]}>
+                          {chartData.map((d) => (
+                            <Cell key={d.value} fill={VALUE_COLOR[d.value as 1 | 2 | 3 | 4]} />
+                          ))}
+                        </Bar>
+                      </BarChart>
+                    </ResponsiveContainer>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Responses over time */}
+      <Card className="shadow-sm">
+        <CardHeader className="flex flex-row items-center gap-3 space-y-0">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <TrendingUp className="h-5 w-5" />
+          </div>
+          <div>
+            <CardTitle className="text-base">Réponses dans le temps</CardTitle>
+            <CardDescription>Nombre de réponses par jour</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {data.reponses_par_jour.length === 0 ? (
+            <p className="py-12 text-center text-sm text-muted-foreground">Aucune réponse sur la période.</p>
+          ) : (
+            <ResponsiveContainer width="100%" height={240}>
+              <BarChart
+                data={data.reponses_par_jour.map((r) => ({ jour: fmtDay(r.jour), count: r.count }))}
+                margin={{ top: 8, right: 8, left: -16, bottom: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
+                <XAxis dataKey="jour" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                <YAxis allowDecimals={false} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                <Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} cursor={{ fill: "hsl(var(--muted))", opacity: 0.4 }} />
+                <Bar dataKey="count" name="Réponses" fill="#4f46e5" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Open-text answers */}
+      {data.text_questions.length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-foreground">Réponses ouvertes</h2>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {data.text_questions.map((q) => (
+              <Card key={q.uuid} className="shadow-sm">
+                <CardHeader className="pb-2">
+                  {q.section_titre && (
+                    <CardDescription className="text-xs uppercase tracking-wide">{q.section_titre}</CardDescription>
+                  )}
+                  <CardTitle className="text-base">{q.libelle}</CardTitle>
+                  <CardDescription>
+                    {q.reponses.length} réponse{q.reponses.length > 1 ? "s" : ""}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {q.reponses.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-muted-foreground">Aucune réponse.</p>
+                  ) : (
+                    <ScrollArea className="h-56 pr-3">
+                      <ul className="space-y-2">
+                        {q.reponses.map((r, i) => (
+                          <li key={i} className="flex gap-2 rounded-md border bg-muted/20 p-2.5 text-sm">
+                            <Quote className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                            <span className="text-foreground">{r.texte}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </ScrollArea>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Legend for the rating colours */}
+      {data.rating_questions.length > 0 && (
+        <div className="flex flex-wrap items-center gap-4 rounded-md border bg-muted/20 px-4 py-3">
+          <span className="text-xs font-medium text-muted-foreground">Échelle :</span>
+          {RATING_SCALE.map((r) => (
+            <span key={r.value} className="flex items-center gap-1.5 text-xs">
+              <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: VALUE_COLOR[r.value] }} />
+              {r.emoji} {r.label} ({r.value})
+            </span>
+          ))}
+          <div className="ml-auto flex items-center gap-2">
+            <Progress value={overall != null ? (overall / 4) * 100 : 0} className="h-1.5 w-24" />
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {overall != null ? `${Math.round((overall / 4) * 100)} %` : "—"}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Admin-built satisfaction-survey **campaigns** with a full builder + a per-campaign KPI/results page. The backend API is also consumed by the Flutter app (which renders the user-facing form on app-open). Country-scoped throughout.

## Deliverables

**1. Migrations (edukia-db `050`–`054`)** — already applied to **edukia-dev** and confirmed via `information_schema`. uuid PKs, idempotent (`IF NOT EXISTS`), FKs `ON DELETE CASCADE`:
`form_campaigns` → `form_sections` → `form_questions`; `form_responses` (**UNIQUE(campaign_id, user_id)**) → `form_answers` (`rating` smallint 1–4 | `texte`). Shipped in the sister `edukia-db` repo (separate PR).

**2. Backend `forms` module** (registered in `AppModule`)
- Entities `FormCampaign/Section/Question/Response/Answer` (`@ManyToOne`/`@OneToMany`).
- **Admin** (`JwtAuthGuard` + admin `RolesGuard`, `@CurrentCountry` first arg): nested **create/replace whole tree** in a transaction, `findAll(pays)` list with `nb_reponses`, `findOne(pays, uuid)` full tree, `PATCH /:uuid/statut` (draft/active/archived), `PATCH /:uuid` (titre/description), `DELETE`.
- `GET /forms/:uuid/results` — raw-SQL KPI aggregation: totals, per-rating distribution `{1,2,3,4}` + average, open-text answer lists, responses-per-day.
- **User** (`JwtAuthGuard`): `GET /forms/active` (active campaign for the caller's pays not yet answered — `NOT EXISTS` on responses, `null` if none); `POST /forms/:uuid/responses` (validates active + pays + question ownership, atomic insert).

**3. Frontend admin (React)**
- `formsService` (campaigns CRUD + statut + results).
- **Campagnes** list (titre, statut badge, #réponses, dates; create/activate/archive/delete).
- **Form builder**: add/remove/**reorder** sections (titre + emoji icône) and questions (libellé + `rating`|`text`), with a **live mobile preview** (4-emoji scale 😍 Top / 🙂 Utile / 😐 Moyen / 😞 Pas utile; textarea for text).
- **Résultats/KPI** page: summary cards, per-rubric rating distribution (recharts) + average satisfaction, open-text answers, responses-over-time. New minimal **"Enquêtes"** sidebar group.

**4. Type-checks + live verification** — backend & frontend `tsc` green; end-to-end flow exercised with a minted admin JWT (build → activate → `GET /forms/active` → submit → active empties → results).

## Guarantees / decisions
- **One response per user per campaign**: DB `UNIQUE` + **409** on re-submit.
- **Structural-edit freeze**: `PUT /forms/:uuid` returns **409** (`Impossible de modifier la structure: des réponses existent déjà`) once a campaign has responses, so a tree-replace can't cascade-delete collected answers; titre/description stay editable via `PATCH /forms/:uuid`, statut via `PATCH /:uuid/statut`.
- **uuid-exposed ids** everywhere (mirrors departements/villes); no internal int / FK id columns leak in nested objects.
- **Country-scoped**: `@CurrentCountry` first service arg; middleware strips `pays`/`country` (not in DTOs).

## Verification
Migrations `050`–`054` are live on **edukia-dev**. Both `tsc` suites pass; the full flow (409 guard, structural freeze, KPI aggregation, `GET /forms/active` lifecycle) and the three admin pages were **PM-verified live** with a minted-JWT session (zero browser console errors).

> Apply the `edukia-db` migrations PR to prod **before** merging this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
