### PR TITLE
feat(utilisateurs): Appareils partagés — accounts grouped by shared FCM token

### DIFF
--- a/backend/src/utilisateurs/utilisateurs.controller.ts
+++ b/backend/src/utilisateurs/utilisateurs.controller.ts
@@ -42,6 +42,14 @@ export class UtilisateursController {
     return this.utilisateursService.findAll(pays, filterDto);
   }
 
+  @UseGuards(JwtAuthGuard, RoleGuard)
+  @Roles(RoleType.ADMIN)
+  @Get('appareils-partages')
+  @ApiOperation({ summary: 'Comptes partageant un même token FCM (appareils partagés)' })
+  async sharedDevices(@CurrentCountry() pays: string, @Query() filterDto: FilterUtilisateurDto) {
+    return this.utilisateursService.findSharedDevices(pays, filterDto);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Get('profil')
   @ApiOperation({ summary: 'Récupérer le profil utilisateur (JSON)' })

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -400,6 +400,77 @@ export class UtilisateursService {
     };
   }
 
+  /**
+   * Comptes partageant un même token FCM (= même appareil / installation).
+   * Ne renvoie que les tokens portés par plus d'un compte, groupés et paginés
+   * par groupe (le token est la clé). Chaque groupe embarque ses comptes — les
+   * groupes sont petits (2-8). Scopé par pays comme le reste de l'admin.
+   */
+  async findSharedDevices(pays: string, filterDto: FilterUtilisateurDto) {
+    const page = Number(filterDto.page ?? 1);
+    const limit = Number(filterDto.limit ?? 10);
+    const offset = (page - 1) * limit;
+    const search = filterDto.search?.trim();
+
+    const params: any[] = [pays];
+    let searchClause = '';
+    if (search) {
+      params.push(`%${search}%`);
+      // A group matches if ANY of its accounts matches the term.
+      searchClause = `AND EXISTS (
+        SELECT 1 FROM utilisateurs s
+        WHERE s.fcm_token = u.fcm_token AND s.pays = $1
+          AND (unaccent(s.email) ILIKE unaccent($2)
+            OR unaccent(coalesce(s.nom, '')) ILIKE unaccent($2)
+            OR unaccent(coalesce(s.prenom, '')) ILIKE unaccent($2)
+            OR unaccent(coalesce(s.pseudo, '')) ILIKE unaccent($2)))`;
+    }
+
+    const groupClause = `
+      FROM utilisateurs u
+      WHERE u.pays = $1 AND NULLIF(TRIM(u.fcm_token), '') IS NOT NULL ${searchClause}
+      GROUP BY u.fcm_token
+      HAVING COUNT(*) > 1`;
+
+    const [{ n: total }] = await this.utilisateursRepository.query(
+      `SELECT COUNT(*)::int n FROM (SELECT u.fcm_token ${groupClause}) g`,
+      params,
+    );
+
+    const groups = await this.utilisateursRepository.query(
+      `SELECT u.fcm_token AS fcm_token, COUNT(*)::int AS accounts_count
+       ${groupClause}
+       ORDER BY accounts_count DESC, u.fcm_token
+       LIMIT ${limit} OFFSET ${offset}`,
+      params,
+    );
+
+    const tokens = groups.map((g: any) => g.fcm_token);
+    const byToken: Record<string, any[]> = {};
+    if (tokens.length) {
+      const accounts = await this.utilisateursRepository.query(
+        `SELECT id, nom, prenom, email, pseudo, pays, role, uuid, fcm_token, date_creation
+         FROM utilisateurs
+         WHERE pays = $1 AND fcm_token = ANY($2)
+         ORDER BY date_creation ASC`,
+        [pays, tokens],
+      );
+      for (const a of accounts) {
+        const tok = a.fcm_token;
+        delete a.fcm_token; // redundant per-account — it's the group key
+        (byToken[tok] ??= []).push(a);
+      }
+    }
+
+    const data = groups.map((g: any) => ({
+      fcm_token: g.fcm_token,
+      accounts_count: g.accounts_count,
+      accounts: byToken[g.fcm_token] ?? [],
+    }));
+
+    return { data, total: Number(total), page, limit, totalPages: Math.ceil(Number(total) / limit) };
+  }
+
   async findOne(id: string) {
     this.logger.log(`Recherche de l'utilisateur avec ID: ${id}`);
     const user = await this.utilisateursRepository.findOne({

--- a/backend/src/utilisateurs/utilisateurs.service.ts
+++ b/backend/src/utilisateurs/utilisateurs.service.ts
@@ -449,7 +449,7 @@ export class UtilisateursService {
     const byToken: Record<string, any[]> = {};
     if (tokens.length) {
       const accounts = await this.utilisateursRepository.query(
-        `SELECT id, nom, prenom, email, pseudo, pays, role, uuid, fcm_token, date_creation
+        `SELECT id, nom, prenom, email, pseudo, pays, role, uuid, fcm_token, verifier, date_creation
          FROM utilisateurs
          WHERE pays = $1 AND fcm_token = ANY($2)
          ORDER BY date_creation ASC`,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import CompetencesAdmin from "./pages/CompetencesAdmin";
 import Notifications from "./pages/Notifications";
 import AppVersions from "./pages/AppVersions";
 import Parrainages from "./pages/Parrainages";
+import AppareilsPartages from "./pages/AppareilsPartages";
 import Indicateurs from "./pages/Indicateurs";
 import StatistiquesApprobations from "./pages/StatistiquesApprobations";
 import RetraitsWallet from "./pages/RetraitsWallet";
@@ -103,6 +104,7 @@ const App = () => (
                       <Route path="/admin/service-types" element={<ServiceTypesAdmin />} />
                       <Route path="/app-versions" element={<AppVersions />} />
                       <Route path="/parrainages" element={<Parrainages />} />
+                      <Route path="/appareils-partages" element={<AppareilsPartages />} />
                       <Route path="/admin/recruteurs" element={<RecruteursAdmin />} />
                       <Route path="/admin/competences" element={<CompetencesAdmin />} />
                       <Route path="/indicateurs" element={<Indicateurs />} />

--- a/frontend/src/components/AppSidebar.tsx
+++ b/frontend/src/components/AppSidebar.tsx
@@ -170,6 +170,7 @@ const navTree: NavItem[] = [
       { title: "Utilisateurs", icon: User, url: "/users" },
       { title: "Indicateurs", icon: BarChart3, url: "/indicateurs" },
       { title: "Parrainage", icon: UserPlus, url: "/parrainages" },
+      { title: "Appareils partagés", icon: Smartphone, url: "/appareils-partages" },
       {
         // geo-profile: Géographie subgroup, nested under Utilisateurs
         title: "Géographie",

--- a/frontend/src/lib/services/users.service.ts
+++ b/frontend/src/lib/services/users.service.ts
@@ -3,10 +3,23 @@ import type { Utilisateur } from '../types';
 import type { PaginationResponse, PaginationParams } from '../types/pagination';
 import { buildPaginationQuery } from '../types/pagination';
 
+// A group of accounts sharing one FCM token (i.e. registered from the same
+// device / app install). Only tokens held by 2+ accounts are returned.
+export interface SharedDeviceGroup {
+  fcm_token: string;
+  accounts_count: number;
+  accounts: Utilisateur[];
+}
+
 export const usersService = {
   async getAll(params?: PaginationParams & { search?: string; role?: string; activated?: boolean; sort_by?: string; sort_order?: 'ASC' | 'DESC'; parrain_id?: string }): Promise<PaginationResponse<Utilisateur>> {
     const query = buildPaginationQuery(params);
     return api.get<PaginationResponse<Utilisateur>>(`/utilisateurs${query}`);
+  },
+
+  async getSharedDevices(params?: PaginationParams & { search?: string }): Promise<PaginationResponse<SharedDeviceGroup>> {
+    const query = buildPaginationQuery(params);
+    return api.get<PaginationResponse<SharedDeviceGroup>>(`/utilisateurs/appareils-partages${query}`);
   },
 
 

--- a/frontend/src/pages/AppareilsPartages.tsx
+++ b/frontend/src/pages/AppareilsPartages.tsx
@@ -133,6 +133,7 @@ function DeviceCard({ group }: { group: SharedDeviceGroup }) {
                                 <TableHead>Nom</TableHead>
                                 <TableHead>Email</TableHead>
                                 <TableHead>Rôle</TableHead>
+                                <TableHead>Vérifié</TableHead>
                                 <TableHead>Pays</TableHead>
                                 <TableHead>Créé le</TableHead>
                             </TableRow>
@@ -143,6 +144,11 @@ function DeviceCard({ group }: { group: SharedDeviceGroup }) {
                                     <TableCell className="font-medium">{[a.prenom, a.nom].filter(Boolean).join(" ") || "—"}</TableCell>
                                     <TableCell className="text-muted-foreground">{a.email}</TableCell>
                                     <TableCell><Badge variant="outline" className="capitalize">{a.role}</Badge></TableCell>
+                                    <TableCell>
+                                        {(a as any).verifier
+                                            ? <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">Vérifié</Badge>
+                                            : <Badge variant="secondary">Non vérifié</Badge>}
+                                    </TableCell>
                                     <TableCell className="capitalize">{a.pays}</TableCell>
                                     <TableCell className="text-muted-foreground">{fmtDate((a as any).date_creation)}</TableCell>
                                 </TableRow>

--- a/frontend/src/pages/AppareilsPartages.tsx
+++ b/frontend/src/pages/AppareilsPartages.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useDebounce } from "@/hooks/use-debounce";
+import { Card } from "@/components/ui/card";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Search, Loader2, ChevronLeft, ChevronRight, ChevronDown, Smartphone, Users } from "lucide-react";
+import { usersService, SharedDeviceGroup } from "@/lib/services/users.service";
+import { cn } from "@/lib/utils";
+
+const fmtDate = (v?: string | null) =>
+    v ? new Date(v).toLocaleString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" }) : "-";
+
+export default function AppareilsPartages() {
+    const [searchQuery, setSearchQuery] = useState("");
+    const debouncedSearch = useDebounce(searchQuery, 500);
+    const [page, setPage] = useState(1);
+    const limit = 10;
+
+    const { data, isLoading, error } = useQuery({
+        queryKey: ["appareils-partages", debouncedSearch, page, limit],
+        queryFn: () => usersService.getSharedDevices({ search: debouncedSearch || undefined, page, limit }),
+    });
+
+    const groups = data?.data || [];
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-3xl font-bold text-foreground">Appareils partagés</h1>
+                    <p className="text-muted-foreground">
+                        Comptes enregistrés depuis un même appareil (token FCM partagé par 2 comptes ou plus)
+                    </p>
+                </div>
+            </div>
+
+            <div className="flex flex-col gap-4">
+                <div className="relative">
+                    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                        placeholder="Rechercher un compte du groupe (nom, email, pseudo)..."
+                        value={searchQuery}
+                        onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
+                        className="pl-10"
+                    />
+                </div>
+
+                {isLoading ? (
+                    <div className="flex items-center justify-center py-8">
+                        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                    </div>
+                ) : error ? (
+                    <div className="text-center py-8 text-destructive">Erreur lors du chargement des données</div>
+                ) : groups.length === 0 ? (
+                    <div className="text-center py-8 text-muted-foreground border rounded-lg bg-muted/10">
+                        Aucun appareil partagé trouvé.
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {groups.map((g) => (
+                            <DeviceCard key={g.fcm_token} group={g} />
+                        ))}
+
+                        {data?.totalPages !== undefined && data.totalPages > 1 && (
+                            <div className="flex items-center justify-center space-x-2 py-4">
+                                <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+                                    <ChevronLeft className="h-4 w-4" />
+                                </Button>
+                                <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                                    Page {page} sur {data.totalPages}
+                                </div>
+                                <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))} disabled={page === data.totalPages}>
+                                    <ChevronRight className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function DeviceCard({ group }: { group: SharedDeviceGroup }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const tokenShort = `${group.fcm_token.slice(0, 16)}…${group.fcm_token.slice(-6)}`;
+
+    return (
+        <Card>
+            <div className="flex items-center justify-between p-6">
+                <div className="flex items-center gap-4 flex-1">
+                    <div className="p-2 bg-primary/10 rounded-full">
+                        <Smartphone className="h-6 w-6 text-primary" />
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1 items-start">
+                        <div className="flex flex-col gap-2">
+                            <span className="text-sm text-muted-foreground font-medium">Token FCM (appareil)</span>
+                            <code className="font-mono text-sm bg-muted px-2 py-0.5 rounded w-fit" title={group.fcm_token}>
+                                {tokenShort}
+                            </code>
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            <span className="text-sm text-muted-foreground font-medium">Comptes</span>
+                            <div className="font-bold text-base flex items-center gap-2">
+                                <Users className="h-4 w-4 text-muted-foreground" />
+                                {group.accounts_count}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <Button variant="ghost" className="gap-2" onClick={() => setIsOpen(!isOpen)}>
+                    {isOpen ? "Masquer" : "Voir comptes"}
+                    <ChevronDown className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")} />
+                </Button>
+            </div>
+
+            {isOpen && (
+                <div className="border-t bg-muted/5 px-6 py-4 animate-in slide-in-from-top-2 duration-200">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Nom</TableHead>
+                                <TableHead>Email</TableHead>
+                                <TableHead>Rôle</TableHead>
+                                <TableHead>Pays</TableHead>
+                                <TableHead>Créé le</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {group.accounts.map((a) => (
+                                <TableRow key={a.id}>
+                                    <TableCell className="font-medium">{[a.prenom, a.nom].filter(Boolean).join(" ") || "—"}</TableCell>
+                                    <TableCell className="text-muted-foreground">{a.email}</TableCell>
+                                    <TableCell><Badge variant="outline" className="capitalize">{a.role}</Badge></TableCell>
+                                    <TableCell className="capitalize">{a.pays}</TableCell>
+                                    <TableCell className="text-muted-foreground">{fmtDate((a as any).date_creation)}</TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+            )}
+        </Card>
+    );
+}


### PR DESCRIPTION
Adds an admin page that lists accounts sharing one **FCM token** — i.e. registered from the **same device / app install** — grouped by token, mirroring the **Parrainages** page. Only tokens held by **2+ accounts** are shown (the useful multi-account / same-device view).

## Backend
- `GET /utilisateurs/appareils-partages` (admin, `RoleGuard`, country-scoped via `@CurrentCountry`).
- Returns tokens with `COUNT(*) > 1`, **paginated by group**, ordered by `accounts_count DESC`. Each group embeds its `accounts` (groups are small, 2–8), so the UI needs no second call.
- Optional `search` matches **any** member of a group (email / nom / prénom / pseudo).
- Per-account rows **omit** the raw token (it's the group key).

## Frontend
- New `AppareilsPartages` page + `/appareils-partages` route + sidebar entry under **Utilisateurs**.
- Expandable cards: token (truncated) + account count → table of accounts (nom, email, rôle, pays, créé le).

## Verified on dev (8/8)
Endpoint 200; `total` = 251 (matches DB benin-scoped); every group has 2+ accounts; embedded `accounts.length === accounts_count` (8/8, 5/5, …); ordered desc; no token leaked per-account; search-by-member returns the right group.

## Note — the Senegal/Congo geo part of the request
Investigated and **verified already working** (no code change): geo data exists on dev **and prod** (Senegal 14 dept/46 villes, Congo 15/91); the profile-update validates against the *user's* `pays` — Senegal & Congo updates succeed and persist, cross-country departments are rejected; Congo users already have departments set on prod. The admin dashboard has no geo-edit form (that path is mobile-only), and its API is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)