### PR TITLE
feat(etablissements): include epreuve uuid in nested epreuves response

### DIFF
--- a/backend/src/etablissements/etablissements.service.ts
+++ b/backend/src/etablissements/etablissements.service.ts
@@ -381,6 +381,7 @@ export class EtablissementsService {
     return {
       data: epreuves.map(epreuve => ({
         id: epreuve.id,
+        uuid: epreuve.uuid,
         titre: epreuve.titre,
         url: epreuve.url,
         duree_minutes: epreuve.duree_minutes,


### PR DESCRIPTION
`GET /etablissements/:id/filieres/:filiereId/niveau-etude/:niveauId/epreuves` returned each épreuve with `id` but **not `uuid`**. Added `uuid` to the mapped épreuve object so clients can key on it.

(Supersedes #170 — that request-side change was reverted per feedback.)

## Verified on dev
Épreuve object keys now include `uuid`:
`id, uuid, titre, url, duree_minutes, date_creation, date_publication, nombre_pages, nombre_telechargements, type, professeur, matiere`

No migration.