### PR TITLE
hotfix(utilisateurs): situation_handicap → boolean

### DIFF
--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsEmail, MinLength, IsEnum, IsOptional, IsDateString, IsIn } from 'class-validator';
+import { IsString, IsEmail, MinLength, IsEnum, IsOptional, IsDateString, IsIn, IsBoolean } from 'class-validator';
 import { RoleType, SexeType, AgeGroup } from '../../utilisateurs/entities/utilisateur.entity';
 
 export class RegisterDto {
@@ -49,8 +49,8 @@ export class RegisterDto {
     @IsIn(['rural', 'urbain'])
     zone_residence?: string;
 
-    @ApiProperty({ enum: ['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'], description: 'Situation de handicap (PII optionnelle)', required: false })
+    @ApiProperty({ example: false, description: 'Situation de handicap (oui/non)', required: false })
     @IsOptional()
-    @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
-    situation_handicap?: string;
+    @IsBoolean()
+    situation_handicap?: boolean;
 }

--- a/backend/src/kpi/kpi.service.ts
+++ b/backend/src/kpi/kpi.service.ts
@@ -12,7 +12,7 @@ import { DataSource } from 'typeorm';
  *  - age ≤ 35: age_group in the under-35 buckets ('< 18','18 - 25','26 - 35').
  *    NULL age_group is excluded automatically (not counted). Replaces the former
  *    date_naissance-based computation.
- *  - disability: situation_handicap IS NOT NULL AND <> 'aucun'.
+ *  - disability: situation_handicap IS TRUE (booléen).
  *  - logins (KPI 8 / 15): distinct refresh_tokens.utilisateur_id in the period
  *    (refresh_tokens has no pays, so we join utilisateurs for the country scope).
  *  - KPI 16: distinct learners with a resource_access row (épreuve|concours) in
@@ -33,13 +33,13 @@ export class KpiService {
         COUNT(*) FILTER (WHERE sexe = 'F')                                                         AS female_users,
         COUNT(*) FILTER (WHERE sexe = 'F' AND age_group IN ('< 18','18 - 25','26 - 35')) AS female_age_35,
         COUNT(*) FILTER (WHERE zone_residence = 'rural')                                           AS rural_users,
-        COUNT(*) FILTER (WHERE situation_handicap IS NOT NULL AND situation_handicap <> 'aucun')   AS disability_users,
+        COUNT(*) FILTER (WHERE situation_handicap IS TRUE)   AS disability_users,
         COUNT(*) FILTER (WHERE role = 'étudiant')                                                  AS learners,
         COUNT(*) FILTER (WHERE role = 'étudiant' AND age_group IN ('< 18','18 - 25','26 - 35')) AS learners_age_35,
         COUNT(*) FILTER (WHERE role = 'étudiant' AND sexe = 'F' AND age_group IN ('< 18','18 - 25','26 - 35')) AS learners_age_35_female,
         COUNT(*) FILTER (WHERE role = 'étudiant' AND sexe = 'F')                                   AS female_learners,
         COUNT(*) FILTER (WHERE role = 'étudiant' AND zone_residence = 'rural')                     AS rural_learners,
-        COUNT(*) FILTER (WHERE role = 'étudiant' AND situation_handicap IS NOT NULL AND situation_handicap <> 'aucun') AS disability_learners
+        COUNT(*) FILTER (WHERE role = 'étudiant' AND situation_handicap IS TRUE) AS disability_learners
       FROM utilisateurs
       WHERE pays = $1
         AND date_creation >= $2::date

--- a/backend/src/utilisateurs/dto/inscription.dto.ts
+++ b/backend/src/utilisateurs/dto/inscription.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsNumber, IsDateString, IsIn } from 'class-validator';
+import { IsEmail, IsString, MinLength, IsOptional, IsEnum, IsNumber, IsDateString, IsIn, IsBoolean } from 'class-validator';
 import { RoleType, SexeType, AgeGroup } from '../entities/utilisateur.entity';
 
 export class InscriptionDto {
@@ -79,8 +79,8 @@ export class InscriptionDto {
   @IsIn(['rural', 'urbain'])
   zone_residence?: string;
 
-  @ApiProperty({ enum: ['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'], description: 'Situation de handicap (PII optionnelle)', required: false })
+  @ApiProperty({ example: false, description: 'Situation de handicap (oui/non)', required: false })
   @IsOptional()
-  @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
-  situation_handicap?: string;
+  @IsBoolean()
+  situation_handicap?: boolean;
 }

--- a/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
+++ b/backend/src/utilisateurs/dto/maj-utilisateur.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsEnum, IsNumber, IsDateString, IsIn, IsUUID } from 'class-validator';
+import { IsOptional, IsString, IsEnum, IsNumber, IsDateString, IsIn, IsUUID, IsBoolean } from 'class-validator';
 import { RoleType, SexeType, AgeGroup } from '../entities/utilisateur.entity';
 
 export class MajUtilisateurDto {
@@ -31,8 +31,8 @@ export class MajUtilisateurDto {
   zone_residence?: string;
 
   @IsOptional()
-  @IsIn(['visuel', 'auditif', 'moteur', 'psychomoteur', 'aucun'])
-  situation_handicap?: string;
+  @IsBoolean()
+  situation_handicap?: boolean;
 
   @IsOptional()
   @IsString()

--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -103,8 +103,9 @@ export class Utilisateur {
   @Column({ type: 'varchar', length: 20, nullable: true })
   zone_residence: string;
 
-  @Column({ type: 'varchar', length: 20, nullable: true })
-  situation_handicap: string;
+  // Situation de handicap : booléen (oui/non). Remplace l'ancienne chaîne (visuel/auditif/…).
+  @Column({ type: 'boolean', nullable: true, default: false })
+  situation_handicap: boolean;
 
   @Column({ nullable: true })
   telephone: string;


### PR DESCRIPTION
Convert `utilisateurs.situation_handicap` from a varchar enum (`visuel`/`auditif`/…/`aucun`) to a **boolean** (has a disability situation, yes/no).

- Entity → `boolean` (default false); inscription/register/update-profil DTOs → `@IsBoolean`.
- KPI disability filter → `situation_handicap IS TRUE`.

**Requires edukia-db migration 046** applied to prod before merge (`aucun`/NULL → false, any other value → true; drops the old enum CHECK).

Verified on dev: `PUT true` → profile `true` (boolean); `"visuel"` → 400; `/stats` → 200.