### PR TITLE
chore(deploy): pass PAYMENT_INTERNAL_API_KEY into the VPS .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,7 @@ jobs:
             R2_SECRET_ACCESS_KEY=${{ secrets.R2_SECRET_ACCESS_KEY }}
             R2_PUBLIC_BUCKET=${{ secrets.R2_PUBLIC_BUCKET }}
             R2_PUBLIC_BUCKET_URL=${{ secrets.R2_PUBLIC_BUCKET_URL }}
+            PAYMENT_INTERNAL_API_KEY=${{ secrets.PAYMENT_INTERNAL_API_KEY }}
             ENV_EOF
 
             # Créer le fichier docker-compose.yml depuis le contenu du repo


### PR DESCRIPTION
## What
Adds one line to `deploy.yml`'s `.env` heredoc:

```
PAYMENT_INTERNAL_API_KEY=${{ secrets.PAYMENT_INTERNAL_API_KEY }}
```

## Why
`docker-compose.yml` already expects it (`PAYMENT_INTERNAL_API_KEY: ${PAYMENT_INTERNAL_API_KEY}`), but `deploy.yml` never wrote it into the VPS `.env`. So on prod it resolved to **empty**, and the guard on the internal wallet-credit endpoint fails open:

```ts
// InternalApiKeyGuard
if (!expected) return true;   // no key configured -> allow everything
```

That left `POST /internal/payment/exam-rewards/credit` effectively unauthenticated. Writing the secret through makes the `x-internal-api-key` check actually enforce.

## Prerequisite
Set the **`PAYMENT_INTERNAL_API_KEY`** secret in the repo's **`PRD`** environment before/at merge. The next deploy will write it into the VPS `.env`, and callers of the internal endpoint must then send `x-internal-api-key: <value>`.

## Note
The guard still fails **open** when the key is unset. Hardening it to fail closed is a separate follow-up (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)