### PR TITLE
feat(departements): GET /:id/villes endpoint + CSV geo seed script

### DIFF
--- a/backend/src/departements/departement.controller.ts
+++ b/backend/src/departements/departement.controller.ts
@@ -72,6 +72,14 @@ export class DepartementController {
     return this.toResponse(await this.departementService.findOne(pays, id));
   }
 
+  @Get(':id/villes')
+  @ApiOperation({ summary: "Lister les villes d'un département (par uuid)" })
+  @ApiResponse({ status: 200, description: 'Villes du département' })
+  async findVilles(@CurrentCountry() pays: string, @Param('id') id: string) {
+    const villes = await this.departementService.findVilles(pays, id);
+    return villes.map((v) => ({ uuid: v.id, nom: v.nom }));
+  }
+
   @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un département' })
   async update(

--- a/backend/src/departements/departement.module.ts
+++ b/backend/src/departements/departement.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { DepartementController } from './departement.controller';
 import { DepartementService } from './departement.service';
 import { Departement } from './entities/departement.entity';
+import { Ville } from '../villes/entities/ville.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Departement])],
+  imports: [TypeOrmModule.forFeature([Departement, Ville])],
   controllers: [DepartementController],
   providers: [DepartementService],
   exports: [DepartementService],

--- a/backend/src/departements/departement.service.ts
+++ b/backend/src/departements/departement.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets } from 'typeorm';
 import { Departement } from './entities/departement.entity';
+import { Ville } from '../villes/entities/ville.entity';
 import { CreerDepartementDto } from './dto/creer-departement.dto';
 import { MajDepartementDto } from './dto/maj-departement.dto';
 import { FilterDepartementDto } from './dto/filter-departement.dto';
@@ -22,7 +23,18 @@ export class DepartementService {
   constructor(
     @InjectRepository(Departement)
     private readonly departementRepository: Repository<Departement>,
+    @InjectRepository(Ville)
+    private readonly villeRepository: Repository<Ville>,
   ) {}
+
+  // Villes d'un département (scopé pays via findOne). Renvoie la liste triée par nom.
+  async findVilles(pays: string, departementId: string): Promise<Ville[]> {
+    await this.findOne(pays, departementId); // 404 si le département n'existe pas pour ce pays
+    return this.villeRepository.find({
+      where: { departement_id: departementId },
+      order: { nom: 'ASC' },
+    });
+  }
 
   async create(pays: string, dto: CreerDepartementDto): Promise<Departement> {
     const existing = await this.departementRepository.findOne({


### PR DESCRIPTION
## Endpoint
**`GET /departements/:id/villes`** — returns a département's villes as `[{ uuid, nom }]` (sorted by nom), scoped by `?country=`, **404** if the département doesn't exist for that country. `DepartementService.findVilles` added (Ville repo registered in the module).

## Seed script
`backend/scripts/seed-geo-from-csv.js` — idempotent seeder for `departements` + `villes` from a `;`-delimited CSV. Configurable columns to handle the different country files:
| file | invocation |
|---|---|
| benin (Departement;Commune) | `… benin 0 1` |
| senegal (Region;Departement) | `… senegal 0 1` |
| congo (Departement;…;Communes;…;Districts) | `… congo 0 2,4` (splits comma-list cells, strips `(…)`) |

## Data seeded (dev + **prod**)
| pays | départements | villes |
|---|---|---|
| benin | 12 | 77 |
| senegal | 14 | 46 |
| congo | 15 | 91 |

Verified: 0 duplicate villes; endpoint returns 6 villes for Alibori, 404 for a bogus uuid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)