### PR TITLE
ci(wallet): wire Infobip/OTP env vars through deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,25 @@ jobs:
             R2_PUBLIC_BUCKET=${{ secrets.R2_PUBLIC_BUCKET }}
             R2_PUBLIC_BUCKET_URL=${{ secrets.R2_PUBLIC_BUCKET_URL }}
             PAYMENT_INTERNAL_API_KEY=${{ secrets.PAYMENT_INTERNAL_API_KEY }}
+            OTP_SMS_PROVIDER=${{ secrets.OTP_SMS_PROVIDER }}
+            OTP_DEBUG_ENABLED=${{ secrets.OTP_DEBUG_ENABLED }}
+            OTP_TTL_MINUTES=${{ secrets.OTP_TTL_MINUTES }}
+            OTP_LENGTH=${{ secrets.OTP_LENGTH }}
+            OTP_MAX_ATTEMPTS=${{ secrets.OTP_MAX_ATTEMPTS }}
+            OTP_HASH_SECRET=${{ secrets.OTP_HASH_SECRET }}
+            OTP_RESEND_COOLDOWN_SECONDS=${{ secrets.OTP_RESEND_COOLDOWN_SECONDS }}
+            OTP_MAX_RESENDS=${{ secrets.OTP_MAX_RESENDS }}
+            OTP_ANDROID_SMS_HASH=${{ secrets.OTP_ANDROID_SMS_HASH }}
+            INFOBIP_BASE_URL=${{ secrets.INFOBIP_BASE_URL }}
+            INFOBIP_API_KEY=${{ secrets.INFOBIP_API_KEY }}
+            INFOBIP_FROM=${{ secrets.INFOBIP_FROM }}
+            INFOBIP_SMS_ENDPOINT=${{ secrets.INFOBIP_SMS_ENDPOINT }}
+            INFOBIP_TIMEOUT_MS=${{ secrets.INFOBIP_TIMEOUT_MS }}
+            INFOBIP_REPORTS_ENDPOINT=${{ secrets.INFOBIP_REPORTS_ENDPOINT }}
+            INFOBIP_REMOVE_PLUS_FROM_TO=${{ secrets.INFOBIP_REMOVE_PLUS_FROM_TO }}
+            INFOBIP_WEBHOOK_SECRET=${{ secrets.INFOBIP_WEBHOOK_SECRET }}
+            INFOBIP_DELIVERY_REPORT_NOTIFY_URL=${{ secrets.INFOBIP_DELIVERY_REPORT_NOTIFY_URL }}
+            INFOBIP_NOTIFY_CONTENT_TYPE=${{ secrets.INFOBIP_NOTIFY_CONTENT_TYPE }}
             ENV_EOF
 
             # Créer le fichier docker-compose.yml depuis le contenu du repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,25 +109,29 @@ jobs:
             R2_PUBLIC_BUCKET=${{ secrets.R2_PUBLIC_BUCKET }}
             R2_PUBLIC_BUCKET_URL=${{ secrets.R2_PUBLIC_BUCKET_URL }}
             PAYMENT_INTERNAL_API_KEY=${{ secrets.PAYMENT_INTERNAL_API_KEY }}
-            OTP_SMS_PROVIDER=${{ secrets.OTP_SMS_PROVIDER }}
-            OTP_DEBUG_ENABLED=${{ secrets.OTP_DEBUG_ENABLED }}
-            OTP_TTL_MINUTES=${{ secrets.OTP_TTL_MINUTES }}
-            OTP_LENGTH=${{ secrets.OTP_LENGTH }}
-            OTP_MAX_ATTEMPTS=${{ secrets.OTP_MAX_ATTEMPTS }}
+            # Wallet OTP — sensitive (set in the PRD GitHub environment secrets)
             OTP_HASH_SECRET=${{ secrets.OTP_HASH_SECRET }}
-            OTP_RESEND_COOLDOWN_SECONDS=${{ secrets.OTP_RESEND_COOLDOWN_SECONDS }}
-            OTP_MAX_RESENDS=${{ secrets.OTP_MAX_RESENDS }}
-            OTP_ANDROID_SMS_HASH=${{ secrets.OTP_ANDROID_SMS_HASH }}
             INFOBIP_BASE_URL=${{ secrets.INFOBIP_BASE_URL }}
             INFOBIP_API_KEY=${{ secrets.INFOBIP_API_KEY }}
             INFOBIP_FROM=${{ secrets.INFOBIP_FROM }}
-            INFOBIP_SMS_ENDPOINT=${{ secrets.INFOBIP_SMS_ENDPOINT }}
-            INFOBIP_TIMEOUT_MS=${{ secrets.INFOBIP_TIMEOUT_MS }}
-            INFOBIP_REPORTS_ENDPOINT=${{ secrets.INFOBIP_REPORTS_ENDPOINT }}
-            INFOBIP_REMOVE_PLUS_FROM_TO=${{ secrets.INFOBIP_REMOVE_PLUS_FROM_TO }}
             INFOBIP_WEBHOOK_SECRET=${{ secrets.INFOBIP_WEBHOOK_SECRET }}
-            INFOBIP_DELIVERY_REPORT_NOTIFY_URL=${{ secrets.INFOBIP_DELIVERY_REPORT_NOTIFY_URL }}
-            INFOBIP_NOTIFY_CONTENT_TYPE=${{ secrets.INFOBIP_NOTIFY_CONTENT_TYPE }}
+            # Wallet OTP — non-sensitive config, set literally here (not secrets).
+            # OTP_SMS_PROVIDER=infobip + OTP_DEBUG_ENABLED=false are the prod
+            # values (test.txt ships console/true for local dev only).
+            OTP_SMS_PROVIDER=infobip
+            OTP_DEBUG_ENABLED=false
+            OTP_TTL_MINUTES=10
+            OTP_LENGTH=6
+            OTP_MAX_ATTEMPTS=3
+            OTP_RESEND_COOLDOWN_SECONDS=60
+            OTP_MAX_RESENDS=2
+            OTP_ANDROID_SMS_HASH=omRcRPVzgWL
+            INFOBIP_SMS_ENDPOINT=/sms/2/text/advanced
+            INFOBIP_TIMEOUT_MS=10000
+            INFOBIP_REPORTS_ENDPOINT=/sms/1/reports
+            INFOBIP_REMOVE_PLUS_FROM_TO=true
+            INFOBIP_DELIVERY_REPORT_NOTIFY_URL=
+            INFOBIP_NOTIFY_CONTENT_TYPE=application/json
             ENV_EOF
 
             # Créer le fichier docker-compose.yml depuis le contenu du repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,32 @@ services:
       # Wallet / payments. PAYMENT_INTERNAL_API_KEY guards the internal
       # exam-reward credit endpoint — MUST be set: an empty value makes the
       # InternalApiKeyGuard fail open (see nginx: /internal/ is also blocked at
-      # the edge as defense-in-depth). TWILIO_* powers withdrawal OTP SMS.
+      # the edge as defense-in-depth).
       PAYMENT_INTERNAL_API_KEY: ${PAYMENT_INTERNAL_API_KEY}
-      TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
-      TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
-      TWILIO_FROM: ${TWILIO_FROM}
+      # Withdrawal OTP SMS via Infobip (replaced Twilio). INFOBIP_BASE_URL +
+      # INFOBIP_API_KEY are REQUIRED — an empty value makes every OTP send throw
+      # "Configuration Infobip incomplète". INFOBIP_WEBHOOK_SECRET secures the
+      # delivery-report webhook (empty → the guard 403s all callbacks). The OTP_*
+      # vars tune code generation/resend/hash; set OTP_DEBUG_ENABLED=false in prod.
+      OTP_SMS_PROVIDER: ${OTP_SMS_PROVIDER}
+      OTP_DEBUG_ENABLED: ${OTP_DEBUG_ENABLED}
+      OTP_TTL_MINUTES: ${OTP_TTL_MINUTES}
+      OTP_LENGTH: ${OTP_LENGTH}
+      OTP_MAX_ATTEMPTS: ${OTP_MAX_ATTEMPTS}
+      OTP_HASH_SECRET: ${OTP_HASH_SECRET}
+      OTP_RESEND_COOLDOWN_SECONDS: ${OTP_RESEND_COOLDOWN_SECONDS}
+      OTP_MAX_RESENDS: ${OTP_MAX_RESENDS}
+      OTP_ANDROID_SMS_HASH: ${OTP_ANDROID_SMS_HASH}
+      INFOBIP_BASE_URL: ${INFOBIP_BASE_URL}
+      INFOBIP_API_KEY: ${INFOBIP_API_KEY}
+      INFOBIP_FROM: ${INFOBIP_FROM}
+      INFOBIP_SMS_ENDPOINT: ${INFOBIP_SMS_ENDPOINT}
+      INFOBIP_TIMEOUT_MS: ${INFOBIP_TIMEOUT_MS}
+      INFOBIP_REPORTS_ENDPOINT: ${INFOBIP_REPORTS_ENDPOINT}
+      INFOBIP_REMOVE_PLUS_FROM_TO: ${INFOBIP_REMOVE_PLUS_FROM_TO}
+      INFOBIP_WEBHOOK_SECRET: ${INFOBIP_WEBHOOK_SECRET}
+      INFOBIP_DELIVERY_REPORT_NOTIFY_URL: ${INFOBIP_DELIVERY_REPORT_NOTIFY_URL}
+      INFOBIP_NOTIFY_CONTENT_TYPE: ${INFOBIP_NOTIFY_CONTENT_TYPE}
     networks:
       - edukia_network
     depends_on:


### PR DESCRIPTION
## Why

The merged OTP feature (#188) reads `INFOBIP_*` and `OTP_*` env vars, but the deploy pipeline injected **none** of them — so in prod every withdrawal OTP send throws `"Configuration Infobip incomplète"`. This wires them in.

## Changes

- **`docker-compose.yml`** — pass each OTP/Infobip var into the backend container via `KEY: ${KEY}`; **drop the dead `TWILIO_*`** (Twilio adapter deleted in #188).
- **`.github/workflows/deploy.yml`** — split the vars two ways in the VPS `.env` heredoc:
  - **5 sensitive → GitHub PRD secrets** (`${{ secrets.* }}`)
  - **14 non-sensitive → literal values** in the heredoc (like `DOCKER_IMAGE_BACKEND`/`PORT`) — no GitHub secret needed.

## ✅ You only need to add these 5 PRD secrets

| Secret | Source |
|---|---|
| `INFOBIP_API_KEY` | Infobip dashboard |
| `INFOBIP_BASE_URL` | Infobip dashboard |
| `INFOBIP_FROM` | Infobip sender id |
| `INFOBIP_WEBHOOK_SECRET` | **generate** (`openssl rand -hex 24`), also configure in Infobip webhook |
| `OTP_HASH_SECRET` | **generate** (`openssl rand -hex 32`) |

The 14 literals (already in the workflow): `OTP_SMS_PROVIDER=infobip`, `OTP_DEBUG_ENABLED=false`, `OTP_TTL_MINUTES=10`, `OTP_LENGTH=6`, `OTP_MAX_ATTEMPTS=3`, `OTP_RESEND_COOLDOWN_SECONDS=60`, `OTP_MAX_RESENDS=2`, `OTP_ANDROID_SMS_HASH=omRcRPVzgWL`, `INFOBIP_SMS_ENDPOINT=/sms/2/text/advanced`, `INFOBIP_TIMEOUT_MS=10000`, `INFOBIP_REPORTS_ENDPOINT=/sms/1/reports`, `INFOBIP_REMOVE_PLUS_FROM_TO=true`, `INFOBIP_DELIVERY_REPORT_NOTIFY_URL=` (empty), `INFOBIP_NOTIFY_CONTENT_TYPE=application/json`.

Note: `OTP_SMS_PROVIDER`/`OTP_DEBUG_ENABLED` use prod values here (`test.txt` ships `console`/`true` for local dev). `OTP_LOCK_DURATION_MINUTES` is intentionally omitted (not read by code). `PAYMENT_INTERNAL_API_KEY` already exists as a secret — consider rotating it off the weak placeholder.

Merging triggers a deploy — **add the 5 secrets first**, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)