### PR TITLE
fix(concours): scope GET /concours + /concours/annees by country

### DIFF
--- a/backend/src/concours/concours.controller.ts
+++ b/backend/src/concours/concours.controller.ts
@@ -39,8 +39,8 @@ export class ConcoursController {
   @ApiQuery({ name: 'search', required: false, type: String, description: 'Recherche textuelle (Titre ou Lieu)' })
   @ApiQuery({ name: 'annee', required: false, type: Number, description: 'Filtrer par année' })
   @ApiQuery({ name: 'sort_by', required: false, type: String, description: 'Trier par (annee, titre) [Default: titre]' })
-  findAll(@Query() filterDto: FilterConcoursDto) {
-    return this.concoursService.findAll(filterDto);
+  findAll(@CurrentCountry() pays: string, @Query() filterDto: FilterConcoursDto) {
+    return this.concoursService.findAll(pays, filterDto);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -59,8 +59,8 @@ export class ConcoursController {
 
   @UseGuards(JwtAuthGuard)
   @Get('annees')
-  getAnnees() {
-    return this.concoursService.getAnnees();
+  getAnnees(@CurrentCountry() pays: string) {
+    return this.concoursService.getAnnees(pays);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/concours/concours.service.ts
+++ b/backend/src/concours/concours.service.ts
@@ -69,13 +69,14 @@ export class ConcoursService {
     return saved;
   }
 
-  async findAll(filterDto: FilterConcoursDto): Promise<PaginationResponse<Concours>> {
+  async findAll(pays: string, filterDto: FilterConcoursDto): Promise<PaginationResponse<Concours>> {
     const { page = 1, limit = 10, search, annee, sort_by = 'titre', sort_order = 'ASC' } = filterDto;
-    this.logger.log(`Récupération des concours - filtres: ${JSON.stringify(filterDto)}`);
+    this.logger.log(`Récupération des concours (pays=${pays}) - filtres: ${JSON.stringify(filterDto)}`);
 
     const queryBuilder = this.concoursRepository.createQueryBuilder('concours')
       .leftJoinAndSelect('concours.structure', 'structure')
-      .leftJoinAndSelect('concours.titre_ref', 'titre_ref');
+      .leftJoinAndSelect('concours.titre_ref', 'titre_ref')
+      .where('concours.pays = :pays', { pays });
 
     if (search) {
       queryBuilder.andWhere(
@@ -113,12 +114,13 @@ export class ConcoursService {
     };
   }
 
-  async getAnnees(): Promise<number[]> {
-    this.logger.log('Récupération des années disponibles');
+  async getAnnees(pays: string): Promise<number[]> {
+    this.logger.log(`Récupération des années disponibles (pays=${pays})`);
     const result = await this.concoursRepository
       .createQueryBuilder('concours')
       .select('DISTINCT concours.annee', 'annee')
-      .where('concours.annee IS NOT NULL')
+      .where('concours.pays = :pays', { pays })
+      .andWhere('concours.annee IS NOT NULL')
       .orderBy('concours.annee', 'DESC')
       .getRawMany();
 


### PR DESCRIPTION
## Problem
`GET /concours` (flat list) and `GET /concours/annees` (year filter) **ignored the country scope** — they never filtered by `pays`, so they returned concours from every country regardless of `?country=`. The grouped endpoint (`GET /v1/concours`) was already correctly scoped, which is why only the flat list looked broken.

## Fix
Mirror the epreuves pattern: inject `@CurrentCountry() pays` in both controller methods and add `WHERE concours.pays = :pays` in `findAll` and `getAnnees`.

## Verified on dev
- `GET /concours?country=benin` total = 71 (matches DB benin count); every returned row is `pays=benin`.
- `GET /concours/annees?country=benin` = 19 (matches DB distinct benin years).
- Cross-country exclusion: flipping one concours to `senegal` moved it out of benin (71→70) into senegal (0→1); reverted cleanly.

Backend-only, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)