### PR TITLE
feat(files): register recruteurs in the R2 files pipeline (profile photo)

### DIFF
--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -115,6 +115,11 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
         // content (legacy `media`) is sometimes a video — no clean image target, not mirrored.
         content: { pathColumn: 'content_image_path', extColumn: 'content_image_extension', authorized: IMAGE_EXTS, public: true },
     },
+    recruteurs: {
+        // Sibling of `prestataires.profil` — public profile photo, mirrored to
+        // the legacy Firebase `photo_profil` column during the transition.
+        profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'photo_profil' },
+    },
     services: {
         image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },
     },

--- a/backend/src/recruteurs/entities/recruteur.entity.ts
+++ b/backend/src/recruteurs/entities/recruteur.entity.ts
@@ -7,6 +7,19 @@ export class Recruteur {
     @PrimaryGeneratedColumn()
     id: number;
 
+    // External identifier the R2 /files pipeline resolves rows by. Mirrors the
+    // sibling `prestataires` — recruteurs were skipped in the original uuid
+    // migration (no photos existed then), added in edukia-db migration 060.
+    @Column({ type: 'uuid', unique: true, default: () => 'gen_random_uuid()' })
+    uuid: string;
+
+    // Public R2 profile-photo slot (full anonymous URL in _path). Legacy
+    // Firebase URL is mirrored to `photo_profil` by the dual-write bridge.
+    @Column({ type: 'text', default: '' })
+    profil_photo_path: string;
+
+    @Column({ type: 'varchar', length: 10, default: '' })
+    profil_photo_extension: string;
 
     @Column({ type: "varchar", length: 50, default: "benin" })
     pays: string;

--- a/frontend/src/lib/services/recruteurs.service.ts
+++ b/frontend/src/lib/services/recruteurs.service.ts
@@ -2,11 +2,15 @@ import { api } from '../api';
 
 export interface RecruteurItem {
     id: number;
+    uuid: string;
     numero_ifu: string | null;
     nom: string;
     nom_recruteur: string;
     prenom: string;
     utilisateur_id: number;
+    // Full public R2 URL for the profile photo (public slot stores the URL).
+    profil_photo_path: string | null;
+    profil_photo_extension: string | null;
     photo_profil: string | null;
     photo_identite: string | null;
     adresse: string | null;

--- a/frontend/src/pages/RecruteursAdmin.tsx
+++ b/frontend/src/pages/RecruteursAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -11,8 +11,10 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, CheckCircle, XCircle, Eye, ChevronLeft, ChevronRight } from "lucide-react";
+import { Loader2, CheckCircle, XCircle, Eye, ChevronLeft, ChevronRight, User, Upload } from "lucide-react";
 import { recruteursService, RecruteurItem } from "@/lib/services/recruteurs.service";
+import { filesService } from "@/lib/services/files.service";
+import { FileImage } from "@/components/FileImage";
 import { useToast } from "@/hooks/use-toast";
 import {
     Select,
@@ -66,6 +68,46 @@ export default function RecruteursAdmin() {
 
     const handleUpdateStatus = (id: number, newStatus: string) => {
         updateStatusMutation.mutate({ id, status: newStatus });
+    };
+
+    // Profile-photo upload via the shared R2 files pipeline (public `profil`
+    // slot). Routes through filesService.uploadFile, which stores the public
+    // URL on recruteurs.profil_photo_path and mirrors the legacy photo_profil.
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const uploadPhotoMutation = useMutation({
+        mutationFn: ({ uuid, file }: { uuid: string; file: File }) =>
+            filesService.uploadFile('recruteurs', uuid, 'profil', file),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["admin-recruteurs"] });
+            toast({
+                title: "Photo mise à jour",
+                description: "La photo de profil du recruteur a été enregistrée.",
+            });
+        },
+        onError: (error: any) => {
+            toast({
+                title: "Erreur",
+                description: error.message || "Échec de l'envoi de la photo",
+                variant: "destructive",
+            });
+        },
+    });
+
+    const handlePhotoSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = ""; // allow re-selecting the same file
+        if (!file || !viewRecruteur?.uuid) return;
+        uploadPhotoMutation.mutate(
+            { uuid: viewRecruteur.uuid, file },
+            {
+                onSuccess: (res) => {
+                    // Reflect the new URL immediately in the open dialog.
+                    setViewRecruteur((prev) =>
+                        prev ? { ...prev, profil_photo_path: res.path } : prev,
+                    );
+                },
+            },
+        );
     };
 
     const getStatusBadgeVariant = (status: string) => {
@@ -171,6 +213,7 @@ export default function RecruteursAdmin() {
                             <Table>
                                 <TableHeader>
                                     <TableRow>
+                                        <TableHead>Photo</TableHead>
                                         <TableHead>Nom Complet</TableHead>
                                         <TableHead>Email Utilisateur</TableHead>
                                         <TableHead>IFU</TableHead>
@@ -182,13 +225,29 @@ export default function RecruteursAdmin() {
                                 <TableBody>
                                     {paginatedRecruteurs.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={6} className="text-center text-muted-foreground">
+                                            <TableCell colSpan={7} className="text-center text-muted-foreground">
                                                 Aucun recruteur trouvé.
                                             </TableCell>
                                         </TableRow>
                                     ) : (
                                         paginatedRecruteurs.map((recruteur) => (
                                             <TableRow key={recruteur.id}>
+                                                <TableCell>
+                                                    <FileImage
+                                                        entity="recruteurs"
+                                                        uuid={recruteur.uuid}
+                                                        slot="profil"
+                                                        url={recruteur.profil_photo_path}
+                                                        fallback={recruteur.photo_profil}
+                                                        alt={`${recruteur.prenom} ${recruteur.nom}`}
+                                                        className="h-10 w-10 object-cover rounded-full bg-muted/20"
+                                                        placeholder={
+                                                            <div className="h-10 w-10 bg-muted rounded-full flex items-center justify-center">
+                                                                <User className="h-5 w-5 text-muted-foreground" />
+                                                            </div>
+                                                        }
+                                                    />
+                                                </TableCell>
                                                 <TableCell className="font-medium">
                                                     {recruteur.prenom} {recruteur.nom}
                                                 </TableCell>
@@ -282,6 +341,42 @@ export default function RecruteursAdmin() {
                     </DialogHeader>
                     {viewRecruteur && (
                         <div className="space-y-4 text-sm mt-4">
+                            <div className="flex flex-col items-center gap-3">
+                                <FileImage
+                                    entity="recruteurs"
+                                    uuid={viewRecruteur.uuid}
+                                    slot="profil"
+                                    url={viewRecruteur.profil_photo_path}
+                                    fallback={viewRecruteur.photo_profil}
+                                    alt={`${viewRecruteur.prenom} ${viewRecruteur.nom}`}
+                                    className="h-24 w-24 object-cover rounded-full bg-muted/20"
+                                    placeholder={
+                                        <div className="h-24 w-24 bg-muted rounded-full flex items-center justify-center">
+                                            <User className="h-10 w-10 text-muted-foreground" />
+                                        </div>
+                                    }
+                                />
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept="image/*"
+                                    className="hidden"
+                                    onChange={handlePhotoSelected}
+                                />
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => fileInputRef.current?.click()}
+                                    disabled={uploadPhotoMutation.isPending}
+                                >
+                                    {uploadPhotoMutation.isPending ? (
+                                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                    ) : (
+                                        <Upload className="h-4 w-4 mr-2" />
+                                    )}
+                                    Changer la photo
+                                </Button>
+                            </div>
                             <div className="grid grid-cols-2 gap-4">
                                 <div>
                                     <h4 className="font-semibold text-muted-foreground">Nom</h4>


### PR DESCRIPTION
## What
Enables recruteur **profile photos** through the R2 presign pipeline. Recruteurs were absent from `/files/:entity/...` — they were skipped in the Firebase→R2 migration (no recruteur photos existed).

## Root cause
`FilesService` resolves rows via `SELECT id FROM "<entity>" WHERE uuid = $1`, so every /files entity needs a `uuid` column. The `recruteurs` table had an **integer PK and no `uuid`** (unlike its sibling `prestataires`). So this adds the `uuid` + R2 columns, then the registry entry.

## Changes
- **edukia-db migration 060** (separate PR): add `uuid` (backfilled + unique) + `profil_photo_path` / `profil_photo_extension` to `recruteurs`.
- Entity: `uuid`, `profil_photo_path`, `profil_photo_extension`.
- Registry: `recruteurs.profil` — public image slot, `legacyColumn: 'photo_profil'` (mirrors the prestataires entry; dual-writes to the legacy column for mobile).
- Admin **RecruteursAdmin**: profile-photo upload/display via `<FileImage>` + `filesService`.

## Requires
- **edukia-db migration 060 applied to prod before merge** (already on edukia-dev).

## Verified (edukia-dev)
- `/files/registry` lists `recruteurs` → slot `profil`.
- `POST /files/recruteurs/:uuid/profil/upload-url` → 201 with presigned URL + `required_headers: [Content-Type, Cache-Control]` (public slot). 16 existing recruteurs backfilled with uuids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)