### PR TITLE
feat(wallet): separate reward for validated concours

### DIFF
--- a/backend/src/concours/concours-submissions.service.ts
+++ b/backend/src/concours/concours-submissions.service.ts
@@ -354,7 +354,7 @@ export class ConcoursSubmissionsService {
         // EXAM_REWARD:<uuid> (re-approving does not double-credit).
         if (submission.soumis_par_id != null) {
             this.creditWalletFromExam
-                .execute({ userId: submission.soumis_par_id, examId: savedConcours.uuid, description: 'Concours validé' })
+                .execute({ userId: submission.soumis_par_id, examId: savedConcours.uuid, description: 'Concours validé', resource: 'concours' })
                 .then((res: any) => this.logger.log(`Wallet crédité (concours ${savedConcours.uuid}) pour user ${submission.soumis_par_id}${res?.duplicated ? ' [déjà crédité]' : ''}`))
                 .catch(err => this.logger.error(`Crédit wallet échoué (soumission ${id}): ${err.message}`));
         }

--- a/backend/src/wallet/shared/payment.ports.ts
+++ b/backend/src/wallet/shared/payment.ports.ts
@@ -18,6 +18,7 @@ export interface PaymentConfigurationModel {
   withdrawFee: number;
   withdrawFeeType: FeeType;
   rewardPerExam: number;
+  rewardPerConcours: number;
   currency: string;
   walletEnabled: boolean;
   withdrawEnabled: boolean;

--- a/backend/src/wallet/user-payment/dto/update-payment-configuration.dto.ts
+++ b/backend/src/wallet/user-payment/dto/update-payment-configuration.dto.ts
@@ -8,6 +8,7 @@ export class UpdatePaymentConfigurationDto {
   @ApiPropertyOptional() @IsOptional() @IsNumber() @Min(0) withdrawFee?: number;
   @ApiPropertyOptional({ enum: FeeType }) @IsOptional() @IsEnum(FeeType) withdrawFeeType?: FeeType;
   @ApiPropertyOptional() @IsOptional() @IsNumber() @Min(0) rewardPerExam?: number;
+  @ApiPropertyOptional() @IsOptional() @IsNumber() @Min(0) rewardPerConcours?: number;
   @ApiPropertyOptional() @IsOptional() @IsBoolean() walletEnabled?: boolean;
   @ApiPropertyOptional() @IsOptional() @IsBoolean() withdrawEnabled?: boolean;
   @ApiPropertyOptional() @IsOptional() @IsBoolean() rewardEnabled?: boolean;

--- a/backend/src/wallet/user-payment/entities/payment-configuration.entity.ts
+++ b/backend/src/wallet/user-payment/entities/payment-configuration.entity.ts
@@ -10,6 +10,7 @@ export class PaymentConfigurationEntity {
   @Column({ name: 'withdraw_fee', type: 'numeric', precision: 14, scale: 2, default: 0, transformer: DecimalColumnTransformer }) withdrawFee: number;
   @Column({ name: 'withdraw_fee_type', type: 'enum', enum: FeeType, default: FeeType.FIXED }) withdrawFeeType: FeeType;
   @Column({ name: 'reward_per_exam', type: 'numeric', precision: 14, scale: 2, default: 100, transformer: DecimalColumnTransformer }) rewardPerExam: number;
+  @Column({ name: 'reward_per_concours', type: 'numeric', precision: 14, scale: 2, default: 100, transformer: DecimalColumnTransformer }) rewardPerConcours: number;
   @Column({ type: 'varchar', length: 10, default: 'XOF' }) currency: string;
   @Column({ name: 'wallet_enabled', default: true }) walletEnabled: boolean;
   @Column({ name: 'withdraw_enabled', default: true }) withdrawEnabled: boolean;

--- a/backend/src/wallet/wallet-balance/use-cases/credit-wallet-from-validated-exam.use-case.ts
+++ b/backend/src/wallet/wallet-balance/use-cases/credit-wallet-from-validated-exam.use-case.ts
@@ -20,6 +20,8 @@ export interface CreditWalletFromValidatedExamCommand {
   userId: number;
   examId: string;
   amount?: number;
+  /** Type de ressource validée — choisit la récompense par défaut (exam vs concours). */
+  resource?: 'exam' | 'concours';
   currency?: string;
   reference?: string;
   description?: string;
@@ -42,7 +44,11 @@ export class CreditWalletFromValidatedExamUseCase {
       throw new ConflictException('La récompense des épreuves est désactivée');
     }
 
-    const amount = Number(command.amount ?? configuration.rewardPerExam);
+    // Récompense par défaut selon le type de ressource ; un `amount` explicite prime.
+    const defaultReward = command.resource === 'concours'
+      ? configuration.rewardPerConcours
+      : configuration.rewardPerExam;
+    const amount = Number(command.amount ?? defaultReward);
     if (!amount || amount <= 0) throw new BadRequestException('Le montant à créditer doit être supérieur à zéro');
 
     const reference = command.reference ?? `EXAM_REWARD:${command.examId}`;

--- a/frontend/src/lib/services/wallet-admin.service.ts
+++ b/frontend/src/lib/services/wallet-admin.service.ts
@@ -51,6 +51,7 @@ export type FeeType = 'FIXED' | 'PERCENTAGE';
 export interface PaymentConfiguration {
   id: string;
   rewardPerExam: number;
+  rewardPerConcours: number;
   rewardEnabled: boolean;
   minimumWithdrawal: number;
   maximumWithdrawal: number;

--- a/frontend/src/pages/ConfigurationWallet.tsx
+++ b/frontend/src/pages/ConfigurationWallet.tsx
@@ -25,7 +25,8 @@ type NumKey = keyof PaymentConfigurationUpdate;
 type NumField = { key: NumKey; label: string; hint?: string };
 
 const REWARD_FIELDS: NumField[] = [
-  { key: "rewardPerExam", label: "Récompense par ressource validée (XOF)", hint: "Montant crédité à l'auteur quand une épreuve/concours est approuvé." },
+  { key: "rewardPerExam", label: "Récompense par épreuve validée (XOF)", hint: "Montant crédité à l'auteur quand une épreuve est approuvée." },
+  { key: "rewardPerConcours", label: "Récompense par concours validé (XOF)", hint: "Montant crédité à l'auteur quand un concours est approuvé." },
 ];
 const WITHDRAW_FIELDS: NumField[] = [
   { key: "minimumWithdrawal", label: "Retrait minimum (XOF)" },
@@ -51,7 +52,7 @@ const TOGGLES: { key: NumKey; label: string; hint?: string }[] = [
 ];
 
 const NUM_KEYS: NumKey[] = [
-  "rewardPerExam", "minimumWithdrawal", "maximumWithdrawal", "withdrawFee",
+  "rewardPerExam", "rewardPerConcours", "minimumWithdrawal", "maximumWithdrawal", "withdrawFee",
   "dailyWithdrawalLimit", "monthlyWithdrawalLimit", "minimumWalletBalance",
   "reviewDelayHours", "maxWithdrawPerDay", "maxWithdrawPerWeek", "maxWithdrawPerMonth",
 ];


### PR DESCRIPTION
Épreuves and concours previously shared one reward (`rewardPerExam`). This adds a **distinct reward for concours**.

- **DB:** `payment_configurations.reward_per_concours` (migration 047, default 100 = exam).
- **Credit use-case:** picks `rewardPerConcours` vs `rewardPerExam` via a `resource` flag; concours approval passes `resource: 'concours'`.
- **Admin config page:** new **"Récompense par concours validé (XOF)"** field alongside the épreuve one.

## Requires
- edukia-db migration **047** applied to prod before merge.

## Verified on dev
`PATCH …/admin/configuration { rewardPerExam: 100, rewardPerConcours: 250 }` → 200, GET confirms both persisted. Épreuve approval → `rewardPerExam`; concours approval → `rewardPerConcours` (idempotent as before).