### PR TITLE
fix(approbations): épreuves/concours queues show oldest submission first

### DIFF
--- a/backend/src/concours/concours-submissions.service.ts
+++ b/backend/src/concours/concours-submissions.service.ts
@@ -158,7 +158,7 @@ export class ConcoursSubmissionsService {
             .addSelect(['soumis_par.id', 'soumis_par.uuid', 'soumis_par.nom', 'soumis_par.prenom', 'soumis_par.email'])
             .where('submission.pays = :pays', { pays })
             .andWhere('submission.status = :status', { status: effectiveStatus })
-            .orderBy('submission.date_creation', 'DESC')
+            .orderBy('submission.date_creation', 'ASC')
             .skip((page - 1) * limit)
             .take(limit)
             .getManyAndCount();

--- a/backend/src/epreuves/submissions/epreuve-submissions.service.ts
+++ b/backend/src/epreuves/submissions/epreuve-submissions.service.ts
@@ -238,7 +238,7 @@ export class EpreuveSubmissionsService {
     const qb = this.baseSubmissionQuery()
       .leftJoinAndSelect('submission.soumis_par', 'soumis_par')
       .where('submission.pays = :pays', { pays })
-      .orderBy('submission.date_creation', 'DESC')
+      .orderBy('submission.date_creation', 'ASC')
       .skip((page - 1) * limit)
       .take(limit);
 


### PR DESCRIPTION
The **Approbations → Épreuves** and **Concours** sub-sections listed submissions **newest-first**; they should be **oldest-first** (FIFO) so the earliest pending request is handled first.

Changed the admin-queue lists to `date_creation ASC`:
- `EpreuveSubmissionsService.findAllForAdmin`
- `ConcoursSubmissionsService.findAll`

The user's own submission history (`findMine`, mobile) stays newest-first.

Verified on dev: épreuves admin queue → first `2026-07-02`, last `2026-07-06` (oldest-first ✓). No migration.