### PR TITLE
feat(etablissements): always show full academic hierarchy for Sénégal

### DIFF
--- a/backend/src/etablissements/etablissements.service.ts
+++ b/backend/src/etablissements/etablissements.service.ts
@@ -18,6 +18,13 @@ import { FilterEpreuveDto } from '../epreuves/dto/filter-epreuve.dto';
 import { FiliereResponseDto } from '../filieres/dto/filiere-response.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
 
+// Countries whose academic hierarchy is always returned in full, regardless of
+// the `all` query flag. The default lists hide établissements / filières /
+// niveaux that have no épreuve yet; for a new market like Sénégal (no épreuves
+// on the platform yet) that would leave the whole catalogue empty, so we always
+// surface everything for these countries.
+const SHOW_ALL_RESOURCES_COUNTRIES = new Set(['senegal']);
+
 @Injectable()
 export class EtablissementsService {
   private readonly logger = new Logger(EtablissementsService.name);
@@ -55,7 +62,8 @@ export class EtablissementsService {
     // through the chain épreuve→matière→niveau→filière→établissement, so the
     // mobile list never surfaces empty établissements. all=true lifts the
     // filter (admin management / parent pickers need every établissement).
-    if (!all) {
+    const showAll = all || SHOW_ALL_RESOURCES_COUNTRIES.has(pays);
+    if (!showAll) {
       queryBuilder.andWhere(
         `EXISTS (
           SELECT 1 FROM epreuves ep
@@ -177,7 +185,8 @@ export class EtablissementsService {
 
     // Default: only filières with at least one épreuve reachable through
     // filière→niveau→matière→épreuve. all=true lifts the filter.
-    if (!all) {
+    const showAll = all || SHOW_ALL_RESOURCES_COUNTRIES.has(pays);
+    if (!showAll) {
       queryBuilder.andWhere(
         `EXISTS (
           SELECT 1 FROM epreuves ep
@@ -237,7 +246,8 @@ export class EtablissementsService {
 
     // Default: only niveaux with at least one épreuve reachable through
     // niveau→matière→épreuve. all=true lifts the filter.
-    if (!all) {
+    const showAll = all || SHOW_ALL_RESOURCES_COUNTRIES.has(pays);
+    if (!showAll) {
       queryBuilder.andWhere(
         `EXISTS (
           SELECT 1 FROM epreuves ep


### PR DESCRIPTION
## Why
Sénégal is a new market with **no épreuves** on the platform yet. The académic list endpoints default to hiding établissements / filières / niveaux that have no épreuve (so the mobile app never shows empty branches). For Sénégal that hid **everything** — the whole catalogue came back empty even though the data exists.

## What
Added `SHOW_ALL_RESOURCES_COUNTRIES = new Set(['senegal'])`. For those countries the "only-with-épreuve" filter is **always bypassed**, regardless of `?all=`. Effectively `showAll = all || SHOW_ALL_RESOURCES_COUNTRIES.has(pays)`.

Applies to the 3 filtered list methods:
- `GET /etablissements`
- `GET /etablissements/:id/filieres`
- `GET /etablissements/:id/filieres/:filiereId/niveau-etude`

`matières` and `épreuves` lists were **never** filtered by épreuve-existence, so they already return everything — no change needed there (listed in the request for completeness).

**Other countries unchanged**: Bénin still filters by default and `all=true` still lifts it.

No migration.

## Verified on dev
Seeded a Sénégal établissement→filière→niveau→matière with **no épreuves**, then:
- `GET /etablissements?country=senegal` (no `all`) → returns it ✅
- `/filieres`, `/niveau-etude`, `/matieres` (no `all`) → all return the épreuve-less entities ✅
- **Bénin control**: default total 16 < `all=true` total 24 → filter still active ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)