### PR TITLE
feat(wallet): paginated GET /wallet/me/transactions (clean port of #161)

### DIFF
--- a/backend/src/wallet/wallet-balance/use-cases/get-my-wallet-transactions.use-case.ts
+++ b/backend/src/wallet/wallet-balance/use-cases/get-my-wallet-transactions.use-case.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { WALLET_TRANSACTION_REPOSITORY } from '../../shared/payment.tokens';
+import { WalletTransactionRepositoryPort } from '../../shared/payment.ports';
+import { CreateWalletForUserUseCase } from './create-wallet-for-user.use-case';
+
+/**
+ * Dedicated paginated transaction history for the connected user's wallet.
+ * `GET /wallet/me` already returns the wallet + a first page of transactions;
+ * this endpoint serves a standalone, paginated history screen ({ data, meta }).
+ */
+@Injectable()
+export class GetMyWalletTransactionsUseCase {
+  constructor(
+    private readonly createWalletForUser: CreateWalletForUserUseCase,
+    @Inject(WALLET_TRANSACTION_REPOSITORY)
+    private readonly transactions: WalletTransactionRepositoryPort,
+  ) {}
+
+  async execute(userId: number, page = 1, limit = 20) {
+    const wallet = await this.createWalletForUser.execute(userId);
+    const safePage = Number.isFinite(page) && page > 0 ? page : 1;
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 100) : 20;
+    const result = await this.transactions.findByWalletId(wallet.id!, safePage, safeLimit);
+
+    return {
+      data: result.data,
+      meta: { page: safePage, limit: safeLimit, total: result.total },
+    };
+  }
+}

--- a/backend/src/wallet/wallet-balance/wallet.controller.ts
+++ b/backend/src/wallet/wallet-balance/wallet.controller.ts
@@ -1,7 +1,8 @@
 import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { GetMyWalletUseCase } from './use-cases/get-my-wallet.use-case';
+import { GetMyWalletTransactionsUseCase } from './use-cases/get-my-wallet-transactions.use-case';
 import { RequestWithdrawalUseCase } from './use-cases/request-withdrawal.use-case';
 import { RequestWithdrawalDto } from './dto/request-withdrawal.dto';
 import { VerifyWithdrawalOtpDto } from '../otp/dto/verify-withdrawal-otp.dto';
@@ -15,6 +16,7 @@ import { GetWithdrawalOtpDebugCodeUseCase } from '../otp/use-cases/get-withdrawa
 export class WalletController {
   constructor(
     private readonly getMyWallet: GetMyWalletUseCase,
+    private readonly getMyWalletTransactions: GetMyWalletTransactionsUseCase,
     private readonly requestWithdrawal: RequestWithdrawalUseCase,
     private readonly verifyWithdrawalOtp: VerifyWithdrawalOtpUseCase,
     private readonly getWithdrawalOtpDebugCode: GetWithdrawalOtpDebugCodeUseCase,
@@ -24,6 +26,14 @@ export class WalletController {
   @ApiOperation({ summary: 'Consulter son wallet et ses dernières transactions' })
   getMine(@Request() req, @Query('page') page?: string, @Query('limit') limit?: string) {
     return this.getMyWallet.execute(req.user.utilisateurId, Number(page ?? 1), Number(limit ?? 20));
+  }
+
+  @Get('me/transactions')
+  @ApiOperation({ summary: "Historique paginé des transactions du wallet de l'utilisateur connecté" })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
+  getMyTransactions(@Request() req, @Query('page') page?: string, @Query('limit') limit?: string) {
+    return this.getMyWalletTransactions.execute(req.user.utilisateurId, Number(page ?? 1), Number(limit ?? 20));
   }
 
   @Post('withdrawals')

--- a/backend/src/wallet/wallet.module.ts
+++ b/backend/src/wallet/wallet.module.ts
@@ -30,6 +30,7 @@ import {
 import { CreateWalletForUserUseCase } from './wallet-balance/use-cases/create-wallet-for-user.use-case';
 import { CreditWalletFromValidatedExamUseCase } from './wallet-balance/use-cases/credit-wallet-from-validated-exam.use-case';
 import { GetMyWalletUseCase } from './wallet-balance/use-cases/get-my-wallet.use-case';
+import { GetMyWalletTransactionsUseCase } from './wallet-balance/use-cases/get-my-wallet-transactions.use-case';
 import { RequestWithdrawalUseCase } from './wallet-balance/use-cases/request-withdrawal.use-case';
 import { VerifyWithdrawalOtpUseCase } from './otp/use-cases/verify-withdrawal-otp.use-case';
 import { GetWithdrawalOtpDebugCodeUseCase } from './otp/use-cases/get-withdrawal-otp-debug-code.use-case';
@@ -85,6 +86,7 @@ import { TwilioOtpSmsAdapter } from './otp/twilio-otp-sms.adapter';
     CreateWalletForUserUseCase,
     CreditWalletFromValidatedExamUseCase,
     GetMyWalletUseCase,
+    GetMyWalletTransactionsUseCase,
     RequestWithdrawalUseCase,
     VerifyWithdrawalOtpUseCase,
     GetWithdrawalOtpDebugCodeUseCase,


### PR DESCRIPTION
## What
A dedicated **`GET /wallet/me/transactions`** endpoint — paginated wallet transaction history for the connected user, returning `{ data, meta: { page, limit, total } }`.

## Why this instead of #161
`#161 (feat/trnasaction)` is the **original wallet branch** (9 days stale). Merging it would **break prod**: it re-adds the whole wallet module in an earlier version (conflicts on every `wallet/*` file), **reverts geo** (départements/villes, live on prod), and **swaps npm→pnpm** (breaks the Docker build). Its only genuinely-new work was this ~30-line transaction endpoint — rebuilt here on the current wallet module.

## Changes (3 files, additive)
- `GetMyWalletTransactionsUseCase` — reuses the existing `WalletTransactionRepository.findByWalletId(walletId, page, limit)`.
- `GET /wallet/me/transactions?page=&limit=` on the wallet controller.
- Registered in `wallet.module.ts`.
- **`GET /wallet/me` is unchanged** (still returns wallet + first page of transactions).

## Safety
- No migration; no change to any existing endpoint; nothing on prod is reverted.
- Verified on edukia-dev: `/wallet/me/transactions` → `{ data:[…], meta:{page,limit,total} }`; `/wallet/me` unchanged.

**Recommend closing #161** in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)