### PR TITLE
feat(etablissements): extend all=true to filieres + niveau-etude

### DIFF
--- a/backend/src/etablissements/etablissements.service.ts
+++ b/backend/src/etablissements/etablissements.service.ts
@@ -166,26 +166,37 @@ export class EtablissementsService {
 
   // Hierarchical navigation methods
   async findFilieresById(pays: string, id: string, filterDto: FilterFiliereDto): Promise<PaginationResponse<FiliereResponseDto>> {
-    const { page = 1, limit = 10, search } = filterDto;
-    this.logger.log(`Récupération des filières (pays=${pays}) pour établissement ID: ${id} - Page: ${page}, Limite: ${limit}, Search: ${search}`);
+    const { page = 1, limit = 10, search, all } = filterDto;
+    this.logger.log(`Récupération des filières (pays=${pays}) pour établissement ID: ${id} - Page: ${page}, Limite: ${limit}, Search: ${search}, All: ${all}`);
     await this.findOne(id); // Verify etablissement exists
 
-    const whereCondition: FindOptionsWhere<Filiere> = {
-      pays,
-      etablissement: { id: parseInt(id) },
-    };
+    const queryBuilder = this.filieresRepository.createQueryBuilder('filiere')
+      .leftJoinAndSelect('filiere.etablissement', 'etablissement')
+      .where('filiere.pays = :pays', { pays })
+      .andWhere('etablissement.id = :etabId', { etabId: parseInt(id) });
 
-    if (search) {
-      whereCondition.nom = Raw(alias => `unaccent(${alias}) ILIKE unaccent('%${search}%')`);
+    // Default: only filières with at least one épreuve reachable through
+    // filière→niveau→matière→épreuve. all=true lifts the filter.
+    if (!all) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM epreuves ep
+          INNER JOIN matieres m ON m.id = ep.matiere_id
+          INNER JOIN niveau_etude n ON n.id = m.niveau_etude_id
+          WHERE n.filiere_id = filiere.id
+        )`,
+      );
     }
 
-    const [filieres, total] = await this.filieresRepository.findAndCount({
-      where: whereCondition,
-      relations: ['etablissement'],
-      order: { nom: filterDto.sort_order || 'ASC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    if (search) {
+      queryBuilder.andWhere('unaccent(filiere.nom) ILIKE unaccent(:search)', { search: `%${search}%` });
+    }
+
+    const [filieres, total] = await queryBuilder
+      .orderBy('filiere.nom', filterDto.sort_order || 'ASC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
 
     this.logger.log(`${filieres.length} filière(s) trouvée(s) pour établissement ${id} sur ${total} total`);
 
@@ -203,8 +214,8 @@ export class EtablissementsService {
   }
 
   async findNiveauEtudeByFiliere(pays: string, etablissementId: string, filiereId: string, filterDto: FilterNiveauEtudeDto): Promise<PaginationResponse<NiveauEtude>> {
-    const { page = 1, limit = 10, search } = filterDto;
-    this.logger.log(`Récupération des niveaux d'étude (pays=${pays}) pour filière ID: ${filiereId} - Page: ${page}, Limite: ${limit}, Search: ${search}`);
+    const { page = 1, limit = 10, search, all } = filterDto;
+    this.logger.log(`Récupération des niveaux d'étude (pays=${pays}) pour filière ID: ${filiereId} - Page: ${page}, Limite: ${limit}, Search: ${search}, All: ${all}`);
 
     // Verify filiere belongs to etablissement
     const filiere = await this.filieresRepository.findOne({
@@ -218,22 +229,33 @@ export class EtablissementsService {
       throw new NotFoundException('Filière non trouvée pour cet établissement');
     }
 
-    const whereCondition: FindOptionsWhere<NiveauEtude> = {
-      pays,
-      filiere: { id: parseInt(filiereId) },
-    };
+    const queryBuilder = this.niveauEtudeRepository.createQueryBuilder('niveau_etude')
+      .leftJoinAndSelect('niveau_etude.filiere', 'filiere')
+      .leftJoinAndSelect('filiere.etablissement', 'etablissement')
+      .where('niveau_etude.pays = :pays', { pays })
+      .andWhere('filiere.id = :filiereId', { filiereId: parseInt(filiereId) });
 
-    if (search) {
-      whereCondition.nom = Raw(alias => `unaccent(${alias}) ILIKE unaccent('%${search}%')`);
+    // Default: only niveaux with at least one épreuve reachable through
+    // niveau→matière→épreuve. all=true lifts the filter.
+    if (!all) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1 FROM epreuves ep
+          INNER JOIN matieres m ON m.id = ep.matiere_id
+          WHERE m.niveau_etude_id = niveau_etude.id
+        )`,
+      );
     }
 
-    const [niveaux, total] = await this.niveauEtudeRepository.findAndCount({
-      where: whereCondition,
-      relations: ['filiere', 'filiere.etablissement'],
-      order: { nom: filterDto.sort_order || 'ASC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    if (search) {
+      queryBuilder.andWhere('unaccent(niveau_etude.nom) ILIKE unaccent(:search)', { search: `%${search}%` });
+    }
+
+    const [niveaux, total] = await queryBuilder
+      .orderBy('niveau_etude.nom', filterDto.sort_order || 'ASC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
 
     this.logger.log(`${niveaux.length} niveau(x) d'étude trouvé(s) pour filière ${filiereId} sur ${total} total`);
 

--- a/backend/src/filieres/dto/filter-filiere.dto.ts
+++ b/backend/src/filieres/dto/filter-filiere.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 
 export class FilterFiliereDto extends PaginationDto {
@@ -9,4 +10,12 @@ export class FilterFiliereDto extends PaginationDto {
     @IsOptional()
     @IsString()
     etablissement?: string;
+
+    // Default: only filières that have at least one épreuve (via
+    // niveau→matière→épreuve). Pass all=true to include empty filières
+    // (admin management / pickers).
+    @IsOptional()
+    @Transform(({ value }) => value === true || value === 'true')
+    @IsBoolean()
+    all?: boolean;
 }

--- a/backend/src/niveau-etude/dto/filter-niveau-etude.dto.ts
+++ b/backend/src/niveau-etude/dto/filter-niveau-etude.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsArray } from 'class-validator';
+import { IsOptional, IsString, IsArray, IsBoolean } from 'class-validator';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { Transform } from 'class-transformer';
 
@@ -10,4 +10,12 @@ export class FilterNiveauEtudeDto extends PaginationDto {
     @IsOptional()
     @IsString()
     filiere?: string;
+
+    // Default: only niveaux d'étude that have at least one épreuve (via
+    // matière→épreuve). Pass all=true to include empty niveaux
+    // (admin management / pickers).
+    @IsOptional()
+    @Transform(({ value }) => value === true || value === 'true')
+    @IsBoolean()
+    all?: boolean;
 }


### PR DESCRIPTION
## What
Extends the existing `all` query param (already on `GET /etablissements`) to two child endpoints:

- `GET /etablissements/:id/filieres`
- `GET /etablissements/:id/filieres/:filiereId/niveau-etude`

**Default** now returns only children that have **at least one épreuve** (via `filière→niveau→matière→épreuve` and `niveau→matière→épreuve` respectively) — so the mobile list never surfaces empty filières/niveaux, matching the établissement list behaviour.

**`?all=true`** lifts the `EXISTS` filter and returns everything (admin management / pickers).

## How
- Added the `all?: boolean` field (same `@Transform(value === true || 'true')`) to `FilterFiliereDto` and `FilterNiveauEtudeDto`.
- Rewrote `findFilieresById` and `findNiveauEtudeByFiliere` from `findAndCount` to a QueryBuilder with the `EXISTS` gate, mirroring `findAll`. Response shapes unchanged.

No schema change.

## Verified (live dev backend)
| Endpoint (etab 9) | default | all=true |
|---|---|---|
| `/filieres` | 3 (with épreuves) | 4 (total) |
| `/filieres/265/niveau-etude` | 1 (with épreuves) | 2 (total) |

Both match direct DB counts. 🤖 Generated with [Claude Code](https://claude.com/claude-code)