### PR TITLE
feat(utilisateurs): persist referral code entered at signup

### DIFF
--- a/backend/src/utilisateurs/entities/utilisateur.entity.ts
+++ b/backend/src/utilisateurs/entities/utilisateur.entity.ts
@@ -70,6 +70,11 @@ export class Utilisateur {
   @Column({ nullable: true, unique: true })
   mon_code_parrainage: string;
 
+  // Referral code the user typed at signup, kept verbatim even if it
+  // matches no user (parrain_id then stays null). Not unique.
+  @Column({ nullable: true })
+  code_parrainage_saisi: string;
+
   @Column({ unique: true })
   email: string;
 

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -176,6 +176,7 @@ export class UtilisateursService {
           mot_de_passe: hashedPassword,
           est_desactive: false,
           date_suppression_prevue: null,
+          code_parrainage_saisi: inscriptionDto.code_parrainage ?? existingUser.code_parrainage_saisi,
         });
 
         // Save reactivated user
@@ -245,6 +246,7 @@ export class UtilisateursService {
       pays,
       mot_de_passe: hashedPassword,
       parrain: parrain,
+      code_parrainage_saisi: inscriptionDto.code_parrainage ?? null,
       mon_code_parrainage: monCodeParrainage,
       uuid: crypto.randomUUID()
     });
@@ -336,7 +338,7 @@ export class UtilisateursService {
       .leftJoinAndSelect('utilisateur.departement', 'departement')
       .leftJoinAndSelect('utilisateur.ville', 'ville')
       .loadRelationCountAndMap('utilisateur.filleulsCount', 'utilisateur.filleuls')
-      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'utilisateur.departement_id', 'utilisateur.ville_id', 'utilisateur.age_group', 'utilisateur.zone_residence', 'utilisateur.situation_handicap', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
+      .select(['utilisateur.id', 'utilisateur.nom', 'utilisateur.prenom', 'utilisateur.email', 'utilisateur.pseudo', 'utilisateur.uuid', 'utilisateur.photo', 'utilisateur.profil_photo_path', 'utilisateur.profil_photo_extension', 'utilisateur.sexe', 'utilisateur.telephone', 'utilisateur.role', 'utilisateur.pays', 'utilisateur.est_desactive', 'utilisateur.date_suppression_prevue', 'utilisateur.date_creation', 'utilisateur.mon_code_parrainage', 'utilisateur.code_parrainage_saisi', 'utilisateur.departement_id', 'utilisateur.ville_id', 'utilisateur.age_group', 'utilisateur.zone_residence', 'utilisateur.situation_handicap', 'etablissement', 'filiere', 'niveau_etude', 'departement', 'ville'])
       .where('utilisateur.pays = :pays', { pays })
       .skip((page - 1) * limit)
       .take(limit);
@@ -402,7 +404,7 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec ID: ${id}`);
     const user = await this.utilisateursRepository.findOne({
       where: { id: parseInt(id) },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id',
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'code_parrainage_saisi', 'departement_id', 'ville_id',
         // geo-profile (D4): previously-dropped profile fields
         'pays', 'age_group', 'zone_residence', 'situation_handicap', 'date_creation',
         // geo-profile: match the unified list shape (enrichUserComplete)
@@ -423,7 +425,7 @@ export class UtilisateursService {
     this.logger.log(`Recherche de l'utilisateur avec UUID: ${uuid}`);
     const user = await this.utilisateursRepository.findOne({
       where: { uuid },
-      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'departement_id', 'ville_id',
+      select: ['id', 'nom', 'prenom', 'email', 'pseudo', 'uuid', 'photo', 'profil_photo_path', 'profil_photo_extension', 'sexe', 'telephone', 'role', 'mon_code_parrainage', 'code_parrainage_saisi', 'departement_id', 'ville_id',
         // geo-profile (D4): previously-dropped profile fields
         'pays', 'age_group', 'zone_residence', 'situation_handicap', 'date_creation',
         // geo-profile: match the unified list shape (enrichUserComplete)

--- a/frontend/src/pages/Users.tsx
+++ b/frontend/src/pages/Users.tsx
@@ -383,7 +383,8 @@ export default function Users() {
               <Field label="Filière" value={detailsUser.filiere?.nom} />
               <Field label="Niveau d'étude" value={detailsUser.niveau_etude?.nom} />
               <Field label="Type de profil" value={detailsUser.type_profil ? `${detailsUser.type_profil.icone ?? ""} ${detailsUser.type_profil.titre}`.trim() : null} />
-              <Field label="Code parrainage" value={detailsUser.mon_code_parrainage} />
+              <Field label="Son code parrainage" value={detailsUser.mon_code_parrainage} />
+              <Field label="Code parrainage saisi" value={detailsUser.code_parrainage_saisi} />
               <Field label="Email vérifié" value={detailsUser.isEmailVerified ? "Oui" : "Non"} />
               <Field label="Prestataire" value={detailsUser.isPrestataire ? "Oui" : "Non"} />
               <Field label="Recruteur" value={detailsUser.isRecruteur ? "Oui" : "Non"} />


### PR DESCRIPTION
## What
Store the referral code a user types at signup **verbatim**, even when it matches no existing user (`parrain_id` then stays `null`). Previously that raw code was discarded — only the resolved `parrain_id` FK was kept, so an invalid/typo'd code left no trace.

New column `utilisateurs.code_parrainage_saisi` (nullable, not unique) — distinct from `mon_code_parrainage` (the user's own generated code).

## Changes
- **Entity**: `code_parrainage_saisi` column.
- **Service** `inscription()`: sets it on create and reactivation.
- **Selects**: added to list, `/:uuid` and `/profil` so it's exposed in the API.
- **Admin frontend**: Users details dialog now shows *"Son code parrainage"* (own code) + *"Code parrainage saisi"* (entered code).

## Requires
Migration **063** in edukia-db (`code_parrainage_saisi` column) — apply to prod before merge.

## Verified on dev stack
- Invalid code `ZZZZ99` → stored, `parrain: null`, 201.
- Valid code `4EHXQW` → stored, referrer resolved, 201.
- Admin list + `/:uuid` expose the field, no password leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)