### PR TITLE
feat(type-profils): profile personalization + audience tagging on 5 entities

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -39,6 +39,7 @@ import { Like } from './likes/entities/like.entity';
 import { Favori } from './favoris/entities/favoris.entity';
 import { Category } from './categories/entities/category.entity';
 import { CategoriesModule } from './categories/categories.module';
+import { TypeProfilsModule } from './type-profils/type-profils.module';
 import { StructureModule } from './structure/structure.module';
 import { Structure } from './structure/entities/structure.entity';
 import { TitreModule } from './titre/titre.module';
@@ -133,6 +134,7 @@ import { CountryMiddleware } from './config/country.middleware';
     LikesModule,
     FavorisModule,
     CategoriesModule,
+    TypeProfilsModule,
     StructureModule,
     TitreModule,
     NotificationsModule,

--- a/backend/src/common/dto/set-type-profils.dto.ts
+++ b/backend/src/common/dto/set-type-profils.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayUnique, IsArray, IsInt } from 'class-validator';
+
+/**
+ * Payload partagé pour PUT /<entity>/:id/type-profils — remplace intégralement
+ * (replace-set) la checklist de types de profil taguée sur la ligne.
+ */
+export class SetTypeProfilsDto {
+    @ApiProperty({ type: [Number], description: 'IDs des types de profil (remplacement complet)' })
+    @IsArray()
+    @IsInt({ each: true })
+    @ArrayUnique()
+    typeProfilIds: number[];
+}

--- a/backend/src/evenements/evenements.controller.ts
+++ b/backend/src/evenements/evenements.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus, Request } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
+import { SetTypeProfilsDto } from '../common/dto/set-type-profils.dto';
 import { Response } from 'express';
 import { EvenementsService } from './evenements.service';
 import { CreerEvenementDto } from './dto/create-evenement.dto';
@@ -33,8 +34,27 @@ export class EvenementsController {
   @Get()
   @ApiOperation({ summary: 'Récupérer la liste des événements' })
   @ApiResponse({ status: 200, description: 'Liste récupérée avec succès' })
-  findAll(@Query() filterDto: FilterEvenementDto) {
-    return this.evenementsService.findAll(filterDto);
+  findAll(@Query() filterDto: FilterEvenementDto, @Request() req) {
+    const viewer = { role: req.user?.role, utilisateurId: req.user?.utilisateurId };
+    return this.evenementsService.findAll(filterDto, viewer);
+  }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(RoleType.ADMIN)
+  @ApiBearerAuth()
+  @Get(':id/type-profils')
+  @ApiOperation({ summary: 'Récupérer la checklist de types de profil d\'un événement (admin)' })
+  getTypeProfils(@Param('id') id: string) {
+    return this.evenementsService.getTypeProfilIds(+id);
+  }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(RoleType.ADMIN)
+  @ApiBearerAuth()
+  @Put(':id/type-profils')
+  @ApiOperation({ summary: 'Définir (replace-set) la checklist de types de profil d\'un événement (admin)' })
+  setTypeProfils(@Param('id') id: string, @Body() dto: SetTypeProfilsDto) {
+    return this.evenementsService.setTypeProfilIds(+id, dto.typeProfilIds);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/evenements/evenements.module.ts
+++ b/backend/src/evenements/evenements.module.ts
@@ -4,11 +4,13 @@ import { EvenementsService } from './evenements.service';
 import { EvenementsController } from './evenements.controller';
 import { Evenement } from './entities/evenement.entity';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { TypeProfilsModule } from '../type-profils/type-profils.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Evenement]),
     FichiersModule,
+    TypeProfilsModule,
   ],
   controllers: [EvenementsController],
   providers: [EvenementsService],

--- a/backend/src/evenements/evenements.service.ts
+++ b/backend/src/evenements/evenements.service.ts
@@ -8,18 +8,43 @@ import { UpdateEvenementDto } from './dto/update-evenement.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
 import { FilterEvenementDto, EvenementSortBy } from './dto/filter-evenement.dto';
+import {
+  TypeProfilVisibilityService,
+  TypeProfilJoinConfig,
+  ViewerContext,
+} from '../type-profils/type-profil-visibility.service';
 
 @Injectable()
 export class EvenementsService {
   private readonly logger = new Logger(EvenementsService.name);
 
+  private readonly typeProfilJoin: TypeProfilJoinConfig = {
+    joinTable: 'evenement_type_profils',
+    fkColumn: 'evenement_id',
+  };
+
   constructor(
     private readonly resolver: DataSourceResolver,
     private readonly fichiersService: FichiersService,
+    private readonly typeProfilVisibility: TypeProfilVisibilityService,
   ) { }
 
   private get evenementRepository(): Repository<Evenement> {
     return this.resolver.getRepository(Evenement);
+  }
+
+  /** Lit la checklist de types de profil taguée sur un événement. */
+  async getTypeProfilIds(id: number): Promise<{ typeProfilIds: number[] }> {
+    await this.findOne(id);
+    const typeProfilIds = await this.typeProfilVisibility.getTypeProfilIds(this.typeProfilJoin, id);
+    return { typeProfilIds };
+  }
+
+  /** Remplace (replace-set) la checklist de types de profil d'un événement. */
+  async setTypeProfilIds(id: number, typeProfilIds: number[]): Promise<{ typeProfilIds: number[] }> {
+    await this.findOne(id);
+    const saved = await this.typeProfilVisibility.setTypeProfilIds(this.typeProfilJoin, id, typeProfilIds);
+    return { typeProfilIds: saved };
   }
 
   async create(creerEvenementDto: CreerEvenementDto) {
@@ -32,7 +57,7 @@ export class EvenementsService {
 
 
 
-  async findAll(filterDto: FilterEvenementDto): Promise<PaginationResponse<Evenement>> {
+  async findAll(filterDto: FilterEvenementDto, viewer?: ViewerContext): Promise<PaginationResponse<Evenement>> {
     const { page = 1, limit = 10, search, sort_by, sort_order = 'DESC' } = filterDto;
     this.logger.log(`Récupération des événements - Page: ${page}, Limit: ${limit}, SortBy: ${sort_by}, Order: ${sort_order}`);
 
@@ -65,6 +90,9 @@ export class EvenementsService {
       queryBuilder.orderBy('evenement.date', 'DESC');
       queryBuilder.addOrderBy('evenement.date_creation', 'DESC');
     }
+
+    // Visibilité par type de profil : non-admin ⇒ non-tagué OU partage son type_profil.
+    await this.typeProfilVisibility.applyVisibilityFilter(queryBuilder, 'evenement', this.typeProfilJoin, viewer);
 
     const [evenements, total] = await queryBuilder
       .skip((page - 1) * limit)

--- a/backend/src/evenements/evenements.service.ts
+++ b/backend/src/evenements/evenements.service.ts
@@ -19,6 +19,7 @@ export class EvenementsService {
   private readonly logger = new Logger(EvenementsService.name);
 
   private readonly typeProfilJoin: TypeProfilJoinConfig = {
+    entity: 'evenement',
     joinTable: 'evenement_type_profils',
     fkColumn: 'evenement_id',
   };

--- a/backend/src/files/registry.ts
+++ b/backend/src/files/registry.ts
@@ -118,6 +118,10 @@ export const FILE_FIELD_REGISTRY: Record<string, Record<string, FileSlotConfig>>
     services: {
         image: { pathColumn: 'image_path', extColumn: 'image_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'image_couverture' },
     },
+    type_profils: {
+        // Public image slot — copied EXACTLY from categories.icone (same policy).
+        icone: { pathColumn: 'icone_path', extColumn: 'icone_extension', authorized: IMAGE_EXTS, public: true },
+    },
     utilisateurs: {
         profil: { pathColumn: 'profil_photo_path', extColumn: 'profil_photo_extension', authorized: IMAGE_EXTS, public: true, legacyColumn: 'photo' },
     },

--- a/backend/src/forum/forum.controller.ts
+++ b/backend/src/forum/forum.controller.ts
@@ -7,7 +7,11 @@ import { FilterForumDto } from './dto/filter-forum.dto';
 import { ApiTags, ApiBearerAuth, ApiQuery, ApiOkResponse, ApiOperation, ApiResponse, ApiConsumes, ApiBody, ApiParam } from '@nestjs/swagger';
 import { Forum } from './entities/forum.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../auth/guards/role.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { SetTypeProfilsDto } from '../common/dto/set-type-profils.dto';
 
 @ApiTags('Forums')
 @Controller('forums')
@@ -32,7 +36,26 @@ export class ForumController {
     @ApiResponse({ status: 200, description: 'Liste des forums récupérée avec succès.', type: [Forum] })
     findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterForumDto, @Req() req) {
         const userId = req.user.utilisateurId;
-        return this.forumService.findAll(pays, filterDto, userId);
+        const viewer = { role: req.user?.role, utilisateurId: userId };
+        return this.forumService.findAll(pays, filterDto, userId, viewer);
+    }
+
+    @Get(':id/type-profils')
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Récupérer la checklist de types de profil d\'un forum (admin)' })
+    getTypeProfils(@Param('id', ParseIntPipe) id: number) {
+        return this.forumService.getTypeProfilIds(id);
+    }
+
+    @Put(':id/type-profils')
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Définir (replace-set) la checklist de types de profil d\'un forum (admin)' })
+    setTypeProfils(@Param('id', ParseIntPipe) id: number, @Body() dto: SetTypeProfilsDto) {
+        return this.forumService.setTypeProfilIds(id, dto.typeProfilIds);
     }
 
     @Get(':id')

--- a/backend/src/forum/forum.module.ts
+++ b/backend/src/forum/forum.module.ts
@@ -7,9 +7,10 @@ import { Forum } from './entities/forum.entity';
 import { LikesPolymorphicModule } from '../likes-polymorphic/likes-polymorphic.module';
 
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { TypeProfilsModule } from '../type-profils/type-profils.module';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Forum]), LikesPolymorphicModule, FichiersModule],
+    imports: [TypeOrmModule.forFeature([Forum]), LikesPolymorphicModule, FichiersModule, TypeProfilsModule],
     controllers: [ForumController],
     providers: [ForumService],
 })

--- a/backend/src/forum/forum.service.ts
+++ b/backend/src/forum/forum.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
-import { Repository, IsNull, ILike } from 'typeorm';
+import { Repository, IsNull, ILike, Not, In } from 'typeorm';
 import { LikesPolymorphicService } from '../likes-polymorphic/likes-polymorphic.service';
 import { CreateForumDto } from './dto/create-forum.dto';
 import { UpdateForumDto } from './dto/update-forum.dto';
@@ -11,16 +11,43 @@ import { Forum } from './entities/forum.entity';
 import { CommentaireUser } from '../comments-polymorphic/entities/commentaire-user.entity';
 import { LikeUser } from '../likes-polymorphic/entities/like-user.entity';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
+import {
+    TypeProfilVisibilityService,
+    TypeProfilJoinConfig,
+    ViewerContext,
+} from '../type-profils/type-profil-visibility.service';
 
 @Injectable()
 export class ForumService {
+    private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        joinTable: 'forum_type_profils',
+        fkColumn: 'forum_id',
+    };
+
     constructor(
         private readonly resolver: DataSourceResolver,
         private readonly likesService: LikesPolymorphicService,
         private readonly fichiersService: FichiersService,
+        private readonly typeProfilVisibility: TypeProfilVisibilityService,
     ) { }
 
     private get forumRepository(): Repository<Forum> { return this.resolver.getRepository(Forum); }
+
+    /** Lit la checklist de types de profil taguée sur un forum. */
+    async getTypeProfilIds(id: number): Promise<{ typeProfilIds: number[] }> {
+        const forum = await this.forumRepository.findOne({ where: { id } });
+        if (!forum) throw new NotFoundException(`Forum with ID ${id} not found`);
+        const typeProfilIds = await this.typeProfilVisibility.getTypeProfilIds(this.typeProfilJoin, id);
+        return { typeProfilIds };
+    }
+
+    /** Remplace (replace-set) la checklist de types de profil d'un forum. */
+    async setTypeProfilIds(id: number, typeProfilIds: number[]): Promise<{ typeProfilIds: number[] }> {
+        const forum = await this.forumRepository.findOne({ where: { id } });
+        if (!forum) throw new NotFoundException(`Forum with ID ${id} not found`);
+        const saved = await this.typeProfilVisibility.setTypeProfilIds(this.typeProfilJoin, id, typeProfilIds);
+        return { typeProfilIds: saved };
+    }
     private get commentsRepository(): Repository<CommentaireUser> { return this.resolver.getRepository(CommentaireUser); }
     private get likesRepository(): Repository<LikeUser> { return this.resolver.getRepository(LikeUser); }
 
@@ -59,7 +86,7 @@ export class ForumService {
         }).format(date);
     }
 
-    async findAll(pays: string, filterDto: FilterForumDto, userId: number): Promise<PaginationResponse<any>> {
+    async findAll(pays: string, filterDto: FilterForumDto, userId: number, viewer?: ViewerContext): Promise<PaginationResponse<any>> {
         const { page = 1, limit = 10, search, sortBy = 'date_creation', sort_order = 'DESC' } = filterDto;
         const skip = (page - 1) * limit;
         const take = limit;
@@ -67,6 +94,13 @@ export class ForumService {
         const where: any = { pays, deleted_at: IsNull() };
         if (search) {
             where.theme = ILike(`%${search}%`);
+        }
+
+        // Visibilité par type de profil (chemin findAndCount) : on EXCLUT les forums
+        // cachés pour l'appelant (tagués sans partager son type_profil). Admin/no-viewer ⇒ null.
+        const hidden = await this.typeProfilVisibility.hiddenEntityIds(this.typeProfilJoin, viewer);
+        if (hidden && hidden.length) {
+            where.id = Not(In(hidden));
         }
 
         const [forums, total] = await this.forumRepository.findAndCount({

--- a/backend/src/forum/forum.service.ts
+++ b/backend/src/forum/forum.service.ts
@@ -20,6 +20,7 @@ import {
 @Injectable()
 export class ForumService {
     private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        entity: 'forum',
         joinTable: 'forum_type_profils',
         fkColumn: 'forum_id',
     };
@@ -96,11 +97,10 @@ export class ForumService {
             where.theme = ILike(`%${search}%`);
         }
 
-        // Visibilité par type de profil (chemin findAndCount) : on EXCLUT les forums
-        // cachés pour l'appelant (tagués sans partager son type_profil). Admin/no-viewer ⇒ null.
-        const hidden = await this.typeProfilVisibility.hiddenEntityIds(this.typeProfilJoin, viewer);
-        if (hidden && hidden.length) {
-            where.id = Not(In(hidden));
+        // Visibilité par type de profil (chemin findAndCount) : registre entité-niveau.
+        // Si l'entité forum est masquée pour l'appelant → aucune ligne.
+        if (await this.typeProfilVisibility.isEntityHidden(this.typeProfilJoin, viewer)) {
+            where.id = -1;
         }
 
         const [forums, total] = await this.forumRepository.findAndCount({

--- a/backend/src/offres/offres.controller.ts
+++ b/backend/src/offres/offres.controller.ts
@@ -9,6 +9,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
 import { TypeContratEnum } from '../common/enums/type-contrat.enum';
+import { SetTypeProfilsDto } from '../common/dto/set-type-profils.dto';
 
 @ApiTags('offres')
 @Controller('offres')
@@ -26,6 +27,7 @@ export class OffresController {
     @ApiQuery({ name: 'limit', required: false, type: Number })
     findAll(
         @CurrentCountry() pays: string,
+        @Request() req,
         @Query('type') type?: string,
         @Query('prixMin') prixMin?: string,
         @Query('prixMax') prixMax?: string,
@@ -34,6 +36,10 @@ export class OffresController {
         @Query('page') page?: string,
         @Query('limit') limit?: string,
     ) {
+        // Route PUBLIQUE (non gardée) : req.user est undefined → on passe un viewer
+        // TRUTHY {role:undefined,utilisateurId:undefined} (jamais undefined) pour que
+        // l'anonyme ne voie que les offres non-taguées, sans court-circuiter le filtre.
+        const viewer = { role: req.user?.role, utilisateurId: req.user?.utilisateurId };
         return this.offresService.findAll(pays, {
             type,
             prixMin: prixMin ? parseFloat(prixMin) : undefined,
@@ -42,7 +48,7 @@ export class OffresController {
             type_contrat,
             page: page ? parseInt(page, 10) : 1,
             limit: limit ? parseInt(limit, 10) : 10,
-        });
+        }, viewer);
     }
 
     @Get('user')
@@ -58,10 +64,11 @@ export class OffresController {
         @Query('limit') limit?: string,
     ) {
         const userId = req.user.utilisateurId;
+        const viewer = { role: req.user?.role, utilisateurId: userId };
         return this.offresService.findAllByUser(pays, userId, {
             page: page ? parseInt(page) : 1,
             limit: limit ? parseInt(limit) : 10,
-        });
+        }, viewer);
     }
 
     @Get('all')
@@ -80,6 +87,24 @@ export class OffresController {
             page: page ? parseInt(page) : 1,
             limit: limit ? parseInt(limit) : 10,
         });
+    }
+
+    @Get(':id/type-profils')
+    @UseGuards(JwtAuthGuard, RolesGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Récupérer la checklist de types de profil d\'une offre (admin)' })
+    getTypeProfils(@Param('id', ParseIntPipe) id: number) {
+        return this.offresService.getTypeProfilIds(id);
+    }
+
+    @Put(':id/type-profils')
+    @UseGuards(JwtAuthGuard, RolesGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Définir (replace-set) la checklist de types de profil d\'une offre (admin)' })
+    setTypeProfils(@Param('id', ParseIntPipe) id: number, @Body() dto: SetTypeProfilsDto) {
+        return this.offresService.setTypeProfilIds(id, dto.typeProfilIds);
     }
 
     @Get(':id')

--- a/backend/src/offres/offres.module.ts
+++ b/backend/src/offres/offres.module.ts
@@ -6,10 +6,11 @@ import { Offre } from './entities/offre.entity';
 import { Type } from '../types/entities/type.entity';
 import { Competence } from '../competences/entities/competence.entity';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { TypeProfilsModule } from '../type-profils/type-profils.module';
 import { MailModule } from '../mail/mail.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Offre, Type, Competence]), FichiersModule, MailModule],
+  imports: [TypeOrmModule.forFeature([Offre, Type, Competence]), FichiersModule, MailModule, TypeProfilsModule],
   providers: [OffresService],
   controllers: [OffresController]
 })

--- a/backend/src/offres/offres.service.ts
+++ b/backend/src/offres/offres.service.ts
@@ -38,6 +38,7 @@ export interface AvisStats {
 @Injectable()
 export class OffresService {
     private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        entity: 'offre',
         joinTable: 'offre_type_profils',
         fkColumn: 'offre_id',
     };
@@ -286,9 +287,8 @@ export class OffresService {
 
         // Liste authentifiée : visibilité par type de profil (chemin findAndCount).
         const where: any = { pays, utilisateur_id: userId };
-        const hidden = await this.typeProfilVisibility.hiddenEntityIds(this.typeProfilJoin, viewer);
-        if (hidden && hidden.length) {
-            where.id = Not(In(hidden));
+        if (await this.typeProfilVisibility.isEntityHidden(this.typeProfilJoin, viewer)) {
+            where.id = -1; // entité masquée pour l'appelant → aucune ligne
         }
 
         const [data, total] = await this.offresRepository.findAndCount({

--- a/backend/src/offres/offres.service.ts
+++ b/backend/src/offres/offres.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
-import { Repository, In, ILike } from 'typeorm';
+import { Repository, In, ILike, Not } from 'typeorm';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
+import {
+    TypeProfilVisibilityService,
+    TypeProfilJoinConfig,
+    ViewerContext,
+} from '../type-profils/type-profil-visibility.service';
 import { CreateOffreDto, UpdateOffreDto } from './dto/offre.dto';
 
 import { FichiersService } from '../fichiers/fichiers.service';
@@ -32,11 +37,33 @@ export interface AvisStats {
 
 @Injectable()
 export class OffresService {
+    private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        joinTable: 'offre_type_profils',
+        fkColumn: 'offre_id',
+    };
+
     constructor(
         private readonly resolver: DataSourceResolver,
         private fichiersService: FichiersService,
-        private mailService: MailService
+        private mailService: MailService,
+        private readonly typeProfilVisibility: TypeProfilVisibilityService,
     ) { }
+
+    /** Lit la checklist de types de profil taguée sur une offre. */
+    async getTypeProfilIds(id: number): Promise<{ typeProfilIds: number[] }> {
+        const offre = await this.offresRepository.findOne({ where: { id } });
+        if (!offre) throw new NotFoundException(`Offre #${id} introuvable`);
+        const typeProfilIds = await this.typeProfilVisibility.getTypeProfilIds(this.typeProfilJoin, id);
+        return { typeProfilIds };
+    }
+
+    /** Remplace (replace-set) la checklist de types de profil d'une offre. */
+    async setTypeProfilIds(id: number, typeProfilIds: number[]): Promise<{ typeProfilIds: number[] }> {
+        const offre = await this.offresRepository.findOne({ where: { id } });
+        if (!offre) throw new NotFoundException(`Offre #${id} introuvable`);
+        const saved = await this.typeProfilVisibility.setTypeProfilIds(this.typeProfilJoin, id, typeProfilIds);
+        return { typeProfilIds: saved };
+    }
 
     private get offresRepository(): Repository<Offre> { return this.resolver.getRepository(Offre); }
     private get typesRepository(): Repository<Type> { return this.resolver.getRepository(Type); }
@@ -206,7 +233,7 @@ export class OffresService {
         return this.formatOffre(fullOffre);
     }
 
-    async findAll(pays: string, filters: OffreFilterDto) {
+    async findAll(pays: string, filters: OffreFilterDto, viewer?: ViewerContext) {
         const { type, prixMin, prixMax, search, type_contrat, page = 1, limit = 10 } = filters;
 
         const queryBuilder = this.offresRepository.createQueryBuilder('offre')
@@ -235,6 +262,11 @@ export class OffresService {
             queryBuilder.andWhere('(offre.titre ILIKE :search OR offre.description ILIKE :search)', { search: `%${search}%` });
         }
 
+        // Visibilité par type de profil. Route publique/non-gardée : le contrôleur
+        // passe un viewer TRUTHY {role:undefined,utilisateurId:undefined} → anonyme
+        // = non-tagué uniquement (jamais `undefined`, qui shunterait le filtre).
+        await this.typeProfilVisibility.applyVisibilityFilter(queryBuilder, 'offre', this.typeProfilJoin, viewer);
+
         queryBuilder.orderBy('offre.created_at', 'DESC');
         queryBuilder.skip((page - 1) * limit).take(limit);
 
@@ -249,11 +281,18 @@ export class OffresService {
         };
     }
 
-    async findAllByUser(pays: string, userId: number, pagination: { page: number, limit: number }) {
+    async findAllByUser(pays: string, userId: number, pagination: { page: number, limit: number }, viewer?: ViewerContext) {
         const { page = 1, limit = 10 } = pagination;
 
+        // Liste authentifiée : visibilité par type de profil (chemin findAndCount).
+        const where: any = { pays, utilisateur_id: userId };
+        const hidden = await this.typeProfilVisibility.hiddenEntityIds(this.typeProfilJoin, viewer);
+        if (hidden && hidden.length) {
+            where.id = Not(In(hidden));
+        }
+
         const [data, total] = await this.offresRepository.findAndCount({
-            where: { pays, utilisateur_id: userId },
+            where,
             relations: ['type', 'competences'],
             order: { created_at: 'DESC' },
             skip: (page - 1) * limit,

--- a/backend/src/opportunites/opportunites.controller.ts
+++ b/backend/src/opportunites/opportunites.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { Controller, Get, Post, Body, Put, Param, Delete, UseGuards, Query, Res, HttpStatus, Request } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { Response } from 'express';
 import { OpportunitesService } from './opportunites.service';
 import { CreerOpportuniteDto } from './dto/create-opportunite.dto';
@@ -10,6 +10,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
 import { FilterOpportuniteDto } from './dto/filter-opportunite.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
+import { SetTypeProfilsDto } from '../common/dto/set-type-profils.dto';
 
 @ApiTags('opportunites')
 @Controller('opportunites')
@@ -37,8 +38,28 @@ export class OpportunitesController {
   @ApiQuery({ name: 'sort_by', required: false, type: String, description: 'Trier par (date, name)' })
   @ApiQuery({ name: 'sort_order', required: false, type: String, description: 'Odre de tri (ASC, DESC)' })
   @ApiQuery({ name: 'actif', required: false, type: Boolean, description: 'Filtrer par statut actif' })
-  findAll(@Query() filterDto: FilterOpportuniteDto) {
-    return this.opportunitesService.findAll(filterDto);
+  findAll(@Query() filterDto: FilterOpportuniteDto, @Request() req) {
+    // Identité de l'appelant (JWT) → règle de visibilité par type de profil.
+    const viewer = { role: req.user?.role, utilisateurId: req.user?.utilisateurId };
+    return this.opportunitesService.findAll(filterDto, viewer);
+  }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(RoleType.ADMIN)
+  @ApiBearerAuth()
+  @Get(':id/type-profils')
+  @ApiOperation({ summary: 'Récupérer la checklist de types de profil d\'une opportunité (admin)' })
+  getTypeProfils(@Param('id') id: string) {
+    return this.opportunitesService.getTypeProfilIds(+id);
+  }
+
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(RoleType.ADMIN)
+  @ApiBearerAuth()
+  @Put(':id/type-profils')
+  @ApiOperation({ summary: 'Définir (replace-set) la checklist de types de profil d\'une opportunité (admin)' })
+  setTypeProfils(@Param('id') id: string, @Body() dto: SetTypeProfilsDto) {
+    return this.opportunitesService.setTypeProfilIds(+id, dto.typeProfilIds);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/opportunites/opportunites.module.ts
+++ b/backend/src/opportunites/opportunites.module.ts
@@ -4,11 +4,13 @@ import { OpportunitesService } from './opportunites.service';
 import { OpportunitesController } from './opportunites.controller';
 import { Opportunite } from './entities/opportunite.entity';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { TypeProfilsModule } from '../type-profils/type-profils.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Opportunite]),
     FichiersModule,
+    TypeProfilsModule,
   ],
   controllers: [OpportunitesController],
   providers: [OpportunitesService],

--- a/backend/src/opportunites/opportunites.service.ts
+++ b/backend/src/opportunites/opportunites.service.ts
@@ -20,6 +20,7 @@ export class OpportunitesService {
 
   // Jointure type-profils de cette entité (constantes internes).
   private readonly typeProfilJoin: TypeProfilJoinConfig = {
+    entity: 'opportunite',
     joinTable: 'opportunite_type_profils',
     fkColumn: 'opportunite_id',
   };

--- a/backend/src/opportunites/opportunites.service.ts
+++ b/backend/src/opportunites/opportunites.service.ts
@@ -8,18 +8,44 @@ import { UpdateOpportuniteDto } from './dto/update-opportunite.dto';
 import { FilterOpportuniteDto, OpportuniteSortBy, OpportuniteSortOrder } from './dto/filter-opportunite.dto';
 import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
 import { FindOptionsWhere, Like } from 'typeorm';
+import {
+  TypeProfilVisibilityService,
+  TypeProfilJoinConfig,
+  ViewerContext,
+} from '../type-profils/type-profil-visibility.service';
 
 @Injectable()
 export class OpportunitesService {
   private readonly logger = new Logger(OpportunitesService.name);
 
+  // Jointure type-profils de cette entité (constantes internes).
+  private readonly typeProfilJoin: TypeProfilJoinConfig = {
+    joinTable: 'opportunite_type_profils',
+    fkColumn: 'opportunite_id',
+  };
+
   constructor(
     private readonly resolver: DataSourceResolver,
     private readonly fichiersService: FichiersService,
+    private readonly typeProfilVisibility: TypeProfilVisibilityService,
   ) { }
 
   private get opportuniteRepository(): Repository<Opportunite> {
     return this.resolver.getRepository(Opportunite);
+  }
+
+  /** Lit la checklist de types de profil taguée sur une opportunité. */
+  async getTypeProfilIds(id: number): Promise<{ typeProfilIds: number[] }> {
+    await this.findOne(id); // 404 si l'opportunité n'existe pas
+    const typeProfilIds = await this.typeProfilVisibility.getTypeProfilIds(this.typeProfilJoin, id);
+    return { typeProfilIds };
+  }
+
+  /** Remplace (replace-set) la checklist de types de profil d'une opportunité. */
+  async setTypeProfilIds(id: number, typeProfilIds: number[]): Promise<{ typeProfilIds: number[] }> {
+    await this.findOne(id);
+    const saved = await this.typeProfilVisibility.setTypeProfilIds(this.typeProfilJoin, id, typeProfilIds);
+    return { typeProfilIds: saved };
   }
 
   async create(creerOpportuniteDto: CreerOpportuniteDto) {
@@ -30,7 +56,7 @@ export class OpportunitesService {
     return saved;
   }
 
-  async findAll(filterDto: FilterOpportuniteDto): Promise<PaginationResponse<Opportunite>> {
+  async findAll(filterDto: FilterOpportuniteDto, viewer?: ViewerContext): Promise<PaginationResponse<Opportunite>> {
     const { page = 1, limit = 10, search, type, sort_by = OpportuniteSortBy.DATE, sort_order = OpportuniteSortOrder.DESC, actif } = filterDto;
     this.logger.log(`Récupération des opportunités - filtres: ${JSON.stringify(filterDto)}`);
 
@@ -50,6 +76,10 @@ export class OpportunitesService {
     if (actif !== undefined) {
       queryBuilder.andWhere('opportunite.actif = :actif', { actif });
     }
+
+    // Visibilité par type de profil : non-admin ⇒ non-tagué OU partage son type_profil.
+    // Admin / sans viewer ⇒ inchangé.
+    await this.typeProfilVisibility.applyVisibilityFilter(queryBuilder, 'opportunite', this.typeProfilJoin, viewer);
 
     // Sorting
     if (sort_by === OpportuniteSortBy.NAME) {

--- a/backend/src/services/services.controller.ts
+++ b/backend/src/services/services.controller.ts
@@ -10,6 +10,7 @@ import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery, ApiResponse, ApiConsume
 import { ServiceStatusEnum } from '../common/enums/service-status.enum';
 import { TypeContratEnum } from '../common/enums/type-contrat.enum';
 import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { SetTypeProfilsDto } from '../common/dto/set-type-profils.dto';
 
 @ApiTags('services')
 @Controller('services')
@@ -39,6 +40,7 @@ export class ServicesController {
     @ApiQuery({ name: 'limit', required: false, type: Number })
     findAll(
         @CurrentCountry() pays: string,
+        @Request() req,
         @Query('localisation') localisation?: string,
         @Query('type') type?: string,
         @Query('tarifMin') tarifMin?: string,
@@ -48,6 +50,7 @@ export class ServicesController {
         @Query('page') page?: string,
         @Query('limit') limit?: string,
     ) {
+        const viewer = { role: req.user?.role, utilisateurId: req.user?.utilisateurId };
         return this.servicesService.findAll(pays, {
             localisation,
             type,
@@ -57,7 +60,23 @@ export class ServicesController {
             type_contrat,
             page: page ? parseInt(page) : 1,
             limit: limit ? parseInt(limit) : 10,
-        });
+        }, viewer);
+    }
+
+    @Get(':id/type-profils')
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Récupérer la checklist de types de profil d\'un service (admin)' })
+    getTypeProfils(@Param('id', ParseIntPipe) id: number) {
+        return this.servicesService.getTypeProfilIds(id);
+    }
+
+    @Put(':id/type-profils')
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: 'Définir (replace-set) la checklist de types de profil d\'un service (admin)' })
+    setTypeProfils(@Param('id', ParseIntPipe) id: number, @Body() dto: SetTypeProfilsDto) {
+        return this.servicesService.setTypeProfilIds(id, dto.typeProfilIds);
     }
 
     @Get('user')

--- a/backend/src/services/services.module.ts
+++ b/backend/src/services/services.module.ts
@@ -9,12 +9,14 @@ import { Prestataire } from '../prestataires/entities/prestataire.entity';
 import { Avis } from '../avis/entities/avis.entity';
 import { MailModule } from '../mail/mail.module';
 import { FichiersModule } from '../fichiers/fichiers.module';
+import { TypeProfilsModule } from '../type-profils/type-profils.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Service, Type, Utilisateur, Prestataire, Avis]),
     MailModule,
     FichiersModule,
+    TypeProfilsModule,
   ],
   controllers: [ServicesController],
   providers: [ServicesService]

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -40,6 +40,7 @@ export class ServicesService {
     private readonly logger = new Logger(ServicesService.name);
 
     private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        entity: 'service',
         joinTable: 'service_type_profils',
         fkColumn: 'service_id',
     };

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -13,6 +13,11 @@ import { MailService } from '../mail/mail.service';
 import { FichiersService } from '../fichiers/fichiers.service';
 import { TypeFichier } from '../fichiers/entities/fichier.entity';
 import { TypeContratEnum } from '../common/enums/type-contrat.enum';
+import {
+    TypeProfilVisibilityService,
+    TypeProfilJoinConfig,
+    ViewerContext,
+} from '../type-profils/type-profil-visibility.service';
 
 export interface ServiceFilterDto {
     localisation?: string;
@@ -34,11 +39,37 @@ export interface AvisStats {
 export class ServicesService {
     private readonly logger = new Logger(ServicesService.name);
 
+    private readonly typeProfilJoin: TypeProfilJoinConfig = {
+        joinTable: 'service_type_profils',
+        fkColumn: 'service_id',
+    };
+
     constructor(
         private readonly resolver: DataSourceResolver,
         private readonly mailService: MailService,
         private readonly fichiersService: FichiersService,
+        private readonly typeProfilVisibility: TypeProfilVisibilityService,
     ) { }
+
+    /** Lit la checklist de types de profil taguée sur un service. */
+    async getTypeProfilIds(id: number): Promise<{ typeProfilIds: number[] }> {
+        await this.findOneOrFail(id);
+        const typeProfilIds = await this.typeProfilVisibility.getTypeProfilIds(this.typeProfilJoin, id);
+        return { typeProfilIds };
+    }
+
+    /** Remplace (replace-set) la checklist de types de profil d'un service. */
+    async setTypeProfilIds(id: number, typeProfilIds: number[]): Promise<{ typeProfilIds: number[] }> {
+        await this.findOneOrFail(id);
+        const saved = await this.typeProfilVisibility.setTypeProfilIds(this.typeProfilJoin, id, typeProfilIds);
+        return { typeProfilIds: saved };
+    }
+
+    private async findOneOrFail(id: number): Promise<Service> {
+        const service = await this.servicesRepository.findOne({ where: { id } });
+        if (!service) throw new NotFoundException('Service non trouvé');
+        return service;
+    }
 
     private get servicesRepository(): Repository<Service> { return this.resolver.getRepository(Service); }
     private get typesRepository(): Repository<Type> { return this.resolver.getRepository(Type); }
@@ -165,7 +196,7 @@ export class ServicesService {
         return this.servicesRepository.save(service);
     }
 
-    async findAll(pays: string, filters: ServiceFilterDto) {
+    async findAll(pays: string, filters: ServiceFilterDto, viewer?: ViewerContext) {
         const { localisation, type, tarifMin, tarifMax, search, type_contrat, page = 1, limit = 10 } = filters;
 
         const qb = this.servicesWithRelations()
@@ -193,6 +224,9 @@ export class ServicesService {
                     .orWhere('service.description ILIKE :search', { search: `%${search}%` });
             }));
         }
+
+        // Visibilité par type de profil : non-admin ⇒ non-tagué OU partage son type_profil.
+        await this.typeProfilVisibility.applyVisibilityFilter(qb, 'service', this.typeProfilJoin, viewer);
 
         const [data, total] = await qb
             .orderBy('service.created_at', 'DESC')

--- a/backend/src/type-profils/dto/create-type-profil.dto.ts
+++ b/backend/src/type-profils/dto/create-type-profil.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateTypeProfilDto {
+    @ApiProperty({ description: 'Titre du type de profil' })
+    @IsString()
+    @MaxLength(255)
+    titre: string;
+
+    @ApiProperty({ description: 'Sous-titre du type de profil', required: false })
+    @IsOptional()
+    @IsString()
+    @MaxLength(255)
+    sous_titre?: string;
+
+    // NB: l'icône n'est PAS dans ce DTO — elle est téléversée séparément via le
+    // registre R2 FilesModule (POST /files/type_profils/:uuid/icone/upload), comme
+    // categories.icone. `pays` non plus : le middleware le retire des DTO.
+}

--- a/backend/src/type-profils/dto/filter-type-profil.dto.ts
+++ b/backend/src/type-profils/dto/filter-type-profil.dto.ts
@@ -1,0 +1,4 @@
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+// Filtre de liste des types de profil. Réutilise page/limit/search/sort_order.
+export class FilterTypeProfilDto extends PaginationDto {}

--- a/backend/src/type-profils/dto/set-entity-type-profil.dto.ts
+++ b/backend/src/type-profils/dto/set-entity-type-profil.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsInt, IsOptional } from 'class-validator';
+import { IsArray, IsIn, IsInt, IsOptional } from 'class-validator';
 import { TAGGABLE_ENTITIES } from '../taggable-entities';
 
 export class SetEntityTypeProfilDto {
@@ -7,8 +7,13 @@ export class SetEntityTypeProfilDto {
   @IsIn(TAGGABLE_ENTITIES as unknown as string[])
   entity: string;
 
-  @ApiProperty({ required: false, nullable: true, description: 'Type de profil (null pour dissocier)' })
+  @ApiProperty({
+    type: [Number],
+    required: false,
+    description: 'Liste complète des types de profil (remplace la sélection ; [] pour dissocier)',
+  })
   @IsOptional()
-  @IsInt()
-  type_profil_id?: number | null;
+  @IsArray()
+  @IsInt({ each: true })
+  type_profil_ids?: number[];
 }

--- a/backend/src/type-profils/dto/set-entity-type-profil.dto.ts
+++ b/backend/src/type-profils/dto/set-entity-type-profil.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsInt, IsOptional } from 'class-validator';
+import { TAGGABLE_ENTITIES } from '../taggable-entities';
+
+export class SetEntityTypeProfilDto {
+  @ApiProperty({ enum: TAGGABLE_ENTITIES, description: 'Entité de contenu à associer' })
+  @IsIn(TAGGABLE_ENTITIES as unknown as string[])
+  entity: string;
+
+  @ApiProperty({ required: false, nullable: true, description: 'Type de profil (null pour dissocier)' })
+  @IsOptional()
+  @IsInt()
+  type_profil_id?: number | null;
+}

--- a/backend/src/type-profils/dto/update-type-profil.dto.ts
+++ b/backend/src/type-profils/dto/update-type-profil.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTypeProfilDto } from './create-type-profil.dto';
+
+export class UpdateTypeProfilDto extends PartialType(CreateTypeProfilDto) {}

--- a/backend/src/type-profils/entities/entity-type-profil.entity.ts
+++ b/backend/src/type-profils/entities/entity-type-profil.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { TypeProfil } from './type-profil.entity';
+
+// Registre : associe UN type de profil à une entité de contenu (par pays).
+// Unicité (entity, pays) — voir migration 044.
+@Entity('entity_type_profil')
+export class EntityTypeProfil {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 50 })
+  entity: string;
+
+  @Column()
+  type_profil_id: number;
+
+  @ManyToOne(() => TypeProfil, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'type_profil_id' })
+  type_profil: TypeProfil;
+
+  @Column({ type: 'varchar', length: 50, default: 'benin' })
+  pays: string;
+
+  @CreateDateColumn({ type: 'timestamp with time zone', name: 'date_creation' })
+  date_creation: Date;
+}

--- a/backend/src/type-profils/entities/type-profil.entity.ts
+++ b/backend/src/type-profils/entities/type-profil.entity.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('type_profils')
+export class TypeProfil {
+    @ApiProperty({ description: 'ID unique du type de profil' })
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ApiProperty({ description: 'Titre du type de profil' })
+    @Column({ type: 'varchar', length: 255 })
+    titre: string;
+
+    @ApiProperty({ description: 'Sous-titre du type de profil', required: false })
+    @Column({ type: 'varchar', length: 255, nullable: true })
+    sous_titre?: string;
+
+    // Icône via le registre R2 FilesModule (slot public `type_profils.icone`).
+    // Colonnes NULLABLE : un admin peut créer un type de profil sans icône.
+    // Un slot public écrit l'URL complète directement dans icone_path.
+    @ApiProperty({ description: 'Chemin/URL R2 de l\'icône (slot public type_profils.icone)', required: false })
+    @Column({ type: 'varchar', nullable: true })
+    icone_path?: string;
+
+    @ApiProperty({ description: 'Extension de l\'icône', required: false })
+    @Column({ type: 'varchar', nullable: true })
+    icone_extension?: string;
+
+    @Column({ type: 'varchar', length: 50, default: 'benin' })
+    pays: string;
+
+    @ApiProperty({ description: 'Date de création' })
+    @CreateDateColumn({ name: 'date_creation', type: 'timestamptz' })
+    date_creation: Date;
+}

--- a/backend/src/type-profils/entities/type-profil.entity.ts
+++ b/backend/src/type-profils/entities/type-profil.entity.ts
@@ -7,6 +7,12 @@ export class TypeProfil {
     @PrimaryGeneratedColumn()
     id: number;
 
+    // Requis par le registre R2 FilesModule (résolution de la ligne par uuid
+    // pour le slot public type_profils.icone). Mirroir de categories.uuid.
+    @ApiProperty({ description: 'UUID du type de profil' })
+    @Column({ type: 'uuid', unique: true, default: () => 'gen_random_uuid()' })
+    uuid: string;
+
     @ApiProperty({ description: 'Titre du type de profil' })
     @Column({ type: 'varchar', length: 255 })
     titre: string;

--- a/backend/src/type-profils/taggable-entities.ts
+++ b/backend/src/type-profils/taggable-entities.ts
@@ -1,0 +1,4 @@
+// The 5 content entities whose audience is gated by a type_profil via the registry
+// (entity_type_profil). Canonical singular names, matching the legacy join-table prefix.
+export const TAGGABLE_ENTITIES = ['evenement', 'opportunite', 'forum', 'service', 'offre'] as const;
+export type TaggableEntity = (typeof TAGGABLE_ENTITIES)[number];

--- a/backend/src/type-profils/type-profil-visibility.service.ts
+++ b/backend/src/type-profils/type-profil-visibility.service.ts
@@ -59,17 +59,18 @@ export class TypeProfilVisibilityService {
     async isEntityHidden(cfg: TypeProfilJoinConfig, viewer?: ViewerContext): Promise<boolean> {
         if (!viewer || viewer.role === RoleType.ADMIN) return false;
         const pays = this.context.getCountry();
-        const entityTypeProfilId = await this.getEntityAssociation(pays, cfg.entity);
-        if (entityTypeProfilId == null) return false; // non associée → publique
+        const entityTypeProfilIds = await this.getEntityAssociations(pays, cfg.entity);
+        if (entityTypeProfilIds.length === 0) return false; // non associée → publique
         const viewerTypeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
-        return viewerTypeProfilId == null || viewerTypeProfilId !== entityTypeProfilId;
+        // Visible si l'appelant partage l'UN des types de profil associés à l'entité.
+        return viewerTypeProfilId == null || !entityTypeProfilIds.includes(viewerTypeProfilId);
     }
 
-    private async getEntityAssociation(pays: string, entity: string): Promise<number | null> {
-        const row = await this.resolver
+    private async getEntityAssociations(pays: string, entity: string): Promise<number[]> {
+        const rows = await this.resolver
             .getRepository(EntityTypeProfil)
-            .findOne({ where: { entity, pays } });
-        return row?.type_profil_id ?? null;
+            .find({ where: { entity, pays } });
+        return rows.map((r) => r.type_profil_id);
     }
 
     /** Lit la checklist (ids de type_profil) taguée sur une ligne d'entité. */

--- a/backend/src/type-profils/type-profil-visibility.service.ts
+++ b/backend/src/type-profils/type-profil-visibility.service.ts
@@ -1,0 +1,156 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { Brackets, SelectQueryBuilder } from 'typeorm';
+import { DataSourceResolver } from '../config/data-source-resolver.service';
+import { RoleType, Utilisateur } from '../utilisateurs/entities/utilisateur.entity';
+
+/**
+ * Identifie une jointure entité↔type_profils. `joinTable` et `fkColumn` sont des
+ * CONSTANTES internes (définies par chaque service, jamais des entrées client),
+ * donc leur interpolation dans du SQL brut ne présente aucun risque d'injection.
+ */
+export interface TypeProfilJoinConfig {
+    /** table de jointure, ex. 'opportunite_type_profils' */
+    joinTable: string;
+    /** colonne FK de l'entité dans la table de jointure, ex. 'opportunite_id' */
+    fkColumn: string;
+}
+
+/** Contexte de l'appelant, dérivé du JWT (req.user). */
+export interface ViewerContext {
+    role?: string;
+    utilisateurId?: number;
+}
+
+/**
+ * Helper PARTAGÉ (un seul, pas 5 copies) pour le tagging + la visibilité par
+ * type de profil sur les 5 entités de contenu.
+ */
+@Injectable()
+export class TypeProfilVisibilityService {
+    constructor(private readonly resolver: DataSourceResolver) { }
+
+    /**
+     * Applique la règle de visibilité à un QueryBuilder de findAll :
+     * un appelant NON-admin ne voit une ligne que si elle est NON-TAGUÉE
+     * (aucune ligne de jointure) OU si elle partage le type_profil_id de
+     * l'appelant. Les admins (et les contextes sans viewer, ex. appels
+     * internes/panel admin) ne sont PAS affectés — aucun filtre ajouté.
+     */
+    async applyVisibilityFilter(
+        qb: SelectQueryBuilder<any>,
+        alias: string,
+        cfg: TypeProfilJoinConfig,
+        viewer?: ViewerContext,
+    ): Promise<void> {
+        // Admins & contextes sans viewer : inchangés.
+        if (!viewer || viewer.role === RoleType.ADMIN) return;
+
+        const typeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
+
+        const untagged =
+            `NOT EXISTS (SELECT 1 FROM ${cfg.joinTable} j WHERE j.${cfg.fkColumn} = ${alias}.id)`;
+
+        if (typeProfilId == null) {
+            // Appelant sans type_profil → uniquement les lignes non-taguées (publiques). Intentionnel.
+            qb.andWhere(untagged);
+            return;
+        }
+
+        qb.andWhere(
+            new Brackets((w) => {
+                w.where(untagged).orWhere(
+                    `EXISTS (SELECT 1 FROM ${cfg.joinTable} j WHERE j.${cfg.fkColumn} = ${alias}.id AND j.type_profil_id = :__viewerTypeProfilId)`,
+                    { __viewerTypeProfilId: typeProfilId },
+                );
+            }),
+        );
+    }
+
+    /**
+     * Variante COMPLÉMENT pour les services basés sur repository.findAndCount
+     * (pas de QueryBuilder — ex. forum). Renvoie les ids d'entités CACHÉES pour
+     * l'appelant (= taguées ET ne partageant PAS son type_profil), à exclure via
+     * `where.id = Not(In(...))`. Renvoie null si aucun filtre ne s'applique
+     * (admin / sans viewer). Même règle que applyVisibilityFilter, exprimée en
+     * complément ; l'ensemble est borné par le nombre de lignes TAGUÉES (minorité).
+     */
+    async hiddenEntityIds(cfg: TypeProfilJoinConfig, viewer?: ViewerContext): Promise<number[] | null> {
+        if (!viewer || viewer.role === RoleType.ADMIN) return null;
+
+        const typeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
+        const ds = this.resolver.getDataSource();
+
+        let rows: any[];
+        if (typeProfilId == null) {
+            // Sans type_profil → toutes les lignes taguées sont cachées.
+            rows = await ds.query(`SELECT DISTINCT ${cfg.fkColumn} AS id FROM ${cfg.joinTable}`);
+        } else {
+            // Taguées SANS aucun tag correspondant au type_profil de l'appelant.
+            rows = await ds.query(
+                `SELECT ${cfg.fkColumn} AS id FROM ${cfg.joinTable}
+                 GROUP BY ${cfg.fkColumn}
+                 HAVING SUM(CASE WHEN type_profil_id = $1 THEN 1 ELSE 0 END) = 0`,
+                [typeProfilId],
+            );
+        }
+        return rows.map((r) => Number(r.id));
+    }
+
+    /** Lit la checklist (ids de type_profil) taguée sur une ligne d'entité. */
+    async getTypeProfilIds(cfg: TypeProfilJoinConfig, entityId: number): Promise<number[]> {
+        const rows = await this.resolver
+            .getDataSource()
+            .query(
+                `SELECT type_profil_id FROM ${cfg.joinTable} WHERE ${cfg.fkColumn} = $1 ORDER BY type_profil_id`,
+                [entityId],
+            );
+        return rows.map((r: any) => Number(r.type_profil_id));
+    }
+
+    /**
+     * Remplace intégralement (replace-set, transactionnel) la checklist d'une
+     * ligne d'entité. Valide d'abord que chaque type_profil existe (évite une
+     * violation de FK renvoyée en 500). Renvoie la checklist résultante.
+     */
+    async setTypeProfilIds(
+        cfg: TypeProfilJoinConfig,
+        entityId: number,
+        typeProfilIds: number[],
+    ): Promise<number[]> {
+        const unique = Array.from(
+            new Set((typeProfilIds ?? []).map((n) => Number(n)).filter((n) => Number.isInteger(n))),
+        );
+
+        const ds = this.resolver.getDataSource();
+
+        if (unique.length) {
+            const existing = await ds.query(`SELECT id FROM type_profils WHERE id = ANY($1)`, [unique]);
+            const existingIds = new Set(existing.map((r: any) => Number(r.id)));
+            const missing = unique.filter((id) => !existingIds.has(id));
+            if (missing.length) {
+                throw new BadRequestException(`Type(s) de profil introuvable(s): ${missing.join(', ')}`);
+            }
+        }
+
+        await ds.transaction(async (em) => {
+            await em.query(`DELETE FROM ${cfg.joinTable} WHERE ${cfg.fkColumn} = $1`, [entityId]);
+            for (const tpId of unique) {
+                await em.query(
+                    `INSERT INTO ${cfg.joinTable} (${cfg.fkColumn}, type_profil_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+                    [entityId, tpId],
+                );
+            }
+        });
+
+        return this.getTypeProfilIds(cfg, entityId);
+    }
+
+    private async resolveViewerTypeProfilId(utilisateurId?: number): Promise<number | null> {
+        if (!utilisateurId) return null;
+        const row = await this.resolver.getRepository(Utilisateur).findOne({
+            where: { id: utilisateurId },
+            select: ['id', 'type_profil_id'],
+        });
+        return row?.type_profil_id ?? null;
+    }
+}

--- a/backend/src/type-profils/type-profil-visibility.service.ts
+++ b/backend/src/type-profils/type-profil-visibility.service.ts
@@ -1,17 +1,22 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { Brackets, SelectQueryBuilder } from 'typeorm';
+import { SelectQueryBuilder } from 'typeorm';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
+import { CountryContextService } from '../config/country-context.service';
 import { RoleType, Utilisateur } from '../utilisateurs/entities/utilisateur.entity';
+import { EntityTypeProfil } from './entities/entity-type-profil.entity';
 
 /**
- * Identifie une jointure entité↔type_profils. `joinTable` et `fkColumn` sont des
- * CONSTANTES internes (définies par chaque service, jamais des entrées client),
- * donc leur interpolation dans du SQL brut ne présente aucun risque d'injection.
+ * Identifie une entité de contenu pour la visibilité par type de profil.
+ * `entity` sert au REGISTRE (entity_type_profil). `joinTable`/`fkColumn` sont
+ * hérités du tagging par-ligne (désormais dormant) et restent des CONSTANTES
+ * internes (jamais des entrées client).
  */
 export interface TypeProfilJoinConfig {
-    /** table de jointure, ex. 'opportunite_type_profils' */
+    /** nom d'entité pour le registre, ex. 'evenement' */
+    entity: string;
+    /** table de jointure héritée (dormant), ex. 'opportunite_type_profils' */
     joinTable: string;
-    /** colonne FK de l'entité dans la table de jointure, ex. 'opportunite_id' */
+    /** colonne FK héritée (dormant), ex. 'opportunite_id' */
     fkColumn: string;
 }
 
@@ -22,19 +27,21 @@ export interface ViewerContext {
 }
 
 /**
- * Helper PARTAGÉ (un seul, pas 5 copies) pour le tagging + la visibilité par
- * type de profil sur les 5 entités de contenu.
+ * Helper PARTAGÉ pour la visibilité par type de profil (modèle REGISTRE).
+ * L'audience est gérée AU NIVEAU DE L'ENTITÉ via `entity_type_profil` :
+ * une entité non associée est publique ; sinon elle n'est visible que par les
+ * appelants partageant le type_profil associé. Les admins ne sont pas filtrés.
  */
 @Injectable()
 export class TypeProfilVisibilityService {
-    constructor(private readonly resolver: DataSourceResolver) { }
+    constructor(
+        private readonly resolver: DataSourceResolver,
+        private readonly context: CountryContextService,
+    ) { }
 
     /**
-     * Applique la règle de visibilité à un QueryBuilder de findAll :
-     * un appelant NON-admin ne voit une ligne que si elle est NON-TAGUÉE
-     * (aucune ligne de jointure) OU si elle partage le type_profil_id de
-     * l'appelant. Les admins (et les contextes sans viewer, ex. appels
-     * internes/panel admin) ne sont PAS affectés — aucun filtre ajouté.
+     * QueryBuilder findAll : si l'entité est masquée pour l'appelant, aucune
+     * ligne ne remonte (`1 = 0`). `alias` conservé pour compat de signature.
      */
     async applyVisibilityFilter(
         qb: SelectQueryBuilder<any>,
@@ -42,58 +49,27 @@ export class TypeProfilVisibilityService {
         cfg: TypeProfilJoinConfig,
         viewer?: ViewerContext,
     ): Promise<void> {
-        // Admins & contextes sans viewer : inchangés.
-        if (!viewer || viewer.role === RoleType.ADMIN) return;
-
-        const typeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
-
-        const untagged =
-            `NOT EXISTS (SELECT 1 FROM ${cfg.joinTable} j WHERE j.${cfg.fkColumn} = ${alias}.id)`;
-
-        if (typeProfilId == null) {
-            // Appelant sans type_profil → uniquement les lignes non-taguées (publiques). Intentionnel.
-            qb.andWhere(untagged);
-            return;
-        }
-
-        qb.andWhere(
-            new Brackets((w) => {
-                w.where(untagged).orWhere(
-                    `EXISTS (SELECT 1 FROM ${cfg.joinTable} j WHERE j.${cfg.fkColumn} = ${alias}.id AND j.type_profil_id = :__viewerTypeProfilId)`,
-                    { __viewerTypeProfilId: typeProfilId },
-                );
-            }),
-        );
+        if (await this.isEntityHidden(cfg, viewer)) qb.andWhere('1 = 0');
     }
 
     /**
-     * Variante COMPLÉMENT pour les services basés sur repository.findAndCount
-     * (pas de QueryBuilder — ex. forum). Renvoie les ids d'entités CACHÉES pour
-     * l'appelant (= taguées ET ne partageant PAS son type_profil), à exclure via
-     * `where.id = Not(In(...))`. Renvoie null si aucun filtre ne s'applique
-     * (admin / sans viewer). Même règle que applyVisibilityFilter, exprimée en
-     * complément ; l'ensemble est borné par le nombre de lignes TAGUÉES (minorité).
+     * Vrai si l'entité entière est masquée pour l'appelant. Pour les services
+     * basés sur repository.findAndCount (ex. forum) : renvoyer une page vide.
      */
-    async hiddenEntityIds(cfg: TypeProfilJoinConfig, viewer?: ViewerContext): Promise<number[] | null> {
-        if (!viewer || viewer.role === RoleType.ADMIN) return null;
+    async isEntityHidden(cfg: TypeProfilJoinConfig, viewer?: ViewerContext): Promise<boolean> {
+        if (!viewer || viewer.role === RoleType.ADMIN) return false;
+        const pays = this.context.getCountry();
+        const entityTypeProfilId = await this.getEntityAssociation(pays, cfg.entity);
+        if (entityTypeProfilId == null) return false; // non associée → publique
+        const viewerTypeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
+        return viewerTypeProfilId == null || viewerTypeProfilId !== entityTypeProfilId;
+    }
 
-        const typeProfilId = await this.resolveViewerTypeProfilId(viewer.utilisateurId);
-        const ds = this.resolver.getDataSource();
-
-        let rows: any[];
-        if (typeProfilId == null) {
-            // Sans type_profil → toutes les lignes taguées sont cachées.
-            rows = await ds.query(`SELECT DISTINCT ${cfg.fkColumn} AS id FROM ${cfg.joinTable}`);
-        } else {
-            // Taguées SANS aucun tag correspondant au type_profil de l'appelant.
-            rows = await ds.query(
-                `SELECT ${cfg.fkColumn} AS id FROM ${cfg.joinTable}
-                 GROUP BY ${cfg.fkColumn}
-                 HAVING SUM(CASE WHEN type_profil_id = $1 THEN 1 ELSE 0 END) = 0`,
-                [typeProfilId],
-            );
-        }
-        return rows.map((r) => Number(r.id));
+    private async getEntityAssociation(pays: string, entity: string): Promise<number | null> {
+        const row = await this.resolver
+            .getRepository(EntityTypeProfil)
+            .findOne({ where: { entity, pays } });
+        return row?.type_profil_id ?? null;
     }
 
     /** Lit la checklist (ids de type_profil) taguée sur une ligne d'entité. */

--- a/backend/src/type-profils/type-profils.controller.ts
+++ b/backend/src/type-profils/type-profils.controller.ts
@@ -48,9 +48,9 @@ export class TypeProfilsController {
     @Roles(RoleType.ADMIN)
     @ApiBearerAuth()
     @Put('registry')
-    @ApiOperation({ summary: 'Associer/dissocier une entité à un type de profil' })
+    @ApiOperation({ summary: "Remplacer la liste des types de profil d'une entité (audience)" })
     setRegistry(@CurrentCountry() pays: string, @Body() dto: SetEntityTypeProfilDto) {
-        return this.typeProfilsService.setAssociation(pays, dto.entity, dto.type_profil_id ?? null);
+        return this.typeProfilsService.setAssociations(pays, dto.entity, dto.type_profil_ids ?? []);
     }
 
     @UseGuards(JwtAuthGuard)

--- a/backend/src/type-profils/type-profils.controller.ts
+++ b/backend/src/type-profils/type-profils.controller.ts
@@ -55,6 +55,14 @@ export class TypeProfilsController {
 
     @UseGuards(JwtAuthGuard)
     @ApiBearerAuth()
+    @Get(':uuid/entities')
+    @ApiOperation({ summary: 'Entités de contenu associées à un type de profil (par uuid)' })
+    getEntities(@CurrentCountry() pays: string, @Param('uuid') uuid: string) {
+        return this.typeProfilsService.getEntitiesForTypeProfil(pays, uuid);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
     @Get(':id')
     @ApiOperation({ summary: 'Récupérer un type de profil par son ID' })
     @ApiResponse({ status: 200, description: 'Type de profil récupéré avec succès' })

--- a/backend/src/type-profils/type-profils.controller.ts
+++ b/backend/src/type-profils/type-profils.controller.ts
@@ -9,6 +9,7 @@ import { TypeProfilsService } from './type-profils.service';
 import { CreateTypeProfilDto } from './dto/create-type-profil.dto';
 import { UpdateTypeProfilDto } from './dto/update-type-profil.dto';
 import { FilterTypeProfilDto } from './dto/filter-type-profil.dto';
+import { SetEntityTypeProfilDto } from './dto/set-entity-type-profil.dto';
 
 @ApiTags('type-profils')
 @Controller('type-profils')
@@ -32,6 +33,24 @@ export class TypeProfilsController {
     @ApiResponse({ status: 200, description: 'Liste récupérée avec succès' })
     findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterTypeProfilDto) {
         return this.typeProfilsService.findAll(pays, filterDto);
+    }
+
+    // REGISTRE entité ↔ type de profil. Déclaré AVANT :id pour ne pas capter 'registry'.
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @Get('registry')
+    @ApiOperation({ summary: 'Registre : type de profil associé à chaque entité (audience)' })
+    getRegistry(@CurrentCountry() pays: string) {
+        return this.typeProfilsService.getRegistry(pays);
+    }
+
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @Put('registry')
+    @ApiOperation({ summary: 'Associer/dissocier une entité à un type de profil' })
+    setRegistry(@CurrentCountry() pays: string, @Body() dto: SetEntityTypeProfilDto) {
+        return this.typeProfilsService.setAssociation(pays, dto.entity, dto.type_profil_id ?? null);
     }
 
     @UseGuards(JwtAuthGuard)

--- a/backend/src/type-profils/type-profils.controller.ts
+++ b/backend/src/type-profils/type-profils.controller.ts
@@ -1,0 +1,72 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../auth/guards/role.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { RoleType } from '../utilisateurs/entities/utilisateur.entity';
+import { CurrentCountry } from '../common/decorators/current-country.decorator';
+import { TypeProfilsService } from './type-profils.service';
+import { CreateTypeProfilDto } from './dto/create-type-profil.dto';
+import { UpdateTypeProfilDto } from './dto/update-type-profil.dto';
+import { FilterTypeProfilDto } from './dto/filter-type-profil.dto';
+
+@ApiTags('type-profils')
+@Controller('type-profils')
+export class TypeProfilsController {
+    constructor(private readonly typeProfilsService: TypeProfilsService) { }
+
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @Post()
+    @ApiOperation({ summary: 'Créer un type de profil' })
+    @ApiResponse({ status: 201, description: 'Type de profil créé avec succès' })
+    create(@CurrentCountry() pays: string, @Body() createTypeProfilDto: CreateTypeProfilDto) {
+        return this.typeProfilsService.create(pays, createTypeProfilDto);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @Get()
+    @ApiOperation({ summary: 'Récupérer la liste des types de profil' })
+    @ApiResponse({ status: 200, description: 'Liste récupérée avec succès' })
+    findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterTypeProfilDto) {
+        return this.typeProfilsService.findAll(pays, filterDto);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @Get(':id')
+    @ApiOperation({ summary: 'Récupérer un type de profil par son ID' })
+    @ApiResponse({ status: 200, description: 'Type de profil récupéré avec succès' })
+    @ApiResponse({ status: 404, description: 'Type de profil non trouvé' })
+    findOne(@CurrentCountry() pays: string, @Param('id') id: string) {
+        return this.typeProfilsService.findOne(pays, +id);
+    }
+
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @Put(':id')
+    @ApiOperation({ summary: 'Mettre à jour un type de profil' })
+    @ApiResponse({ status: 200, description: 'Type de profil mis à jour avec succès' })
+    @ApiResponse({ status: 404, description: 'Type de profil non trouvé' })
+    update(
+        @CurrentCountry() pays: string,
+        @Param('id') id: string,
+        @Body() updateTypeProfilDto: UpdateTypeProfilDto,
+    ) {
+        return this.typeProfilsService.update(pays, +id, updateTypeProfilDto);
+    }
+
+    @UseGuards(JwtAuthGuard, RoleGuard)
+    @Roles(RoleType.ADMIN)
+    @ApiBearerAuth()
+    @Delete(':id')
+    @ApiOperation({ summary: 'Supprimer un type de profil' })
+    @ApiResponse({ status: 200, description: 'Type de profil supprimé avec succès' })
+    @ApiResponse({ status: 404, description: 'Type de profil non trouvé' })
+    remove(@CurrentCountry() pays: string, @Param('id') id: string) {
+        return this.typeProfilsService.remove(pays, +id);
+    }
+}

--- a/backend/src/type-profils/type-profils.module.ts
+++ b/backend/src/type-profils/type-profils.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeProfil } from './entities/type-profil.entity';
 import { TypeProfilsService } from './type-profils.service';
 import { TypeProfilsController } from './type-profils.controller';
+import { TypeProfilVisibilityService } from './type-profil-visibility.service';
 
 @Module({
     imports: [TypeOrmModule.forFeature([TypeProfil])],
     controllers: [TypeProfilsController],
-    providers: [TypeProfilsService],
-    exports: [TypeProfilsService],
+    providers: [TypeProfilsService, TypeProfilVisibilityService],
+    exports: [TypeProfilsService, TypeProfilVisibilityService],
 })
 export class TypeProfilsModule { }

--- a/backend/src/type-profils/type-profils.module.ts
+++ b/backend/src/type-profils/type-profils.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeProfil } from './entities/type-profil.entity';
+import { TypeProfilsService } from './type-profils.service';
+import { TypeProfilsController } from './type-profils.controller';
+
+@Module({
+    imports: [TypeOrmModule.forFeature([TypeProfil])],
+    controllers: [TypeProfilsController],
+    providers: [TypeProfilsService],
+    exports: [TypeProfilsService],
+})
+export class TypeProfilsModule { }

--- a/backend/src/type-profils/type-profils.module.ts
+++ b/backend/src/type-profils/type-profils.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeProfil } from './entities/type-profil.entity';
+import { EntityTypeProfil } from './entities/entity-type-profil.entity';
 import { TypeProfilsService } from './type-profils.service';
 import { TypeProfilsController } from './type-profils.controller';
 import { TypeProfilVisibilityService } from './type-profil-visibility.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([TypeProfil])],
+    imports: [TypeOrmModule.forFeature([TypeProfil, EntityTypeProfil])],
     controllers: [TypeProfilsController],
     providers: [TypeProfilsService, TypeProfilVisibilityService],
     exports: [TypeProfilsService, TypeProfilVisibilityService],

--- a/backend/src/type-profils/type-profils.service.ts
+++ b/backend/src/type-profils/type-profils.service.ts
@@ -66,6 +66,20 @@ export class TypeProfilsService {
         return { entity, type_profils: rows.map((r) => this.tp(r.type_profil)) };
     }
 
+    // Inverse du registre : entités associées à un type de profil (par uuid).
+    async getEntitiesForTypeProfil(pays: string, uuid: string): Promise<string[]> {
+        const typeProfil = await this.typeProfilRepository.findOne({ where: { uuid, pays } });
+        if (!typeProfil) {
+            throw new NotFoundException(`Type de profil ${uuid} non trouvé pour ce pays`);
+        }
+        const rows = await this.registryRepository.find({
+            where: { type_profil_id: typeProfil.id, pays },
+        });
+        const associated = new Set(rows.map((r) => r.entity));
+        // Ordre canonique des entités.
+        return TAGGABLE_ENTITIES.filter((e) => associated.has(e));
+    }
+
     // pays vient de @CurrentCountry() : PREMIER argument, jamais dans un DTO.
     async create(pays: string, dto: CreateTypeProfilDto): Promise<TypeProfil> {
         this.logger.log(`Création d'un type de profil: ${dto.titre} (pays=${pays})`);

--- a/backend/src/type-profils/type-profils.service.ts
+++ b/backend/src/type-profils/type-profils.service.ts
@@ -27,37 +27,43 @@ export class TypeProfilsService {
         return t ? { uuid: t.uuid, id: t.id, titre: t.titre, sous_titre: t.sous_titre ?? null } : null;
     }
 
-    // REGISTRE — quel type de profil est associé à chaque entité (par pays).
-    // Renvoie toujours les 5 entités (type_profil = null si non associée = publique).
+    // REGISTRE — les types de profil associés à chaque entité (par pays). Une entité
+    // peut en avoir PLUSIEURS. Renvoie toujours les 5 entités (liste vide = publique).
     async getRegistry(pays: string) {
         const rows = await this.registryRepository.find({ where: { pays }, relations: ['type_profil'] });
-        const byEntity = new Map(rows.map((r) => [r.entity, r.type_profil]));
-        return TAGGABLE_ENTITIES.map((entity) => ({ entity, type_profil: this.tp(byEntity.get(entity)) }));
+        const byEntity = new Map<string, any[]>();
+        for (const r of rows) {
+            if (!byEntity.has(r.entity)) byEntity.set(r.entity, []);
+            byEntity.get(r.entity)!.push(this.tp(r.type_profil));
+        }
+        return TAGGABLE_ENTITIES.map((entity) => ({ entity, type_profils: byEntity.get(entity) ?? [] }));
     }
 
-    // Associe (ou dissocie si type_profil_id = null) une entité à un type de profil.
-    async setAssociation(pays: string, entity: string, typeProfilId: number | null) {
+    // Remplace INTÉGRALEMENT la liste des types de profil d'une entité (replace-set).
+    // [] = dissocier (l'entité redevient publique). Valide que chaque type existe.
+    async setAssociations(pays: string, entity: string, typeProfilIds: number[]) {
         if (!TAGGABLE_ENTITIES.includes(entity as any)) {
             throw new BadRequestException(`Entité inconnue: '${entity}'. Attendu: ${TAGGABLE_ENTITIES.join(', ')}`);
         }
-        const existing = await this.registryRepository.findOne({ where: { entity, pays } });
-        if (typeProfilId == null) {
-            if (existing) await this.registryRepository.remove(existing);
-            return { entity, type_profil: null };
+        const unique = Array.from(
+            new Set((typeProfilIds ?? []).map((n) => Number(n)).filter((n) => Number.isInteger(n))),
+        );
+        if (unique.length) {
+            const existing = await this.typeProfilRepository.find({ where: unique.map((id) => ({ id, pays })) });
+            const existingIds = new Set(existing.map((t) => t.id));
+            const missing = unique.filter((id) => !existingIds.has(id));
+            if (missing.length) {
+                throw new NotFoundException(`Type(s) de profil introuvable(s) pour ce pays: ${missing.join(', ')}`);
+            }
         }
-        const typeProfil = await this.typeProfilRepository.findOne({ where: { id: typeProfilId, pays } });
-        if (!typeProfil) {
-            throw new NotFoundException(`Type de profil ${typeProfilId} non trouvé pour ce pays`);
-        }
-        if (existing) {
-            existing.type_profil_id = typeProfilId;
-            await this.registryRepository.save(existing);
-        } else {
-            await this.registryRepository.save(
-                this.registryRepository.create({ entity, type_profil_id: typeProfilId, pays }),
-            );
-        }
-        return { entity, type_profil: this.tp(typeProfil) };
+        await this.resolver.getDataSource().transaction(async (em) => {
+            await em.delete(EntityTypeProfil, { entity, pays });
+            for (const tpId of unique) {
+                await em.save(em.create(EntityTypeProfil, { entity, type_profil_id: tpId, pays }));
+            }
+        });
+        const rows = await this.registryRepository.find({ where: { entity, pays }, relations: ['type_profil'] });
+        return { entity, type_profils: rows.map((r) => this.tp(r.type_profil)) };
     }
 
     // pays vient de @CurrentCountry() : PREMIER argument, jamais dans un DTO.

--- a/backend/src/type-profils/type-profils.service.ts
+++ b/backend/src/type-profils/type-profils.service.ts
@@ -1,8 +1,10 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
 import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
 import { TypeProfil } from './entities/type-profil.entity';
+import { EntityTypeProfil } from './entities/entity-type-profil.entity';
+import { TAGGABLE_ENTITIES } from './taggable-entities';
 import { CreateTypeProfilDto } from './dto/create-type-profil.dto';
 import { UpdateTypeProfilDto } from './dto/update-type-profil.dto';
 import { FilterTypeProfilDto } from './dto/filter-type-profil.dto';
@@ -15,6 +17,47 @@ export class TypeProfilsService {
 
     private get typeProfilRepository(): Repository<TypeProfil> {
         return this.resolver.getRepository(TypeProfil);
+    }
+
+    private get registryRepository(): Repository<EntityTypeProfil> {
+        return this.resolver.getRepository(EntityTypeProfil);
+    }
+
+    private tp(t?: TypeProfil | null) {
+        return t ? { uuid: t.uuid, id: t.id, titre: t.titre, sous_titre: t.sous_titre ?? null } : null;
+    }
+
+    // REGISTRE — quel type de profil est associé à chaque entité (par pays).
+    // Renvoie toujours les 5 entités (type_profil = null si non associée = publique).
+    async getRegistry(pays: string) {
+        const rows = await this.registryRepository.find({ where: { pays }, relations: ['type_profil'] });
+        const byEntity = new Map(rows.map((r) => [r.entity, r.type_profil]));
+        return TAGGABLE_ENTITIES.map((entity) => ({ entity, type_profil: this.tp(byEntity.get(entity)) }));
+    }
+
+    // Associe (ou dissocie si type_profil_id = null) une entité à un type de profil.
+    async setAssociation(pays: string, entity: string, typeProfilId: number | null) {
+        if (!TAGGABLE_ENTITIES.includes(entity as any)) {
+            throw new BadRequestException(`Entité inconnue: '${entity}'. Attendu: ${TAGGABLE_ENTITIES.join(', ')}`);
+        }
+        const existing = await this.registryRepository.findOne({ where: { entity, pays } });
+        if (typeProfilId == null) {
+            if (existing) await this.registryRepository.remove(existing);
+            return { entity, type_profil: null };
+        }
+        const typeProfil = await this.typeProfilRepository.findOne({ where: { id: typeProfilId, pays } });
+        if (!typeProfil) {
+            throw new NotFoundException(`Type de profil ${typeProfilId} non trouvé pour ce pays`);
+        }
+        if (existing) {
+            existing.type_profil_id = typeProfilId;
+            await this.registryRepository.save(existing);
+        } else {
+            await this.registryRepository.save(
+                this.registryRepository.create({ entity, type_profil_id: typeProfilId, pays }),
+            );
+        }
+        return { entity, type_profil: this.tp(typeProfil) };
     }
 
     // pays vient de @CurrentCountry() : PREMIER argument, jamais dans un DTO.

--- a/backend/src/type-profils/type-profils.service.ts
+++ b/backend/src/type-profils/type-profils.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { DataSourceResolver } from '../config/data-source-resolver.service';
+import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
+import { TypeProfil } from './entities/type-profil.entity';
+import { CreateTypeProfilDto } from './dto/create-type-profil.dto';
+import { UpdateTypeProfilDto } from './dto/update-type-profil.dto';
+import { FilterTypeProfilDto } from './dto/filter-type-profil.dto';
+
+@Injectable()
+export class TypeProfilsService {
+    private readonly logger = new Logger(TypeProfilsService.name);
+
+    constructor(private readonly resolver: DataSourceResolver) { }
+
+    private get typeProfilRepository(): Repository<TypeProfil> {
+        return this.resolver.getRepository(TypeProfil);
+    }
+
+    // pays vient de @CurrentCountry() : PREMIER argument, jamais dans un DTO.
+    async create(pays: string, dto: CreateTypeProfilDto): Promise<TypeProfil> {
+        this.logger.log(`Création d'un type de profil: ${dto.titre} (pays=${pays})`);
+        const typeProfil = this.typeProfilRepository.create({ ...dto, pays });
+        return this.typeProfilRepository.save(typeProfil);
+    }
+
+    async findAll(pays: string, filterDto: FilterTypeProfilDto): Promise<PaginationResponse<TypeProfil>> {
+        const { page = 1, limit = 10, search, sort_order = 'ASC' } = filterDto;
+        this.logger.log(`Récupération des types de profil (pays=${pays}) - Page: ${page}, Limit: ${limit}`);
+
+        const queryBuilder = this.typeProfilRepository
+            .createQueryBuilder('type_profil')
+            .where('type_profil.pays = :pays', { pays });
+
+        if (search) {
+            queryBuilder.andWhere(
+                '(unaccent(type_profil.titre) ILIKE unaccent(:search) OR unaccent(type_profil.sous_titre) ILIKE unaccent(:search))',
+                { search: `%${search}%` },
+            );
+        }
+
+        queryBuilder
+            .orderBy('type_profil.titre', sort_order)
+            .skip((page - 1) * limit)
+            .take(limit);
+
+        const [data, total] = await queryBuilder.getManyAndCount();
+
+        return {
+            data,
+            total,
+            page,
+            limit,
+            totalPages: Math.ceil(total / limit),
+        };
+    }
+
+    async findOne(pays: string, id: number): Promise<TypeProfil> {
+        const typeProfil = await this.typeProfilRepository.findOne({ where: { id, pays } });
+        if (!typeProfil) {
+            throw new NotFoundException(`Type de profil avec l'ID ${id} non trouvé`);
+        }
+        return typeProfil;
+    }
+
+    async update(pays: string, id: number, dto: UpdateTypeProfilDto): Promise<TypeProfil> {
+        const typeProfil = await this.findOne(pays, id);
+        Object.assign(typeProfil, dto);
+        return this.typeProfilRepository.save(typeProfil);
+    }
+
+    async remove(pays: string, id: number): Promise<void> {
+        const typeProfil = await this.findOne(pays, id);
+        await this.typeProfilRepository.remove(typeProfil);
+    }
+}

--- a/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
@@ -53,4 +53,9 @@ export class MajUtilisateurDto {
   @IsOptional()
   @IsNumber()
   niveau_etude_id?: number;
+
+  // Type de profil (personnalisation) — nullable : null pour le retirer.
+  @IsOptional()
+  @IsNumber()
+  type_profil_id?: number | null;
 }

--- a/backend/src/utilisateurs/dto/update-profil.dto.ts
+++ b/backend/src/utilisateurs/dto/update-profil.dto.ts
@@ -13,4 +13,5 @@ export class UpdateProfilDto extends PickType(MajUtilisateurDto, [
     'date_naissance',
     'zone_residence',
     'situation_handicap',
+    'type_profil_id',
 ] as const) { }

--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -126,6 +126,12 @@ export class Utilisateur {
   @JoinColumn({ name: 'niveau_etude_id' })
   niveau_etude: NiveauEtude;
 
+  // Type de profil (personnalisation) — un seul par utilisateur, nullable.
+  // Scalaire seul (pas de relation) pour garder l'édition de cette entité
+  // partagée minimale ; l'objet type_profil est résolu côté service.
+  @Column({ nullable: true })
+  type_profil_id: number;
+
   @OneToMany(() => Commentaire, commentaire => commentaire.utilisateur)
   commentaires: Commentaire[];
 

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -49,13 +49,9 @@ export class UtilisateursController {
     const userId = req.user.utilisateurId.toString();
     const email = req.user.email;
     console.log(`[UtilisateursController] Récupération du profil pour l'utilisateur: ${email} (ID: ${userId})`);
-    // geo-profile: unified complete user shape (geo {uuid,nom} + age + booleans) via the service
+    // Unified complete user shape (geo {uuid,nom} + age_group + booleans + type_profil) via the service.
     const profil = await this.utilisateursService.findOne(userId);
-    // geo/hotfix: enrichUserComplete builds geo {uuid,nom} + age_group + booleans;
-    // graft the resolved type_profil (personnalisation) on top.
-    const enriched = await this.utilisateursService.enrichUserComplete(profil);
-    const { type_profil_id, type_profil } = await this.utilisateursService.getTypeProfilForProfil(parseInt(userId));
-    return { ...enriched, type_profil_id, type_profil };
+    return this.utilisateursService.enrichUserComplete(profil);
   }
 
   @UseGuards(JwtAuthGuard, RoleGuard)

--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -55,12 +55,15 @@ export class UtilisateursController {
     const { isVerified: isEmailVerified } = await this.utilisateursService.isEmailVerified(userIdNum);
     const { isPrestataire } = await this.utilisateursService.isPrestataire(userIdNum);
     const { isRecruteur } = await this.utilisateursService.isRecruteur(userIdNum);
+    const { type_profil_id, type_profil } = await this.utilisateursService.getTypeProfilForProfil(userIdNum);
 
     return {
       ...profil,
       isEmailVerified,
       isPrestataire,
-      isRecruteur
+      isRecruteur,
+      type_profil_id,
+      type_profil,
     };
   }
 

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -3,6 +3,7 @@ import { Repository, Brackets, LessThan, IsNull } from 'typeorm';
 import { Utilisateur } from './entities/utilisateur.entity';
 import { Prestataire } from '../prestataires/entities/prestataire.entity';
 import { Recruteur } from '../recruteurs/entities/recruteur.entity';
+import { TypeProfil } from '../type-profils/entities/type-profil.entity';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
 import { CountryContextService } from '../config/country-context.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -350,6 +351,22 @@ export class UtilisateursService {
       throw new NotFoundException('Utilisateur non trouvé');
     }
 
+    // Type de profil : valider qu'il existe ET appartient au pays de l'utilisateur.
+    // `undefined` = champ absent (on n'y touche pas) ; `null` = retirer l'assignation.
+    if (majUtilisateurDto.type_profil_id !== undefined && majUtilisateurDto.type_profil_id !== null) {
+      const typeProfil = await this.resolver.getRepository(TypeProfil).findOne({
+        where: { id: majUtilisateurDto.type_profil_id },
+      });
+      if (!typeProfil) {
+        throw new NotFoundException(`Type de profil ${majUtilisateurDto.type_profil_id} non trouvé`);
+      }
+      if (typeProfil.pays !== user.pays) {
+        throw new BadRequestException(
+          `Le type de profil ${majUtilisateurDto.type_profil_id} n'appartient pas à votre pays`,
+        );
+      }
+    }
+
     // Update user
     Object.assign(user, majUtilisateurDto);
     const updatedUser = await this.utilisateursRepository.save(user);
@@ -378,6 +395,40 @@ export class UtilisateursService {
       where: { utilisateur_id: userId },
     });
     return { isRecruteur: !!recruteur };
+  }
+
+  /**
+   * Résout le type de profil d'un utilisateur pour la réponse GET /utilisateurs/profil.
+   * Renvoie l'id brut (`type_profil_id`) + l'objet `type_profil`
+   * { id, titre, sous_titre, icone_path } (ou null si non assigné).
+   */
+  async getTypeProfilForProfil(userId: number): Promise<{
+    type_profil_id: number | null;
+    type_profil: { id: number; titre: string; sous_titre: string | null; icone_path: string | null } | null;
+  }> {
+    const user = await this.utilisateursRepository.findOne({
+      where: { id: userId },
+      select: ['id', 'type_profil_id'],
+    });
+    const typeProfilId = user?.type_profil_id ?? null;
+    if (!typeProfilId) {
+      return { type_profil_id: null, type_profil: null };
+    }
+    const typeProfil = await this.resolver.getRepository(TypeProfil).findOne({
+      where: { id: typeProfilId },
+      select: ['id', 'titre', 'sous_titre', 'icone_path'],
+    });
+    return {
+      type_profil_id: typeProfilId,
+      type_profil: typeProfil
+        ? {
+          id: typeProfil.id,
+          titre: typeProfil.titre,
+          sous_titre: typeProfil.sous_titre ?? null,
+          icone_path: typeProfil.icone_path ?? null,
+        }
+        : null,
+    };
   }
 
   async verifyEmail(email: string) {

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -109,13 +109,14 @@ export class UtilisateursService {
   // GET /utilisateurs (list), /utilisateurs/profil and /utilisateurs/:uuid — withProfil +
   // geo {uuid,nom} + derived age + verify/prestataire/recruteur booleans. The caller must
   // load the departement/ville relations (findOne/findByUuid/findAll all do).
-  // PERF NOTE: 3 boolean lookups per user (isEmailVerified/isPrestataire/isRecruteur) => N+1
-  // on the list (3 x page_size). Acceptable at the current default page size; batch if page size grows.
+  // PERF NOTE: 4 lookups per user (isEmailVerified/isPrestataire/isRecruteur + type_profil)
+  // => N+1 on the list (4 x page_size). Acceptable at the current default page size; batch if it grows.
   async enrichUserComplete<T extends Utilisateur>(user: T) {
-    const [{ isVerified }, { isPrestataire }, { isRecruteur }] = await Promise.all([
+    const [{ isVerified }, { isPrestataire }, { isRecruteur }, typeProfil] = await Promise.all([
       this.isEmailVerified(user.id),
       this.isPrestataire(user.id),
       this.isRecruteur(user.id),
+      this.getTypeProfilForProfil(user.id),
     ]);
     const result: any = {
       ...this.withProfil(user),
@@ -126,6 +127,9 @@ export class UtilisateursService {
       isEmailVerified: isVerified,
       isPrestataire,
       isRecruteur,
+      // type-profils: id brut + objet résolu, sur les 3 endpoints (liste / profil / :uuid).
+      type_profil_id: typeProfil.type_profil_id,
+      type_profil: typeProfil.type_profil,
     };
     // raw ids redundant now that departement/ville are {uuid,nom}.
     delete result.departement_id;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import ContactsProfessionnels from "./pages/ContactsProfessionnels";
 import Parcours from "./pages/Parcours";
 import Categories from "./pages/Categories";
 import TypesProfil from "./pages/TypesProfil";
+import TypeProfilAssociations from "./pages/TypeProfilAssociations";
 import Structures from "./pages/Structures";
 import Titres from "./pages/Titres";
 import Departements from "./pages/Departements";
@@ -86,6 +87,7 @@ const App = () => (
                       <Route path="/parcours" element={<Parcours />} />
                       <Route path="/categories" element={<Categories />} />
                       <Route path="/types-profil" element={<TypesProfil />} />
+                      <Route path="/types-profil/associations" element={<TypeProfilAssociations />} />
                       <Route path="/structures" element={<Structures />} />
                       <Route path="/titres" element={<Titres />} />
                       <Route path="/departements" element={<Departements />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import ConcoursAdmin from "./pages/ConcoursAdmin";
 import ContactsProfessionnels from "./pages/ContactsProfessionnels";
 import Parcours from "./pages/Parcours";
 import Categories from "./pages/Categories";
+import TypesProfil from "./pages/TypesProfil";
 import Structures from "./pages/Structures";
 import Titres from "./pages/Titres";
 import Settings from "./pages/Settings";
@@ -82,6 +83,7 @@ const App = () => (
                       <Route path="/forums" element={<Forums />} />
                       <Route path="/parcours" element={<Parcours />} />
                       <Route path="/categories" element={<Categories />} />
+                      <Route path="/types-profil" element={<TypesProfil />} />
                       <Route path="/structures" element={<Structures />} />
                       <Route path="/titres" element={<Titres />} />
                       <Route path="/contacts-professionnels" element={<ContactsProfessionnels />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -178,6 +178,7 @@ const navTree: NavItem[] = [
     icon: UserCog,
     children: [
       { title: "Types de profil", icon: Tags, url: "/types-profil" },
+      { title: "Associations audience", icon: Tags, url: "/types-profil/associations" },
     ],
   },
   {

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -163,6 +163,13 @@ const navTree: NavItem[] = [
     ],
   },
   {
+    title: "Personnalisation",
+    icon: UserCog,
+    children: [
+      { title: "Types de profil", icon: Tags, url: "/types-profil" },
+    ],
+  },
+  {
     title: "Système",
     icon: Settings,
     children: [

--- a/frontend/src/components/TypeProfilChecklist.tsx
+++ b/frontend/src/components/TypeProfilChecklist.tsx
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { typeProfilsService } from "@/lib/services/typeProfils.service";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+interface TypeProfilChecklistProps {
+  /** Controlled selection (type_profil ids). */
+  value: number[];
+  onChange: (ids: number[]) => void;
+  disabled?: boolean;
+  label?: string;
+}
+
+/**
+ * Shared multi-select checklist of the country's type-profils. Used in the
+ * create/edit form of all 5 taggable admin pages (Opportunités, Événements,
+ * Forums, Services, Offres). Controlled: the parent owns the selected ids,
+ * prefills on edit (GET /<entity>/:id/type-profils) and saves them via
+ * PUT /<entity>/:id/type-profils after the entity itself is created/updated.
+ */
+export function TypeProfilChecklist({
+  value,
+  onChange,
+  disabled,
+  label = "Types de profil (audience)",
+}: TypeProfilChecklistProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["type-profils", "checklist-options"],
+    queryFn: () => typeProfilsService.getAll({ page: 1, limit: 100 }),
+  });
+  const options = data?.data || [];
+
+  const toggle = (id: number, checked: boolean) => {
+    if (checked) {
+      if (!value.includes(id)) onChange([...value, id]);
+    } else {
+      onChange(value.filter((v) => v !== id));
+    }
+  };
+
+  return (
+    <div className="grid gap-2">
+      <Label>{label}</Label>
+      <p className="text-xs text-muted-foreground">
+        Aucune sélection = visible par tous. Sinon, visible uniquement par les utilisateurs
+        ayant l'un de ces types de profil.
+      </p>
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
+        </div>
+      ) : options.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Aucun type de profil. Créez-en dans « Personnalisation › Types de profil ».
+        </p>
+      ) : (
+        <ScrollArea className="h-32 rounded-md border p-2">
+          <div className="grid gap-2">
+            {options.map((tp) => (
+              <label key={tp.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                <Checkbox
+                  checked={value.includes(tp.id)}
+                  onCheckedChange={(c) => toggle(tp.id, c === true)}
+                  disabled={disabled}
+                />
+                <span>
+                  {tp.titre}
+                  {tp.sous_titre ? <span className="text-muted-foreground"> — {tp.sous_titre}</span> : null}
+                </span>
+              </label>
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TypeProfilChecklist.tsx
+++ b/frontend/src/components/TypeProfilChecklist.tsx
@@ -1,9 +1,20 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { Loader2, Check, ChevronsUpDown, X } from "lucide-react";
 import { typeProfilsService } from "@/lib/services/typeProfils.service";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
 
 interface TypeProfilChecklistProps {
   /** Controlled selection (type_profil ids). */
@@ -14,11 +25,11 @@ interface TypeProfilChecklistProps {
 }
 
 /**
- * Shared multi-select checklist of the country's type-profils. Used in the
- * create/edit form of all 5 taggable admin pages (Opportunités, Événements,
- * Forums, Services, Offres). Controlled: the parent owns the selected ids,
- * prefills on edit (GET /<entity>/:id/type-profils) and saves them via
- * PUT /<entity>/:id/type-profils after the entity itself is created/updated.
+ * Shared multi-select of the country's type-profils, used in the create/edit
+ * form of all 5 taggable admin pages (Opportunités, Événements, Forums,
+ * Services, Offres). Searchable popover + removable badges for the current
+ * selection. Controlled: the parent owns the selected ids, prefills on edit
+ * (GET /<entity>/:id/type-profils) and saves via PUT /<entity>/:id/type-profils.
  */
 export function TypeProfilChecklist({
   value,
@@ -26,18 +37,17 @@ export function TypeProfilChecklist({
   disabled,
   label = "Types de profil (audience)",
 }: TypeProfilChecklistProps) {
+  const [open, setOpen] = useState(false);
   const { data, isLoading } = useQuery({
     queryKey: ["type-profils", "checklist-options"],
     queryFn: () => typeProfilsService.getAll({ page: 1, limit: 100 }),
   });
   const options = data?.data || [];
+  const selected = options.filter((tp) => value.includes(tp.id));
 
-  const toggle = (id: number, checked: boolean) => {
-    if (checked) {
-      if (!value.includes(id)) onChange([...value, id]);
-    } else {
-      onChange(value.filter((v) => v !== id));
-    }
+  const toggle = (id: number) => {
+    if (value.includes(id)) onChange(value.filter((v) => v !== id));
+    else onChange([...value, id]);
   };
 
   return (
@@ -47,6 +57,7 @@ export function TypeProfilChecklist({
         Aucune sélection = visible par tous. Sinon, visible uniquement par les utilisateurs
         ayant l'un de ces types de profil.
       </p>
+
       {isLoading ? (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
@@ -56,23 +67,77 @@ export function TypeProfilChecklist({
           Aucun type de profil. Créez-en dans « Personnalisation › Types de profil ».
         </p>
       ) : (
-        <ScrollArea className="h-32 rounded-md border p-2">
-          <div className="grid gap-2">
-            {options.map((tp) => (
-              <label key={tp.id} className="flex items-center gap-2 text-sm cursor-pointer">
-                <Checkbox
-                  checked={value.includes(tp.id)}
-                  onCheckedChange={(c) => toggle(tp.id, c === true)}
-                  disabled={disabled}
-                />
-                <span>
+        <>
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                disabled={disabled}
+                className="w-full justify-between font-normal"
+              >
+                {value.length > 0
+                  ? `${value.length} type${value.length > 1 ? "s" : ""} de profil sélectionné${value.length > 1 ? "s" : ""}`
+                  : "Sélectionner des types de profil"}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+              <Command
+                filter={(val, search) => (val.toLowerCase().includes(search.toLowerCase()) ? 1 : 0)}
+              >
+                <CommandInput placeholder="Rechercher un type de profil..." />
+                <CommandList>
+                  <CommandEmpty>Aucun type trouvé.</CommandEmpty>
+                  <CommandGroup>
+                    {options.map((tp) => (
+                      <CommandItem
+                        key={tp.id}
+                        value={`${tp.titre} ${tp.sous_titre ?? ""}`}
+                        onSelect={() => toggle(tp.id)}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            value.includes(tp.id) ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span>
+                          {tp.titre}
+                          {tp.sous_titre ? (
+                            <span className="text-muted-foreground"> — {tp.sous_titre}</span>
+                          ) : null}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+
+          {selected.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {selected.map((tp) => (
+                <Badge key={tp.id} variant="secondary" className="gap-1">
                   {tp.titre}
-                  {tp.sous_titre ? <span className="text-muted-foreground"> — {tp.sous_titre}</span> : null}
-                </span>
-              </label>
-            ))}
-          </div>
-        </ScrollArea>
+                  {!disabled && (
+                    <button
+                      type="button"
+                      aria-label={`Retirer ${tp.titre}`}
+                      className="ml-0.5 rounded-full outline-none hover:text-destructive"
+                      onClick={() => toggle(tp.id)}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/lib/services/typeProfilTagging.service.ts
+++ b/frontend/src/lib/services/typeProfilTagging.service.ts
@@ -1,0 +1,23 @@
+import { api } from '../api';
+
+/**
+ * Generic client for the per-entity type-profil CHECKLIST endpoints
+ * (GET/PUT /<entity>/:id/type-profils). Shared by all 5 admin pages so the
+ * tagging round-trip isn't copied five times. `entity` is the backend route
+ * segment: 'opportunites' | 'evenements' | 'forums' | 'services' | 'offres'.
+ *
+ * This is a SEPARATE side-call from an entity's own create/update body: after
+ * the entity is created/updated (and you have its id), call `set` with the
+ * selected ids.
+ */
+export const typeProfilTaggingService = {
+    async get(entity: string, id: number | string): Promise<number[]> {
+        const res = await api.get<{ typeProfilIds: number[] }>(`/${entity}/${id}/type-profils`);
+        return res.typeProfilIds ?? [];
+    },
+
+    async set(entity: string, id: number | string, typeProfilIds: number[]): Promise<number[]> {
+        const res = await api.put<{ typeProfilIds: number[] }>(`/${entity}/${id}/type-profils`, { typeProfilIds });
+        return res.typeProfilIds ?? [];
+    },
+};

--- a/frontend/src/lib/services/typeProfils.service.ts
+++ b/frontend/src/lib/services/typeProfils.service.ts
@@ -1,0 +1,53 @@
+import { api } from '../api';
+import type { PaginationResponse, PaginationParams } from '../types/pagination';
+import { buildPaginationQuery } from '../types/pagination';
+import { filesService } from './files.service';
+
+export interface TypeProfil {
+    id: number;
+    uuid?: string;
+    titre: string;
+    sous_titre?: string;
+    /** Full public URL of the R2 icône (slot type_profils.icone). Prefer FileImage. */
+    icone_path?: string;
+    icone_extension?: string;
+    pays?: string;
+    date_creation?: string;
+}
+
+export interface TypeProfilsFilters extends PaginationParams {
+    search?: string;
+}
+
+export const typeProfilsService = {
+    async getAll(params?: TypeProfilsFilters): Promise<PaginationResponse<TypeProfil>> {
+        const query = buildPaginationQuery(params);
+        return api.get<PaginationResponse<TypeProfil>>(`/type-profils${query}`);
+    },
+
+    async getById(id: number): Promise<TypeProfil> {
+        return api.get<TypeProfil>(`/type-profils/${id}`);
+    },
+
+    async create(data: { titre: string; sous_titre?: string }): Promise<TypeProfil> {
+        // Country-scoped server-side via @CurrentCountry(); pays never in the body.
+        return api.post<TypeProfil>('/type-profils', data);
+    },
+
+    async update(id: number, data: Partial<{ titre: string; sous_titre: string }>): Promise<TypeProfil> {
+        return api.put<TypeProfil>(`/type-profils/${id}`, data);
+    },
+
+    async delete(id: number): Promise<void> {
+        return api.delete(`/type-profils/${id}`);
+    },
+
+    /**
+     * Upload the icône to the R2 public slot `type_profils.icone`. The row must
+     * already exist (its uuid keys the R2 object). Icône is optional — only call
+     * this when the admin actually picked a file.
+     */
+    async uploadIcone(uuid: string, file: File) {
+        return filesService.uploadFile('type_profils', uuid, 'icone', file);
+    },
+};

--- a/frontend/src/lib/services/typeProfils.service.ts
+++ b/frontend/src/lib/services/typeProfils.service.ts
@@ -19,10 +19,10 @@ export interface TypeProfilsFilters extends PaginationParams {
     search?: string;
 }
 
-/** Une ligne du registre entité ↔ type de profil (audience). */
+/** Une ligne du registre entité ↔ types de profil (audience). Plusieurs possibles. */
 export interface EntityTypeProfilAssoc {
     entity: string;
-    type_profil: { uuid: string; id: number; titre: string; sous_titre: string | null } | null;
+    type_profils: { uuid: string; id: number; titre: string; sous_titre: string | null }[];
 }
 
 export const typeProfilsService = {
@@ -62,8 +62,8 @@ export const typeProfilsService = {
         return api.get<EntityTypeProfilAssoc[]>('/type-profils/registry');
     },
 
-    /** Associe (ou dissocie si type_profil_id = null) une entité à un type de profil. */
-    async setAssociation(entity: string, type_profil_id: number | null): Promise<EntityTypeProfilAssoc> {
-        return api.put<EntityTypeProfilAssoc>('/type-profils/registry', { entity, type_profil_id });
+    /** Remplace la liste complète des types de profil d'une entité ([] pour dissocier). */
+    async setAssociations(entity: string, type_profil_ids: number[]): Promise<EntityTypeProfilAssoc> {
+        return api.put<EntityTypeProfilAssoc>('/type-profils/registry', { entity, type_profil_ids });
     },
 };

--- a/frontend/src/lib/services/typeProfils.service.ts
+++ b/frontend/src/lib/services/typeProfils.service.ts
@@ -19,6 +19,12 @@ export interface TypeProfilsFilters extends PaginationParams {
     search?: string;
 }
 
+/** Une ligne du registre entité ↔ type de profil (audience). */
+export interface EntityTypeProfilAssoc {
+    entity: string;
+    type_profil: { uuid: string; id: number; titre: string; sous_titre: string | null } | null;
+}
+
 export const typeProfilsService = {
     async getAll(params?: TypeProfilsFilters): Promise<PaginationResponse<TypeProfil>> {
         const query = buildPaginationQuery(params);
@@ -49,5 +55,15 @@ export const typeProfilsService = {
      */
     async uploadIcone(uuid: string, file: File) {
         return filesService.uploadFile('type_profils', uuid, 'icone', file);
+    },
+
+    /** Registre : type de profil associé à chaque entité de contenu (audience). */
+    async getRegistry(): Promise<EntityTypeProfilAssoc[]> {
+        return api.get<EntityTypeProfilAssoc[]>('/type-profils/registry');
+    },
+
+    /** Associe (ou dissocie si type_profil_id = null) une entité à un type de profil. */
+    async setAssociation(entity: string, type_profil_id: number | null): Promise<EntityTypeProfilAssoc> {
+        return api.put<EntityTypeProfilAssoc>('/type-profils/registry', { entity, type_profil_id });
     },
 };

--- a/frontend/src/pages/Evenements.tsx
+++ b/frontend/src/pages/Evenements.tsx
@@ -357,7 +357,6 @@ export default function Evenements() {
                                         )}
                                     </div>
                                 </div>
-                                <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
                             </div>
                             <DialogFooter>
                                 <Button type="submit" disabled={createMutation.isPending || isUploading}>
@@ -594,7 +593,6 @@ export default function Evenements() {
                                 />
                             </div>
                             <div className="mt-4">
-                                <TypeProfilChecklist value={editTypeProfilIds} onChange={setEditTypeProfilIds} />
                             </div>
                         </div>
                         <DialogFooter>

--- a/frontend/src/pages/Evenements.tsx
+++ b/frontend/src/pages/Evenements.tsx
@@ -6,6 +6,8 @@ import { evenementsService, type Evenement } from "@/lib/services/evenements.ser
 import { fichiersService } from "@/lib/services/fichiers.service";
 import { filesService } from "@/lib/services/files.service";
 import { FileImage } from "@/components/FileImage";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
+import { typeProfilTaggingService } from "@/lib/services/typeProfilTagging.service";
 import { API_URL } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -57,6 +59,8 @@ export default function Evenements() {
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
     const [deleteId, setDeleteId] = useState<number | null>(null);
     const [editingEvenement, setEditingEvenement] = useState<Evenement | null>(null);
+    const [newTypeProfilIds, setNewTypeProfilIds] = useState<number[]>([]);
+    const [editTypeProfilIds, setEditTypeProfilIds] = useState<number[]>([]);
     const [formData, setFormData] = useState<EvenementFormData>({
         titre: "",
         description: "",
@@ -168,12 +172,23 @@ export default function Evenements() {
                 }
             }
 
+            // Step 3: type-profil checklist (separate side-call, only if selected).
+            if (newTypeProfilIds.length > 0) {
+                try {
+                    await typeProfilTaggingService.set('evenements', createdEvenement.id, newTypeProfilIds);
+                } catch (tagError) {
+                    console.error("Failed to save type-profils", tagError);
+                    toast({ title: "Attention", description: "Événement créé mais échec de l'enregistrement des types de profil" });
+                }
+            }
+
             // Success
             queryClient.invalidateQueries({ queryKey: ["evenements"] });
             queryClient.invalidateQueries({ queryKey: ["dashboard-stats"] });
             setIsCreateDialogOpen(false);
             setFormData({ titre: "", description: "", date: "", lieu: "", lien_inscription: "", image: "", actif: true });
             setSelectedFile(null);
+            setNewTypeProfilIds([]);
             setImageVersion(Date.now());
             toast({ title: "Succès", description: "Événement créé avec succès" });
         } catch (error: any) {
@@ -209,10 +224,14 @@ export default function Evenements() {
                 await filesService.uploadFile('evenements', editingEvenement.uuid, 'image', selectedFile);
             }
 
+            // Step 3: replace-set the type-profil checklist (always PUT so edits can clear).
+            await typeProfilTaggingService.set('evenements', editingEvenement.id, editTypeProfilIds);
+
             // Success
             queryClient.invalidateQueries({ queryKey: ["evenements"] });
             setIsEditDialogOpen(false);
             setEditingEvenement(null);
+            setEditTypeProfilIds([]);
             setSelectedFile(null); // Clear file
             setImageVersion(Date.now());
             toast({ title: "Succès", description: "Événement mis à jour avec succès" });
@@ -338,6 +357,7 @@ export default function Evenements() {
                                         )}
                                     </div>
                                 </div>
+                                <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
                             </div>
                             <DialogFooter>
                                 <Button type="submit" disabled={createMutation.isPending || isUploading}>
@@ -427,7 +447,9 @@ export default function Evenements() {
                                                     size="icon"
                                                     onClick={() => {
                                                         setEditingEvenement(evenement);
+                                                        setEditTypeProfilIds([]);
                                                         setIsEditDialogOpen(true);
+                                                        typeProfilTaggingService.get('evenements', evenement.id).then(setEditTypeProfilIds).catch(() => { });
                                                     }}
                                                 >
                                                     <Pencil className="h-4 w-4" />
@@ -570,6 +592,9 @@ export default function Evenements() {
                                     onChange={(e) => setEditingEvenement(editingEvenement ? { ...editingEvenement, actif: e.target.checked } : null)}
                                     className="h-4 w-4"
                                 />
+                            </div>
+                            <div className="mt-4">
+                                <TypeProfilChecklist value={editTypeProfilIds} onChange={setEditTypeProfilIds} />
                             </div>
                         </div>
                         <DialogFooter>

--- a/frontend/src/pages/Forums.tsx
+++ b/frontend/src/pages/Forums.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Search, Plus, Loader2, Trash2, ArrowUpDown, MessageSquare, Heart, Image as ImageIcon } from "lucide-react";
 import { forumService } from "@/lib/services/forum.service";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
+import { typeProfilTaggingService } from "@/lib/services/typeProfilTagging.service";
 import { useToast } from "@/hooks/use-toast";
 import {
     AlertDialog,
@@ -153,6 +155,7 @@ export default function Forums() {
         theme: "",
         content: "",
     });
+    const [newTypeProfilIds, setNewTypeProfilIds] = useState<number[]>([]);
 
     const { toast } = useToast();
     const queryClient = useQueryClient();
@@ -170,6 +173,10 @@ export default function Forums() {
             if (selectedFile) {
                 await forumService.uploadPhoto(forum.id, selectedFile);
             }
+            // type-profil checklist (separate side-call, only if selected).
+            if (newTypeProfilIds.length > 0) {
+                await typeProfilTaggingService.set('forums', forum.id, newTypeProfilIds);
+            }
             return forum;
         },
         onSuccess: () => {
@@ -177,6 +184,7 @@ export default function Forums() {
             setIsCreateOpen(false);
             setNewForum({ theme: "", content: "", });
             setSelectedFile(null);
+            setNewTypeProfilIds([]);
             toast({ title: "Succès", description: "Forum créé avec succès" });
         },
         onError: (error: any) => {
@@ -440,6 +448,8 @@ export default function Forums() {
                                 }}
                             />
                         </div>
+
+                        <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
 
                         <DialogFooter>
                             <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}>Annuler</Button>

--- a/frontend/src/pages/Forums.tsx
+++ b/frontend/src/pages/Forums.tsx
@@ -449,7 +449,6 @@ export default function Forums() {
                             />
                         </div>
 
-                        <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
 
                         <DialogFooter>
                             <Button type="button" variant="outline" onClick={() => setIsCreateOpen(false)}>Annuler</Button>

--- a/frontend/src/pages/OffresAdmin.tsx
+++ b/frontend/src/pages/OffresAdmin.tsx
@@ -420,7 +420,6 @@ export default function OffresAdmin() {
                             )}
 
                             <div className="border-t pt-4">
-                                <TypeProfilChecklist value={viewOffreTypeProfilIds} onChange={setViewOffreTypeProfilIds} />
                                 <Button className="mt-3" size="sm" onClick={handleSaveOffreTags} disabled={savingTags}>
                                     {savingTags ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Enregistrement...</> : "Enregistrer les types de profil"}
                                 </Button>

--- a/frontend/src/pages/OffresAdmin.tsx
+++ b/frontend/src/pages/OffresAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -13,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, CheckCircle, XCircle, Eye, ChevronLeft, ChevronRight, Star, MessageSquare, User, Trash2 } from "lucide-react";
 import { offresService, OffreItem } from "@/lib/services/offres.service";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
+import { typeProfilTaggingService } from "@/lib/services/typeProfilTagging.service";
 import { avisService } from "@/lib/services/avis.service";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -45,6 +47,9 @@ export default function OffresAdmin() {
     const [page, setPage] = useState(1);
     const [limit, setLimit] = useState(10);
     const [viewOffre, setViewOffre] = useState<OffreItem | null>(null);
+    // Type-profil tagging in the view dialog (this admin page has no create/edit form).
+    const [viewOffreTypeProfilIds, setViewOffreTypeProfilIds] = useState<number[]>([]);
+    const [savingTags, setSavingTags] = useState(false);
     const [viewRecruteur, setViewRecruteur] = useState<OffreItem['recruteur'] | null>(null);
     const [selectedOffreAvisId, setSelectedOffreAvisId] = useState<number | null>(null);
     const [deleteId, setDeleteId] = useState<number | null>(null);
@@ -92,6 +97,30 @@ export default function OffresAdmin() {
 
     const handleUpdateStatus = (id: number, newStatus: string) => {
         updateStatusMutation.mutate({ id, status: newStatus });
+    };
+
+    // Prefill the checklist when an offre's detail dialog opens.
+    useEffect(() => {
+        if (viewOffre?.id) {
+            typeProfilTaggingService.get('offres', viewOffre.id)
+                .then(setViewOffreTypeProfilIds)
+                .catch(() => setViewOffreTypeProfilIds([]));
+        } else {
+            setViewOffreTypeProfilIds([]);
+        }
+    }, [viewOffre?.id]);
+
+    const handleSaveOffreTags = async () => {
+        if (!viewOffre) return;
+        setSavingTags(true);
+        try {
+            await typeProfilTaggingService.set('offres', viewOffre.id, viewOffreTypeProfilIds);
+            toast({ title: "Succès", description: "Types de profil enregistrés" });
+        } catch (e: any) {
+            toast({ title: "Erreur", description: e.message || "Échec de l'enregistrement", variant: "destructive" });
+        } finally {
+            setSavingTags(false);
+        }
     };
 
     const deleteMutation = useMutation({
@@ -390,6 +419,12 @@ export default function OffresAdmin() {
                                 </div>
                             )}
 
+                            <div className="border-t pt-4">
+                                <TypeProfilChecklist value={viewOffreTypeProfilIds} onChange={setViewOffreTypeProfilIds} />
+                                <Button className="mt-3" size="sm" onClick={handleSaveOffreTags} disabled={savingTags}>
+                                    {savingTags ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Enregistrement...</> : "Enregistrer les types de profil"}
+                                </Button>
+                            </div>
                         </div>
                     )}
                 </DialogContent>

--- a/frontend/src/pages/Opportunites.tsx
+++ b/frontend/src/pages/Opportunites.tsx
@@ -6,6 +6,8 @@ import { opportunitesService, type Opportunite, type OpportuniteType } from "@/l
 import { fichiersService } from "@/lib/services/fichiers.service";
 import { filesService } from "@/lib/services/files.service";
 import { FileImage } from "@/components/FileImage";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
+import { typeProfilTaggingService } from "@/lib/services/typeProfilTagging.service";
 import { API_URL } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -34,6 +36,9 @@ export default function Opportunites() {
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
     const [deleteId, setDeleteId] = useState<number | null>(null);
     const [editingOpportunite, setEditingOpportunite] = useState<Opportunite | null>(null);
+    // Type-profil checklist selection (create vs edit dialogs).
+    const [newTypeProfilIds, setNewTypeProfilIds] = useState<number[]>([]);
+    const [editTypeProfilIds, setEditTypeProfilIds] = useState<number[]>([]);
 
     // Filters state
     const [searchTerm, setSearchTerm] = useState("");
@@ -151,12 +156,24 @@ export default function Opportunites() {
                 }
             }
 
+            // Step 3: type-profil checklist (separate side-call). Only PUT when
+            // something is selected — a fresh row is untagged by default.
+            if (newTypeProfilIds.length > 0) {
+                try {
+                    await typeProfilTaggingService.set('opportunites', createdOpportunite.id, newTypeProfilIds);
+                } catch (tagError) {
+                    console.error("Failed to save type-profils", tagError);
+                    toast({ title: "Attention", description: "Opportunité créée mais échec de l'enregistrement des types de profil" });
+                }
+            }
+
             // Success
             queryClient.invalidateQueries({ queryKey: ["opportunites"] });
             queryClient.invalidateQueries({ queryKey: ["dashboard-stats"] });
             setIsCreateDialogOpen(false);
             setFormData({ titre: "", type: "Bourses", organisme: "", lieu: "", date_publication: "", image: "", lien_postuler: "", actif: true });
             setSelectedFile(null);
+            setNewTypeProfilIds([]);
             setImageVersion(Date.now());
             toast({ title: "Succès", description: "Opportunité créée avec succès" });
         } catch (error: any) {
@@ -190,11 +207,16 @@ export default function Opportunites() {
                 await filesService.uploadFile('opportunites', editingOpportunite.uuid, 'image', selectedFile);
             }
 
+            // Step 3: replace-set the type-profil checklist (always PUT so edits
+            // can also CLEAR tags).
+            await typeProfilTaggingService.set('opportunites', editingOpportunite.id, editTypeProfilIds);
+
             // Success
             queryClient.invalidateQueries({ queryKey: ["opportunites"] });
             setIsEditDialogOpen(false);
             setEditingOpportunite(null);
             setSelectedFile(null);
+            setEditTypeProfilIds([]);
             setImageVersion(Date.now());
             toast({ title: "Succès", description: "Opportunité mise à jour avec succès" });
         } catch (error: any) {
@@ -311,6 +333,7 @@ export default function Opportunites() {
                                     <Label htmlFor="lien_postuler">Lien pour postuler</Label>
                                     <Input id="lien_postuler" value={formData.lien_postuler} onChange={(e) => setFormData({ ...formData, lien_postuler: e.target.value })} />
                                 </div>
+                                <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
                             </div>
                             <DialogFooter>
                                 <Button type="submit" disabled={createMutation.isPending || isUploading}>
@@ -395,7 +418,7 @@ export default function Opportunites() {
                                         <TableCell><Badge variant={opp.actif ? "default" : "secondary"}>{opp.actif ? "Actif" : "Inactif"}</Badge></TableCell>
                                         <TableCell className="text-right">
                                             <div className="flex justify-end gap-2">
-                                                <Button variant="ghost" size="icon" onClick={() => { setEditingOpportunite(opp); setIsEditDialogOpen(true); }}>
+                                                <Button variant="ghost" size="icon" onClick={() => { setEditingOpportunite(opp); setEditTypeProfilIds([]); setIsEditDialogOpen(true); typeProfilTaggingService.get('opportunites', opp.id).then(setEditTypeProfilIds).catch(() => { }); }}>
                                                     <Pencil className="h-4 w-4" />
                                                 </Button>
                                                 <Button variant="ghost" size="icon" onClick={() => setDeleteId(opp.id)}>
@@ -530,6 +553,9 @@ export default function Opportunites() {
                                     onChange={(e) => setEditingOpportunite(editingOpportunite ? { ...editingOpportunite, actif: e.target.checked } : null)}
                                     className="h-4 w-4"
                                 />
+                            </div>
+                            <div className="mt-4">
+                                <TypeProfilChecklist value={editTypeProfilIds} onChange={setEditTypeProfilIds} />
                             </div>
                         </div>
                         <DialogFooter>

--- a/frontend/src/pages/Opportunites.tsx
+++ b/frontend/src/pages/Opportunites.tsx
@@ -333,7 +333,6 @@ export default function Opportunites() {
                                     <Label htmlFor="lien_postuler">Lien pour postuler</Label>
                                     <Input id="lien_postuler" value={formData.lien_postuler} onChange={(e) => setFormData({ ...formData, lien_postuler: e.target.value })} />
                                 </div>
-                                <TypeProfilChecklist value={newTypeProfilIds} onChange={setNewTypeProfilIds} />
                             </div>
                             <DialogFooter>
                                 <Button type="submit" disabled={createMutation.isPending || isUploading}>
@@ -555,7 +554,6 @@ export default function Opportunites() {
                                 />
                             </div>
                             <div className="mt-4">
-                                <TypeProfilChecklist value={editTypeProfilIds} onChange={setEditTypeProfilIds} />
                             </div>
                         </div>
                         <DialogFooter>

--- a/frontend/src/pages/ServicesAdmin.tsx
+++ b/frontend/src/pages/ServicesAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -13,6 +13,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Loader2, CheckCircle, XCircle, Eye, ChevronLeft, ChevronRight, Star, MessageSquare, User, Trash2 } from "lucide-react";
 import { servicesService, ServiceItem } from "@/lib/services/services.service";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
+import { typeProfilTaggingService } from "@/lib/services/typeProfilTagging.service";
 import { avisService } from "@/lib/services/avis.service";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -45,6 +47,9 @@ export default function ServicesAdmin() {
     const [page, setPage] = useState(1);
     const [limit, setLimit] = useState(10);
     const [viewService, setViewService] = useState<ServiceItem | null>(null);
+    // Type-profil tagging in the view dialog (this admin page has no create/edit form).
+    const [viewServiceTypeProfilIds, setViewServiceTypeProfilIds] = useState<number[]>([]);
+    const [savingTags, setSavingTags] = useState(false);
     const [viewPrestataire, setViewPrestataire] = useState<ServiceItem['prestataire'] | null>(null);
     const [selectedServiceAvisId, setSelectedServiceAvisId] = useState<number | null>(null);
     const [deleteId, setDeleteId] = useState<number | null>(null);
@@ -92,6 +97,30 @@ export default function ServicesAdmin() {
 
     const handleUpdateStatus = (id: number, newStatus: string) => {
         updateStatusMutation.mutate({ id, status: newStatus });
+    };
+
+    // Prefill the checklist when a service's detail dialog opens.
+    useEffect(() => {
+        if (viewService?.id) {
+            typeProfilTaggingService.get('services', viewService.id)
+                .then(setViewServiceTypeProfilIds)
+                .catch(() => setViewServiceTypeProfilIds([]));
+        } else {
+            setViewServiceTypeProfilIds([]);
+        }
+    }, [viewService?.id]);
+
+    const handleSaveServiceTags = async () => {
+        if (!viewService) return;
+        setSavingTags(true);
+        try {
+            await typeProfilTaggingService.set('services', viewService.id, viewServiceTypeProfilIds);
+            toast({ title: "Succès", description: "Types de profil enregistrés" });
+        } catch (e: any) {
+            toast({ title: "Erreur", description: e.message || "Échec de l'enregistrement", variant: "destructive" });
+        } finally {
+            setSavingTags(false);
+        }
     };
 
     const deleteMutation = useMutation({
@@ -394,6 +423,12 @@ export default function ServicesAdmin() {
                                 </div>
                             )}
 
+                            <div className="border-t pt-4">
+                                <TypeProfilChecklist value={viewServiceTypeProfilIds} onChange={setViewServiceTypeProfilIds} />
+                                <Button className="mt-3" size="sm" onClick={handleSaveServiceTags} disabled={savingTags}>
+                                    {savingTags ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Enregistrement...</> : "Enregistrer les types de profil"}
+                                </Button>
+                            </div>
                         </div>
                     )}
                 </DialogContent>

--- a/frontend/src/pages/ServicesAdmin.tsx
+++ b/frontend/src/pages/ServicesAdmin.tsx
@@ -424,7 +424,6 @@ export default function ServicesAdmin() {
                             )}
 
                             <div className="border-t pt-4">
-                                <TypeProfilChecklist value={viewServiceTypeProfilIds} onChange={setViewServiceTypeProfilIds} />
                                 <Button className="mt-3" size="sm" onClick={handleSaveServiceTags} disabled={savingTags}>
                                     {savingTags ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Enregistrement...</> : "Enregistrer les types de profil"}
                                 </Button>

--- a/frontend/src/pages/TypeProfilAssociations.tsx
+++ b/frontend/src/pages/TypeProfilAssociations.tsx
@@ -1,0 +1,104 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { typeProfilsService } from "@/lib/services/typeProfils.service";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+
+// Libellés d'affichage des 5 entités taguables (l'API renvoie les clés canoniques).
+const ENTITY_LABELS: Record<string, string> = {
+  evenement: "Événements",
+  opportunite: "Opportunités",
+  forum: "Forums",
+  service: "Services",
+  offre: "Offres",
+};
+
+const NONE = "__none__";
+
+export default function TypeProfilAssociations() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data: registry, isLoading } = useQuery({
+    queryKey: ["type-profils", "registry"],
+    queryFn: () => typeProfilsService.getRegistry(),
+  });
+
+  const { data: typeProfils } = useQuery({
+    queryKey: ["type-profils", "options"],
+    queryFn: () => typeProfilsService.getAll({ page: 1, limit: 100 }),
+  });
+  const options = typeProfils?.data || [];
+
+  const mutation = useMutation({
+    mutationFn: ({ entity, typeProfilId }: { entity: string; typeProfilId: number | null }) =>
+      typeProfilsService.setAssociation(entity, typeProfilId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["type-profils", "registry"] });
+      toast({ title: "Association mise à jour" });
+    },
+    onError: () => toast({ title: "Échec de la mise à jour", variant: "destructive" }),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Associations Type de profil</h1>
+        <p className="text-muted-foreground">
+          Associez chaque type de contenu à un type de profil. Une entité non associée est
+          visible par tous ; sinon elle n'est visible que par les utilisateurs de ce type de profil.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Audience par entité</CardTitle>
+          <CardDescription>Un seul type de profil par entité (le premier / principal).</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:max-w-xl">
+              {(registry || []).map((row) => (
+                <div key={row.entity} className="flex items-center justify-between gap-4">
+                  <Label className="w-40 shrink-0">{ENTITY_LABELS[row.entity] || row.entity}</Label>
+                  <Select
+                    value={row.type_profil ? String(row.type_profil.id) : NONE}
+                    onValueChange={(v) =>
+                      mutation.mutate({ entity: row.entity, typeProfilId: v === NONE ? null : Number(v) })
+                    }
+                    disabled={mutation.isPending}
+                  >
+                    <SelectTrigger className="flex-1">
+                      <SelectValue placeholder="Aucune (public)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={NONE}>Aucune (public)</SelectItem>
+                      {options.map((tp) => (
+                        <SelectItem key={tp.id} value={String(tp.id)}>
+                          {tp.titre}
+                          {tp.sous_titre ? ` — ${tp.sous_titre}` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/TypeProfilAssociations.tsx
+++ b/frontend/src/pages/TypeProfilAssociations.tsx
@@ -1,15 +1,9 @@
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { typeProfilsService } from "@/lib/services/typeProfils.service";
+import { TypeProfilChecklist } from "@/components/TypeProfilChecklist";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 
 // Libellés d'affichage des 5 entités taguables (l'API renvoie les clés canoniques).
@@ -21,8 +15,6 @@ const ENTITY_LABELS: Record<string, string> = {
   offre: "Offres",
 };
 
-const NONE = "__none__";
-
 export default function TypeProfilAssociations() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -32,36 +24,47 @@ export default function TypeProfilAssociations() {
     queryFn: () => typeProfilsService.getRegistry(),
   });
 
-  const { data: typeProfils } = useQuery({
-    queryKey: ["type-profils", "options"],
-    queryFn: () => typeProfilsService.getAll({ page: 1, limit: 100 }),
-  });
-  const options = typeProfils?.data || [];
+  // Sélection locale par entité (évite le flicker entre un toggle et le refetch).
+  const [selections, setSelections] = useState<Record<string, number[]>>({});
+  useEffect(() => {
+    if (!registry) return;
+    const next: Record<string, number[]> = {};
+    for (const row of registry) next[row.entity] = row.type_profils.map((tp) => tp.id);
+    setSelections(next);
+  }, [registry]);
 
   const mutation = useMutation({
-    mutationFn: ({ entity, typeProfilId }: { entity: string; typeProfilId: number | null }) =>
-      typeProfilsService.setAssociation(entity, typeProfilId),
+    mutationFn: ({ entity, ids }: { entity: string; ids: number[] }) =>
+      typeProfilsService.setAssociations(entity, ids),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["type-profils", "registry"] });
-      toast({ title: "Association mise à jour" });
+      toast({ title: "Audience mise à jour" });
     },
     onError: () => toast({ title: "Échec de la mise à jour", variant: "destructive" }),
   });
+
+  const handleChange = (entity: string, ids: number[]) => {
+    setSelections((prev) => ({ ...prev, [entity]: ids }));
+    mutation.mutate({ entity, ids });
+  };
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Associations Type de profil</h1>
         <p className="text-muted-foreground">
-          Associez chaque type de contenu à un type de profil. Une entité non associée est
-          visible par tous ; sinon elle n'est visible que par les utilisateurs de ce type de profil.
+          Associez chaque type de contenu à un ou plusieurs types de profil. Une entité sans
+          sélection est visible par tous ; sinon elle n'est visible que par les utilisateurs de
+          l'un des types choisis.
         </p>
       </div>
 
       <Card>
         <CardHeader>
           <CardTitle>Audience par entité</CardTitle>
-          <CardDescription>Un seul type de profil par entité (le premier / principal).</CardDescription>
+          <CardDescription>
+            Plusieurs types de profil possibles par entité. La sélection remplace l'audience existante.
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -69,31 +72,15 @@ export default function TypeProfilAssociations() {
               <Loader2 className="h-4 w-4 animate-spin" /> Chargement...
             </div>
           ) : (
-            <div className="grid gap-4 sm:max-w-xl">
+            <div className="grid gap-6 sm:max-w-2xl">
               {(registry || []).map((row) => (
-                <div key={row.entity} className="flex items-center justify-between gap-4">
-                  <Label className="w-40 shrink-0">{ENTITY_LABELS[row.entity] || row.entity}</Label>
-                  <Select
-                    value={row.type_profil ? String(row.type_profil.id) : NONE}
-                    onValueChange={(v) =>
-                      mutation.mutate({ entity: row.entity, typeProfilId: v === NONE ? null : Number(v) })
-                    }
-                    disabled={mutation.isPending}
-                  >
-                    <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Aucune (public)" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={NONE}>Aucune (public)</SelectItem>
-                      {options.map((tp) => (
-                        <SelectItem key={tp.id} value={String(tp.id)}>
-                          {tp.titre}
-                          {tp.sous_titre ? ` — ${tp.sous_titre}` : ""}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                <TypeProfilChecklist
+                  key={row.entity}
+                  label={ENTITY_LABELS[row.entity] || row.entity}
+                  value={selections[row.entity] ?? row.type_profils.map((tp) => tp.id)}
+                  onChange={(ids) => handleChange(row.entity, ids)}
+                  disabled={mutation.isPending}
+                />
               ))}
             </div>
           )}

--- a/frontend/src/pages/TypesProfil.tsx
+++ b/frontend/src/pages/TypesProfil.tsx
@@ -43,6 +43,19 @@ interface TypeProfilFormData {
   sous_titre: string;
 }
 
+// Sanitize the local-file preview URL before it reaches <img src>: only allow the
+// blob:/data: schemes that URL.createObjectURL / FileReader produce. Blocks any
+// other scheme (e.g. javascript:) — clears the js/xss-through-dom scan on the src sink.
+function safePreviewUrl(url: string | null): string {
+  if (!url) return "";
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "blob:" || protocol === "data:" ? url : "";
+  } catch {
+    return "";
+  }
+}
+
 export default function TypesProfil() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -262,7 +275,7 @@ export default function TypesProfil() {
                     {iconeFile && (
                       <div className="relative h-10 w-10">
                         <img
-                          src={previewUrl || ""}
+                          src={safePreviewUrl(previewUrl)}
                           alt="Preview"
                           className="h-full w-full object-cover rounded"
                         />
@@ -441,7 +454,7 @@ export default function TypesProfil() {
                 {iconeFile ? (
                   <div className="relative h-16 w-16">
                     <img
-                      src={previewUrl || ""}
+                      src={safePreviewUrl(previewUrl)}
                       alt="Preview"
                       className="h-full w-full object-contain rounded-md border"
                     />

--- a/frontend/src/pages/TypesProfil.tsx
+++ b/frontend/src/pages/TypesProfil.tsx
@@ -1,0 +1,531 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useDebounce } from "@/hooks/use-debounce";
+import { Tags, Plus, Pencil, Trash2, Loader2, Search, X, ChevronLeft, ChevronRight } from "lucide-react";
+import { typeProfilsService } from "@/lib/services/typeProfils.service";
+import { filesService } from "@/lib/services/files.service";
+import { FileImage } from "@/components/FileImage";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface TypeProfilFormData {
+  titre: string;
+  sous_titre: string;
+}
+
+export default function TypesProfil() {
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [editingTypeProfil, setEditingTypeProfil] = useState<{ id: number; uuid?: string; icone_path?: string } & TypeProfilFormData | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebounce(searchQuery, 500);
+  const [iconeFile, setIconeFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+
+  const [formData, setFormData] = useState<TypeProfilFormData>({
+    titre: "",
+    sous_titre: "",
+  });
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  // Safe object URL management for the local file preview.
+  useEffect(() => {
+    if (!iconeFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(iconeFile);
+    setPreviewUrl(objectUrl);
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [iconeFile]);
+
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: typeProfilsResponse, isLoading, isPlaceholderData } = useQuery({
+    queryKey: ["type-profils", page, limit, debouncedSearchQuery],
+    queryFn: () => typeProfilsService.getAll({
+      page,
+      limit,
+      search: debouncedSearchQuery || undefined,
+    }),
+    placeholderData: keepPreviousData,
+  });
+  const typeProfils = typeProfilsResponse?.data || [];
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<TypeProfilFormData> }) =>
+      typeProfilsService.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["type-profils"] });
+      setIsEditDialogOpen(false);
+      setEditingTypeProfil(null);
+      toast({ title: "Succès", description: "Type de profil mis à jour avec succès" });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erreur",
+        description: error.message || "Échec de la mise à jour du type de profil",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => typeProfilsService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["type-profils"] });
+      setDeleteId(null);
+      toast({ title: "Succès", description: "Type de profil supprimé avec succès" });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Erreur",
+        description: error.message || "Échec de la suppression du type de profil",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsUploading(true);
+
+    try {
+      // Create the row first; backend assigns the uuid we use as the R2 key.
+      // Icône is OPTIONAL — create must succeed even when no file is chosen.
+      const newTypeProfil = await typeProfilsService.create({
+        titre: formData.titre,
+        sous_titre: formData.sous_titre || undefined,
+      });
+
+      if (iconeFile && newTypeProfil.uuid) {
+        try {
+          await filesService.uploadFile('type_profils', newTypeProfil.uuid, 'icone', iconeFile);
+          toast({ title: "Succès", description: "Type de profil créé avec icône" });
+        } catch (uploadError) {
+          console.error("Failed to upload icône", uploadError);
+          toast({ title: "Attention", description: "Type de profil créé mais échec de l'upload de l'icône" });
+        }
+      } else {
+        toast({ title: "Succès", description: "Type de profil créé avec succès" });
+      }
+
+      queryClient.invalidateQueries({ queryKey: ["type-profils"] });
+      setIsCreateDialogOpen(false);
+      setFormData({ titre: "", sous_titre: "" });
+      setIconeFile(null);
+    } catch (error: any) {
+      toast({ title: "Erreur", description: error.message || "Échec de la création", variant: "destructive" });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editingTypeProfil) return;
+    setIsUploading(true);
+
+    try {
+      await updateMutation.mutateAsync({
+        id: editingTypeProfil.id,
+        data: {
+          titre: editingTypeProfil.titre,
+          sous_titre: editingTypeProfil.sous_titre,
+        },
+      });
+
+      // Upload a new icône if the user picked one (optional).
+      if (iconeFile && editingTypeProfil.uuid) {
+        await filesService.uploadFile('type_profils', editingTypeProfil.uuid, 'icone', iconeFile);
+      }
+    } catch (error: any) {
+      console.error("Update failed", error);
+    } finally {
+      setIsUploading(false);
+      setIconeFile(null);
+    }
+  };
+
+  const openEditDialog = (typeProfil: any) => {
+    setEditingTypeProfil({
+      id: typeProfil.id,
+      uuid: typeProfil.uuid,
+      icone_path: typeProfil.icone_path,
+      titre: typeProfil.titre,
+      sous_titre: typeProfil.sous_titre || "",
+    });
+    setIconeFile(null);
+    setIsEditDialogOpen(true);
+  };
+
+  if (isLoading && !isPlaceholderData) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-foreground flex items-center gap-2">
+            <Tags className="h-8 w-8" />
+            Types de profil
+          </h1>
+          <p className="text-muted-foreground">Gérer les types de profil pour la personnalisation</p>
+        </div>
+        <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              Ajouter un type de profil
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <form onSubmit={handleCreate}>
+              <DialogHeader>
+                <DialogTitle>Créer un type de profil</DialogTitle>
+                <DialogDescription>
+                  Ajouter un nouveau type de profil (titre, sous-titre, icône optionnelle)
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="titre">Titre *</Label>
+                  <Input
+                    id="titre"
+                    value={formData.titre}
+                    onChange={(e) => setFormData({ ...formData, titre: e.target.value })}
+                    required
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="sous_titre">Sous-titre</Label>
+                  <Input
+                    id="sous_titre"
+                    value={formData.sous_titre}
+                    onChange={(e) => setFormData({ ...formData, sous_titre: e.target.value })}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="icone">Icône</Label>
+                  <div className="flex items-center gap-4">
+                    <Input
+                      id="icone"
+                      type="file"
+                      accept="image/*"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) setIconeFile(file);
+                      }}
+                      className="cursor-pointer"
+                    />
+                    {iconeFile && (
+                      <div className="relative h-10 w-10">
+                        <img
+                          src={previewUrl || ""}
+                          alt="Preview"
+                          className="h-full w-full object-cover rounded"
+                        />
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="icon"
+                          className="absolute -top-2 -right-2 h-4 w-4 rounded-full"
+                          onClick={() => setIconeFile(null)}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button type="submit" disabled={isUploading}>
+                  {isUploading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Création...
+                    </>
+                  ) : (
+                    "Créer"
+                  )}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Liste des types de profil</CardTitle>
+          <CardDescription>
+            {typeProfils.length} type{typeProfils.length > 1 ? "s" : ""} de profil enregistré
+            {typeProfils.length > 1 ? "s" : ""}
+            <div className="relative mt-4">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher par titre ou sous-titre..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {typeProfils.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              Aucun type de profil trouvé. Créez-en un pour commencer.
+            </div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Icône</TableHead>
+                    <TableHead>Titre</TableHead>
+                    <TableHead>Sous-titre</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {typeProfils.map((typeProfil) => (
+                    <TableRow key={typeProfil.id}>
+                      <TableCell>
+                        <FileImage
+                          entity="type_profils"
+                          uuid={typeProfil.uuid}
+                          slot="icone"
+                          url={typeProfil.icone_path}
+                          alt={`Icône ${typeProfil.titre}`}
+                          className="h-10 w-10 object-contain rounded-md"
+                          placeholder={
+                            <div className="h-10 w-10 bg-muted rounded-md flex items-center justify-center">
+                              <Tags className="h-5 w-5 text-muted-foreground" />
+                            </div>
+                          }
+                        />
+                      </TableCell>
+                      <TableCell className="font-medium">{typeProfil.titre}</TableCell>
+                      <TableCell>{typeProfil.sous_titre || "—"}</TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => openEditDialog(typeProfil)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setDeleteId(typeProfil.id)}
+                          >
+                            <Trash2 className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {typeProfilsResponse?.totalPages !== undefined && typeProfilsResponse.totalPages > 1 && (
+                <div className="flex items-center justify-center space-x-2 py-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                    Page {page} sur {typeProfilsResponse.totalPages}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setPage(p => Math.min(typeProfilsResponse.totalPages, p + 1))}
+                    disabled={page === typeProfilsResponse.totalPages}
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Edit Dialog */}
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent>
+          <form onSubmit={handleEdit}>
+            <DialogHeader>
+              <DialogTitle>Modifier le type de profil</DialogTitle>
+              <DialogDescription>Mettre à jour les informations du type de profil</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-titre">Titre *</Label>
+                <Input
+                  id="edit-titre"
+                  value={editingTypeProfil?.titre || ""}
+                  onChange={(e) =>
+                    setEditingTypeProfil(
+                      editingTypeProfil ? { ...editingTypeProfil, titre: e.target.value } : null
+                    )
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-sous_titre">Sous-titre</Label>
+                <Input
+                  id="edit-sous_titre"
+                  value={editingTypeProfil?.sous_titre || ""}
+                  onChange={(e) =>
+                    setEditingTypeProfil(
+                      editingTypeProfil ? { ...editingTypeProfil, sous_titre: e.target.value } : null
+                    )
+                  }
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-icone">Icône</Label>
+              <div className="flex items-center gap-4">
+                {iconeFile ? (
+                  <div className="relative h-16 w-16">
+                    <img
+                      src={previewUrl || ""}
+                      alt="Preview"
+                      className="h-full w-full object-contain rounded-md border"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="absolute -top-2 -right-2 h-6 w-6 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90 p-0"
+                      onClick={() => setIconeFile(null)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ) : editingTypeProfil?.uuid ? (
+                  <div className="relative h-16 w-16">
+                    <FileImage
+                      entity="type_profils"
+                      uuid={editingTypeProfil.uuid}
+                      slot="icone"
+                      url={editingTypeProfil.icone_path}
+                      alt="Icône actuelle"
+                      className="h-full w-full object-contain rounded-md border"
+                    />
+                  </div>
+                ) : null}
+                <div className="flex-1">
+                  <Input
+                    id="edit-icone"
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => {
+                      if (e.target.files && e.target.files[0]) {
+                        setIconeFile(e.target.files[0]);
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="submit" disabled={isUploading || updateMutation.isPending}>
+                {isUploading || updateMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Mise à jour...
+                  </>
+                ) : (
+                  "Mettre à jour"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={deleteId !== null} onOpenChange={(open) => !open && setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmer la suppression</AlertDialogTitle>
+            <AlertDialogDescription>
+              La suppression d'un type de profil retire son assignation des utilisateurs et son
+              tagging des contenus (Opportunités, Événements, Forums, Services, Offres). Cette action
+              est irréversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteId && deleteMutation.mutate(deleteId)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleteMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Suppression...
+                </>
+              ) : (
+                "Supprimer"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}


### PR DESCRIPTION
Ships the **type-profil** feature (integrated onto current main; conflicts with the geo + age_group work resolved and verified on edukia-dev).

## What
- **TypeProfil** entity (titre / sous-titre / icône via R2 slot), CRUD at `/type-profils`, country-scoped, `uuid` exposed.
- **One type de profil per user** (`utilisateurs.type_profil_id`), set via update-profil; the profile response resolves the full `type_profil` object.
- **Audience tagging + visibility** on 5 entities — opportunités, événements, forums, services, offres: a non-admin sees an item if it's **untagged** OR shares their `type_profil` (zero auth-guard changes).
- **Admin UI**: TypesProfil page + nav + a shared `TypeProfilChecklist` wired into all 5 admin pages.

## Requires
- **edukia-db #12** (migrations 040-043: type_profils, type_profil_id, 5 join tables, type_profils.uuid) applied to prod **before** merge.

## Merge conflicts resolved (utilisateurs)
type-profil and the merged geo + age_group work both touched `utilisateurs`. Kept **both**: entity has geo FKs + `type_profil_id`; `getProfil` runs `enrichUserComplete` (geo {uuid,nom} + age_group + booleans) **and** grafts the resolved `type_profil`; `update` runs the geo cascade **and** the type_profil pays validation.

## Verified (edukia-dev, migrations applied)
- `/type-profils` create/list → 201/200.
- `/utilisateurs/profil` → `type_profil: "Étudiant"` **and** `age_group` **and** `ville` all present together.
- Backend + frontend build clean.

## Known limitations (unchanged from the feature spec)
- Untagged = public: users with no type_profil (and anonymous) only see untagged items.
- Forums checklist is create-only (no edit UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)