### PR TITLE
feat(parcours): add profil to nested comments in GET /parcours

### DIFF
--- a/backend/src/parcours/parcours.service.ts
+++ b/backend/src/parcours/parcours.service.ts
@@ -21,6 +21,16 @@ export class ParcoursService {
   private get likeRepository(): Repository<Like> { return this.resolver.getRepository(Like); }
   private get favoriRepository(): Repository<Favori> { return this.resolver.getRepository(Favori); }
 
+  // Expose each nested comment's author profile photo URL as `profil` (public
+  // R2 path), and drop the full utilisateur relation so no sensitive user
+  // fields (e.g. password) leak into the parcours payload.
+  private withCommentProfils(parcours: any): any[] {
+    return (parcours.commentaires || []).map((cm: any) => {
+      const { utilisateur, ...rest } = cm;
+      return { ...rest, profil: utilisateur?.profil_photo_path || null };
+    });
+  }
+
   /**
    * Crée un nouveau parcours
    * @param createParcoursDto - Données pour créer le parcours
@@ -91,12 +101,13 @@ export class ParcoursService {
       order: { [filters.sortBy]: filters.order },
       skip,
       take: limit,
-      relations: ['commentaires', 'likes', 'favoris', 'category'],
+      relations: ['commentaires', 'commentaires.utilisateur', 'likes', 'favoris', 'category'],
     });
 
     // Ajout des compteurs
     const parcoursWithCounts = data.map(parcours => ({
       ...parcours,
+      commentaires: this.withCommentProfils(parcours),
       commentairesCount: parcours.commentaires?.length || 0,
       likesCount: parcours.likes?.filter(like => like.type == "like").length || 0,
       favorisCount: parcours.favoris?.length || 0,
@@ -122,7 +133,7 @@ export class ParcoursService {
   async findOne(id: number): Promise<Parcour> {
     const parcours = await this.parcoursRepository.findOne({
       where: { id },
-      relations: ['commentaires', 'likes', 'favoris', 'category'],
+      relations: ['commentaires', 'commentaires.utilisateur', 'likes', 'favoris', 'category'],
     });
 
     if (!parcours) {
@@ -132,6 +143,7 @@ export class ParcoursService {
     // Ajout des compteurs
     return {
       ...parcours,
+      commentaires: this.withCommentProfils(parcours),
       commentairesCount: parcours.commentaires?.length || 0,
       likesCount: parcours.likes?.filter(like => like.type == "like").length || 0,
       favorisCount: parcours.favoris?.length || 0,


### PR DESCRIPTION
## What
Each object in the `commentaires` list nested in `GET /parcours` now includes a **`profil`** field — the comment author's public R2 profile-photo URL (`null` when the author has no photo).

## How
- Load `commentaires.utilisateur` in `findAll` + `findOne`.
- A `withCommentProfils` helper maps each comment to add `profil = utilisateur.profil_photo_path` and **drops the full `utilisateur` relation** so no sensitive fields (password, etc.) leak into the payload.

No migration.

## Verified on dev
Comment keys: `id, pays, parcours_id, utilisateur_id, contenu, date_commentaire, parent_id, profil`. A comment whose author has a photo resolves e.g. `https://assets-dev.edukia.net/utilisateurs/25d0fd1f-…/profil.jpg`; others get `null`. No `utilisateur`/`mot_de_passe` in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)