### PR TITLE
feat(api): ensure every user sub-object carries id, uuid, profil

### DIFF
--- a/backend/src/avis/avis.service.ts
+++ b/backend/src/avis/avis.service.ts
@@ -83,10 +83,11 @@ export class AvisService {
                 ...restAvis,
                 utilisateur: utilisateur ? {
                     id: utilisateur.id,
-                    ui: utilisateur.uuid,
+                    uuid: utilisateur.uuid,
                     nom: utilisateur.nom,
                     prenom: utilisateur.prenom,
                     email: utilisateur.email,
+                    profil: utilisateur.profil_photo_path || null,
                 } : null,
             };
         });

--- a/backend/src/comments-polymorphic/comments-polymorphic.service.ts
+++ b/backend/src/comments-polymorphic/comments-polymorphic.service.ts
@@ -11,7 +11,7 @@ import { Avis } from '../avis/entities/avis.entity';
 import { DataSourceResolver } from '../config/data-source-resolver.service';
 
 const VALID_MODELS = ['Forums', 'Parcours', 'Commentaires', 'Avis'];
-const USER_FIELDS = ['id', 'nom', 'prenom', 'pseudo', 'email', 'sexe'] as const;
+const USER_FIELDS = ['id', 'uuid', 'nom', 'prenom', 'pseudo', 'email', 'sexe'] as const;
 
 const userSelect = USER_FIELDS.reduce((acc, f) => ({ ...acc, [f]: true }), {} as Record<string, true>);
 
@@ -210,7 +210,8 @@ export class CommentsPolymorphicService {
 
     private narrowUser(user: any) {
         if (!user) return null;
-        return USER_FIELDS.reduce((acc, f) => ({ ...acc, [f]: user[f] }), {} as Record<string, any>);
+        const base = USER_FIELDS.reduce((acc, f) => ({ ...acc, [f]: user[f] }), {} as Record<string, any>);
+        return { ...base, profil: user.profil_photo_path || null };
     }
 
     private mapResponse(

--- a/backend/src/offres/offres.service.ts
+++ b/backend/src/offres/offres.service.ts
@@ -110,7 +110,8 @@ export class OffresService {
             uuid: user.uuid,
             nom: user.nom,
             prenom: user.prenom,
-            email: user.email
+            email: user.email,
+            profil: user.profil_photo_path || null
         };
     }
 

--- a/backend/src/parcours/parcours.service.ts
+++ b/backend/src/parcours/parcours.service.ts
@@ -21,13 +21,21 @@ export class ParcoursService {
   private get likeRepository(): Repository<Like> { return this.resolver.getRepository(Like); }
   private get favoriRepository(): Repository<Favori> { return this.resolver.getRepository(Favori); }
 
-  // Expose each nested comment's author profile photo URL as `profil` (public
-  // R2 path), and drop the full utilisateur relation so no sensitive user
-  // fields (e.g. password) leak into the parcours payload.
+  // Expose each nested comment's author as a minimal `utilisateur` sub-object
+  // ({ id, uuid, profil }) and keep the flat `profil` (public R2 path) for
+  // backward-compat. The full utilisateur relation is dropped so no sensitive
+  // user fields (e.g. password) leak into the parcours payload.
   private withCommentProfils(parcours: any): any[] {
     return (parcours.commentaires || []).map((cm: any) => {
       const { utilisateur, ...rest } = cm;
-      return { ...rest, profil: utilisateur?.profil_photo_path || null };
+      const profil = utilisateur?.profil_photo_path || null;
+      return {
+        ...rest,
+        profil,
+        utilisateur: utilisateur
+          ? { id: utilisateur.id, uuid: utilisateur.uuid, profil }
+          : null,
+      };
     });
   }
 

--- a/backend/src/prestataires/prestataires.service.ts
+++ b/backend/src/prestataires/prestataires.service.ts
@@ -27,7 +27,8 @@ export class PrestatairesService {
             uuid: user.uuid,
             nom: user.nom,
             prenom: user.prenom,
-            email: user.email
+            email: user.email,
+            profil: user.profil_photo_path || null
         };
     }
 

--- a/backend/src/recruteurs/recruteurs.service.ts
+++ b/backend/src/recruteurs/recruteurs.service.ts
@@ -32,6 +32,7 @@ export class RecruteursService {
                 nom: utilisateur.nom,
                 prenom: utilisateur.prenom,
                 email: utilisateur.email,
+                profil: utilisateur.profil_photo_path || null,
             } : null,
         };
     }

--- a/backend/src/services/services.service.ts
+++ b/backend/src/services/services.service.ts
@@ -136,6 +136,7 @@ export class ServicesService {
                     nom: utilisateur.nom,
                     prenom: utilisateur.prenom,
                     email: utilisateur.email,
+                    profil: utilisateur.profil_photo_path || null,
                 },
             };
         }
@@ -149,6 +150,7 @@ export class ServicesService {
                 nom: utilisateur.nom,
                 prenom: utilisateur.prenom,
                 email: utilisateur.email,
+                profil: utilisateur.profil_photo_path || null,
             } : null,
             prestataire,
             avis,

--- a/backend/src/wallet/infrastructure/typeorm-payment.repositories.ts
+++ b/backend/src/wallet/infrastructure/typeorm-payment.repositories.ts
@@ -543,6 +543,8 @@ export class UtilisateursUserProfileAdapter implements UserProfilePort {
     const verification = await this.utilisateursService.isEmailVerified(userId);
     return {
       id: user.id,
+      uuid: user.uuid ?? null,
+      profil: user.profil_photo_path || null,
       email: user.email,
       telephone: user.telephone,
       isEmailVerified: verification.isVerified,

--- a/backend/src/wallet/shared/payment.ports.ts
+++ b/backend/src/wallet/shared/payment.ports.ts
@@ -243,6 +243,8 @@ export interface PaymentConfigurationRepositoryPort {
 
 export interface PaymentUserProfile {
   id: number;
+  uuid?: string | null;
+  profil?: string | null;
   email: string;
   telephone?: string | null;
   isEmailVerified: boolean;


### PR DESCRIPTION
## What

Standardizes every embedded **user reference** in API responses so each sub-object carries at least `id`, `uuid`, and `profil` (the public R2 profile-photo URL, `null` when unset). Extends the convention started in #186/#187 to the rest of the codebase.

## Audit

Swept all domains for endpoints embedding a user/author sub-object. **No password/raw-entity leaks** were found — every site hand-picks fields. Already-compliant: `commentaires`, `forum`. No user object: `opportunites`, `evenements`, `notifications`, `favoris`, `likes`.

## Changes (10 sites / 9 files)

| File | Fix |
|---|---|
| `comments-polymorphic.service.ts` | add `uuid` + `profil` to user projection (root + nested children) |
| `parcours.service.ts` | expose nested comment author as `utilisateur {id, uuid, profil}` (flat `profil` kept for compat) |
| `avis.service.ts` | fix key typo **`ui` → `uuid`**, add `profil` |
| `services.service.ts` | add `profil` to `utilisateur` **and** `prestataire.utilisateur` |
| `offres.service.ts` | add `profil` (`formatUtilisateur`, covers `recruteur.utilisateur`) |
| `prestataires.service.ts` | add `profil` (`formatUtilisateur`) |
| `recruteurs.service.ts` | add `profil` (`formatRecruteur`) |
| `wallet/…/typeorm-payment.repositories.ts` + `payment.ports.ts` | `getPaymentProfile`: add `uuid` + `profil` (+ widen `PaymentUserProfile`) |

## Backward-compat

Purely **additive** except the `avis` `ui`→`uuid` typo fix (nothing legitimately reads a key named `ui`). No query changes — all sites already load the full `utilisateur` relation, so no new DB cost. Flutter `fromJson` ignores unknown keys.

## Verification

- `npx tsc --noEmit` clean.
- Live-tested against dev DB: `POST /commentaires/Forums/:id`, `GET /avis/Services/3`, `GET /services` all now return `id` + `uuid` + `profil` (incl. nested `prestataire.utilisateur`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)