### PR TITLE
fix(files): cache-bust public slot URLs so re-uploads show the new file

### DIFF
--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -166,7 +166,12 @@ export class FilesService {
      */
     private storedPathFor(cfg: FileSlotConfig, entity: string, uuid: string, slot: string, extension: string): string {
         if (cfg.public) {
-            return this.publicUrl(buildObjectKey(entity, uuid, slot, extension));
+            // The R2 object key is DETERMINISTIC (<entity>/<uuid>/<slot>.<ext>) and public
+            // objects are served with `immutable` (PUBLIC_CACHE_CONTROL). A re-upload
+            // overwrites the object but keeps the SAME URL, so CDNs/browsers keep serving
+            // the stale copy. Append a per-upload version → a fresh URL (new CDN cache key)
+            // each time, so the new file is visible while caching stays aggressive.
+            return `${this.publicUrl(buildObjectKey(entity, uuid, slot, extension))}?v=${Date.now()}`;
         }
         return buildLogicalPath(entity, uuid, slot);
     }


### PR DESCRIPTION
## Symptom
Uploading a new file to a **public** slot (e.g. `utilisateurs.profil`) via the `/files/...` presign flow succeeds (PUT → R2 `200`), but the file **appears unchanged**.

## Root cause
Public objects use a **deterministic R2 key** `<entity>/<uuid>/<slot>.<ext>` and are written with `Cache-Control: public, max-age=31536000, immutable`. On re-upload:
- R2 **does** overwrite the object (the bucket is updated),
- **but** the stored `<slot>_path` URL is identical (same key) and marked `immutable` for a year → the Cloudflare CDN (in front of the public bucket custom domain) and the browser keep serving the **stale cached copy**. Nothing revalidates.

So it's not that R2 fails to store the new file — it's that every reader hits an immutable, unchanging URL.

## Fix
`storedPathFor` now appends a per-upload version to the stored public URL:
`…/profil.png` → `…/profil.png?v=<timestamp>`. Each upload writes a fresh URL (new CDN cache key) → the new object is fetched, while the R2 key stays deterministic (overwrite in place) and `immutable` caching is preserved. One change covers all write paths (presign / proxy / mirror / backfill copy).

## Verified (dev)
Two `upload-url` calls → paths differ by `?v=` but share the same object key; `Cache-Control` unchanged.

## Note
Relies on the CDN including the query string in its cache key (Cloudflare default). If the zone is set to *ignore query string*, switch to a versioned object key or drop `immutable` for mutable slots instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)