### PR TITLE
feat(commentaires,forums): tidy user/parcours sub-objects in responses

### DIFF
--- a/backend/src/commentaires/commentaires.service.ts
+++ b/backend/src/commentaires/commentaires.service.ts
@@ -66,6 +66,31 @@ export class CommentairesService {
  * @param query - Paramètres de requête
  * @returns Liste paginée des commentaires avec métadonnées
  */
+  // Reshape a commentaire for API responses: drop the redundant FK columns
+  // (parcours_id / utilisateur_id — already carried by the sub-objects), add
+  // `uuid` to the parcours + utilisateur sub-objects, and expose the user's
+  // public profile photo URL as `profil` (replacing the legacy `photo`).
+  private mapCommentaire(commentaire: any) {
+    if (!commentaire) return commentaire;
+    const { parcours_id, utilisateur_id, utilisateur, parcours, ...rest } = commentaire;
+    return {
+      ...rest,
+      utilisateur: utilisateur ? {
+        id: utilisateur.id,
+        uuid: utilisateur.uuid,
+        nom: utilisateur.nom,
+        prenom: utilisateur.prenom,
+        email: utilisateur.email,
+        profil: utilisateur.profil_photo_path || null,
+      } : null,
+      parcours: parcours ? {
+        id: parcours.id,
+        uuid: parcours.uuid,
+        titre: parcours.titre,
+      } : null,
+    };
+  }
+
   async findAll(query: CommentaireQueryDto): Promise<{
     data: any[];
     meta: {
@@ -98,11 +123,13 @@ export class CommentairesService {
       .select([
         'commentaire',
         'utilisateur.id',
+        'utilisateur.uuid',
         'utilisateur.nom',
         'utilisateur.prenom',
-        'utilisateur.photo',
+        'utilisateur.profil_photo_path',
         'utilisateur.email',
         'parcours.id',
+        'parcours.uuid',
         'parcours.titre',
         'likes.id',
         'likes.type', // Important pour filtrer côté client si besoin
@@ -147,7 +174,7 @@ export class CommentairesService {
     const [data, total] = await qb.getManyAndCount();
 
     return {
-      data,
+      data: data.map((c) => this.mapCommentaire(c)),
       meta: {
         page,
         limit,
@@ -167,7 +194,7 @@ export class CommentairesService {
   async findOne(id: number): Promise<Commentaire> {
     const commentaire = await this.commentaireRepository.findOne({
       where: { id },
-      relations: ['parcours', 'likes', 'parent', 'enfants'],
+      relations: ['utilisateur', 'parcours', 'likes', 'parent', 'enfants'],
     });
 
     if (!commentaire) {
@@ -183,11 +210,11 @@ export class CommentairesService {
       where: { parent_id: commentaire.id },
     });
 
-    return {
+    return this.mapCommentaire({
       ...commentaire,
       likesCount: commentaire.likes?.filter(like => like.type == "like").length || 0,
       enfantsCount: commentaire.enfantsCount || 0,
-    };
+    });
 
     // return {
     //   ...commentaire,

--- a/backend/src/forum/forum.service.ts
+++ b/backend/src/forum/forum.service.ts
@@ -133,11 +133,13 @@ export class ForumService {
             const { user_id, user, ...forumWithoutUserId } = forum;
             const safeUser = user ? {
                 id: user.id,
+                uuid: user.uuid,
                 nom: user.nom,
                 prenom: user.prenom,
                 pseudo: user.pseudo,
                 email: user.email,
                 sexe: user.sexe,
+                profil: user.profil_photo_path || null,
             } : null;
 
             return {
@@ -188,11 +190,13 @@ export class ForumService {
         const { user_id, user, ...forumWithoutUserId } = forum;
         const safeUser = user ? {
             id: user.id,
+            uuid: user.uuid,
             nom: user.nom,
             prenom: user.prenom,
             pseudo: user.pseudo,
             email: user.email,
             sexe: user.sexe,
+            profil: user.profil_photo_path || null,
         } : null;
 
         return {


### PR DESCRIPTION
## GET /commentaires
- **Remove** redundant top-level `parcours_id` and `utilisateur_id` (already carried by the `parcours` / `utilisateur` sub-objects).
- **Add `uuid`** to the `parcours` and `utilisateur` sub-objects.
- **`utilisateur`**: replace `photo` (legacy Firebase URL) with **`profil`** (public R2 profile-photo URL, `null` when unset).
- Applied to `findAll` **and** `findOne` via a shared `mapCommentaire` helper. `findOne` now loads the `utilisateur` relation but is shaped to safe fields only (no password leak).

## GET /forums
- Add **`uuid`** and **`profil`** to the `user` sub-object (`findAll` + `findOne`).

No migration.

## Verified on dev
- `/commentaires`: top-level keys no longer include `parcours_id`/`utilisateur_id`; `utilisateur = {id, uuid, nom, prenom, email, profil}` (no `photo`); `parcours = {id, uuid, titre}`.
- `/forums`: `user = {id, uuid, nom, prenom, pseudo, email, sexe, profil}` with a real R2 URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)