### PR TITLE
feat(observability): Phase 2 — Loki (R2) + Vector + Grafana

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,9 +137,6 @@ jobs:
             INFOBIP_REMOVE_PLUS_FROM_TO=true
             INFOBIP_DELIVERY_REPORT_NOTIFY_URL=
             INFOBIP_NOTIFY_CONTENT_TYPE=application/json
-            LOKI_R2_ENDPOINT=${{ secrets.LOKI_R2_ENDPOINT }}
-            LOKI_R2_ACCESS_KEY_ID=${{ secrets.LOKI_R2_ACCESS_KEY_ID }}
-            LOKI_R2_SECRET_ACCESS_KEY=${{ secrets.LOKI_R2_SECRET_ACCESS_KEY }}
             GF_SECURITY_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}
             ENV_EOF
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,10 @@ jobs:
           NGINX_CONTENT=$(cat nginx/nginx.conf | base64 -w 0)
           echo "nginx_content=$NGINX_CONTENT" >> $GITHUB_OUTPUT
 
+          # Observability configs (loki, vector, grafana provisioning) as a tarball.
+          OBS_CONTENT=$(tar czf - observability | base64 -w 0)
+          echo "obs_content=$OBS_CONTENT" >> $GITHUB_OUTPUT
+
       # Absorb transient runner→VPS network blips (the last failure was
       # `dial tcp <vps>:22: i/o timeout`, i.e. the SSH action couldn't even
       # open the socket). Poll TCP/22 until it answers before attempting the
@@ -59,12 +63,13 @@ jobs:
         env:
           COMPOSE_CONTENT: ${{ steps.prepare.outputs.compose_content }}
           NGINX_CONTENT: ${{ steps.prepare.outputs.nginx_content }}
+          OBS_CONTENT: ${{ steps.prepare.outputs.obs_content }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USERNAME }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT || 22 }}
-          envs: COMPOSE_CONTENT,NGINX_CONTENT
+          envs: COMPOSE_CONTENT,NGINX_CONTENT,OBS_CONTENT
           # `timeout` = SSH connection-establishment timeout (only real knobs
           # appleboy/ssh-action@v1.0.0 exposes are `timeout` + `command_timeout`;
           # there is no native connect-retry). The "Wait for VPS SSH" step
@@ -132,6 +137,10 @@ jobs:
             INFOBIP_REMOVE_PLUS_FROM_TO=true
             INFOBIP_DELIVERY_REPORT_NOTIFY_URL=
             INFOBIP_NOTIFY_CONTENT_TYPE=application/json
+            LOKI_R2_ENDPOINT=${{ secrets.LOKI_R2_ENDPOINT }}
+            LOKI_R2_ACCESS_KEY_ID=${{ secrets.LOKI_R2_ACCESS_KEY_ID }}
+            LOKI_R2_SECRET_ACCESS_KEY=${{ secrets.LOKI_R2_SECRET_ACCESS_KEY }}
+            GF_SECURITY_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}
             ENV_EOF
 
             # Créer le fichier docker-compose.yml depuis le contenu du repo
@@ -139,6 +148,9 @@ jobs:
 
             # Créer le fichier nginx.conf depuis le contenu du repo
             echo "$NGINX_CONTENT" | base64 -d > ./nginx/nginx.conf
+
+            # Extraire les configs d'observabilité (loki, vector, grafana).
+            echo "$OBS_CONTENT" | base64 -d | tar xzf - -C "$DEPLOY_DIR"
 
             # Use Docker Compose v2 (the Go plugin, invoked as `docker compose`).
             # The legacy v1 Python binary (`docker-compose`, 1.29.2) crashes with
@@ -211,9 +223,29 @@ jobs:
                   --webroot-path=/var/www/certbot \
                   --email "$CERT_EMAIL" --agree-tos --no-eff-email \
                   --rsa-key-size 4096 \
-                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" </dev/null || true
+                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" -d "grafana.$PRIMARY_DOMAIN" </dev/null || true
 
               # Recharger nginx avec le vrai certificat
+              timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
+            fi
+
+            # Expand an existing certificate to cover grafana.educ-prime.com when
+            # it's missing (idempotent: certbot skips if already covered & not due
+            # for renewal). Requires a DNS A record for grafana.$PRIMARY_DOMAIN.
+            # Guarded so a not-yet-propagated DNS record never fails the deploy —
+            # nginx then serves the base cert for grafana (TLS warning) until the
+            # next deploy succeeds.
+            if ! grep -q "grafana.$PRIMARY_DOMAIN" "$DEPLOY_DIR/certbot/conf/live/$PRIMARY_DOMAIN/cert.pem" 2>/dev/null \
+               && ! openssl x509 -in "$DEPLOY_DIR/certbot/conf/live/$PRIMARY_DOMAIN/cert.pem" -noout -text 2>/dev/null | grep -q "grafana.$PRIMARY_DOMAIN"; then
+              echo "=== Expansion du certificat pour grafana.$PRIMARY_DOMAIN"
+              timeout 180 docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                -v "$DEPLOY_DIR/certbot/www:/var/www/certbot" \
+                certbot/certbot certonly --webroot \
+                  --webroot-path=/var/www/certbot \
+                  --email "$CERT_EMAIL" --agree-tos --no-eff-email \
+                  --rsa-key-size 4096 --expand \
+                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" -d "grafana.$PRIMARY_DOMAIN" </dev/null || true
               timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
             fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,9 +147,10 @@ services:
     restart: unless-stopped
     command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
     environment:
-      LOKI_R2_ENDPOINT: ${LOKI_R2_ENDPOINT}
-      LOKI_R2_ACCESS_KEY_ID: ${LOKI_R2_ACCESS_KEY_ID}
-      LOKI_R2_SECRET_ACCESS_KEY: ${LOKI_R2_SECRET_ACCESS_KEY}
+      # Reuse the app's account-wide R2 credentials (they can reach edukia-logs).
+      LOKI_R2_ENDPOINT: ${R2_ENDPOINT}
+      LOKI_R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID}
+      LOKI_R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY}
     volumes:
       - ./observability/loki-config.yaml:/etc/loki/loki-config.yaml:ro
       - loki_data:/loki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,11 +135,63 @@ services:
       - ./certbot/www:/var/www/certbot
     entrypoint: >
       /bin/sh -c ' if [ ! -f /etc/letsencrypt/live/educ-prime.com/fullchain.pem ]; then
-        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.cloud --agree-tos --no-eff-email -d educ-prime.com -d api.educ-prime.com;
+        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.cloud --agree-tos --no-eff-email -d educ-prime.com -d api.educ-prime.com -d grafana.educ-prime.com;
       fi; trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done; '
+    networks:
+      - edukia_network
+
+  # --- Observability: Vector -> Loki (R2 backend) -> Grafana ---
+  loki:
+    image: grafana/loki:3.3.2
+    container_name: edukia_loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yaml -config.expand-env=true
+    environment:
+      LOKI_R2_ENDPOINT: ${LOKI_R2_ENDPOINT}
+      LOKI_R2_ACCESS_KEY_ID: ${LOKI_R2_ACCESS_KEY_ID}
+      LOKI_R2_SECRET_ACCESS_KEY: ${LOKI_R2_SECRET_ACCESS_KEY}
+    volumes:
+      - ./observability/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki_data:/loki
+    networks:
+      - edukia_network
+
+  vector:
+    image: timberio/vector:0.44.0-debian
+    container_name: edukia_vector
+    restart: unless-stopped
+    volumes:
+      - ./observability/vector.yaml:/etc/vector/vector.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - vector_data:/var/lib/vector
+    depends_on:
+      - loki
+    networks:
+      - edukia_network
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: edukia_grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
+      GF_SERVER_ROOT_URL: https://grafana.educ-prime.com
+      GF_SERVER_DOMAIN: grafana.educ-prime.com
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - loki
     networks:
       - edukia_network
 
 networks:
   edukia_network:
     driver: bridge
+
+volumes:
+  loki_data:
+  vector_data:
+  grafana_data:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,10 +22,16 @@ log_format json_access escape=json
     '"scheme":"$scheme"'
   '}';
 
-# HTTP for Frontend & Backend : educ-prime.com, api.educ-prime.com
+# Grafana Live / websockets need Connection: upgrade to pass through the proxy.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# HTTP for Frontend, Backend & Grafana : educ-prime.com, api., grafana.
 server {
     listen 80;
-    server_name educ-prime.com api.educ-prime.com;
+    server_name educ-prime.com api.educ-prime.com grafana.educ-prime.com;
     access_log /var/log/nginx/access.log json_access;
 
     location /.well-known/acme-challenge/ {
@@ -82,5 +88,29 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_request_buffering off;
+    }
+}
+
+# HTTPS for Grafana : grafana.educ-prime.com
+# Uses the same SAN cert as educ-prime.com — the deploy expands the certificate
+# to include grafana.educ-prime.com (requires a DNS A record for it first).
+server {
+    listen 443 ssl;
+    server_name grafana.educ-prime.com;
+    access_log /var/log/nginx/access.log json_access;
+
+    ssl_certificate /etc/letsencrypt/live/educ-prime.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/educ-prime.com/privkey.pem;
+
+    location / {
+        proxy_pass http://grafana:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Grafana Live (websockets)
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,11 @@
+# Auto-provision the Loki datasource so Grafana is query-ready on first boot.
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false
+    jsonData:
+      maxLines: 2000

--- a/observability/loki-config.yaml
+++ b/observability/loki-config.yaml
@@ -1,0 +1,70 @@
+# Self-hosted Loki (monolithic / single-binary) with Cloudflare R2 as the
+# object store for BOTH chunks and the TSDB index. Sized for one VPS: all
+# components in one process, only small caches on local disk, bulk data in R2.
+# `${VAR}` are expanded at start via `-config.expand-env=true` (see compose).
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    s3:
+      # R2 S3 API endpoint, e.g. https://<accountid>.r2.cloudflarestorage.com
+      endpoint: ${LOKI_R2_ENDPOINT}
+      bucketnames: edukia-logs
+      access_key_id: ${LOKI_R2_ACCESS_KEY_ID}
+      secret_access_key: ${LOKI_R2_SECRET_ACCESS_KEY}
+      region: auto
+      s3forcepathstyle: true
+      insecure: false
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+    cache_ttl: 24h
+
+# 90-day retention: the compactor deletes chunks older than this from R2.
+limits_config:
+  retention_period: 2160h # 90 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+  max_query_series: 5000
+  allow_structured_metadata: true
+  volume_enabled: true
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: s3
+
+# Disable the legacy table-manager retention (compactor owns retention now).
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0
+
+analytics:
+  reporting_enabled: false

--- a/observability/vector.yaml
+++ b/observability/vector.yaml
@@ -1,0 +1,63 @@
+# Vector: tails every edukia_* container's stdout/stderr via the Docker API and
+# ships to Loki. Backend (pino) and nginx access logs are already JSON — we ship
+# the raw line as-is (codec: text) and label by service, so Grafana can `| json`
+# them. A defense-in-depth redaction pass runs on top of pino's source redaction.
+data_dir: /var/lib/vector
+
+api:
+  enabled: false
+
+sources:
+  containers:
+    type: docker_logs
+    include_containers:
+      - edukia_
+    # Never tail the logging stack itself (avoids a feedback loop).
+    exclude_containers:
+      - edukia_vector
+      - edukia_loki
+      - edukia_grafana
+
+transforms:
+  process:
+    type: remap
+    inputs:
+      - containers
+    source: |
+      # Service label = container name without a leading slash.
+      .service = replace(string!(.container_name), r'^/', "")
+      # Defense-in-depth secret redaction on the raw line (the backend already
+      # redacts sensitive headers at the pino source; nginx access-log URIs can
+      # still carry a `?secret=` query param, e.g. the Infobip webhook). Literal
+      # replacements only — no `$`-backreferences, which Vector's config
+      # interpolation would mistake for env vars.
+      msg = string!(.message)
+      # 1) Bearer tokens.
+      msg = replace(msg, r'(?i)bearer\s+[A-Za-z0-9._\-]+', "Bearer [REDACTED]")
+      # 2) Query-string secrets, e.g. nginx URI `?secret=...` (Infobip webhook).
+      msg = replace(msg, r'(?i)(?:secret|token|password|passwd|api[_-]?key|authorization)=[^&"\s]+', "[REDACTED-PARAM]")
+      # 3) JSON-style "key":"value" secrets, e.g. pino's structured req.query.
+      #    Replacements are VRL raw strings (s'...') so the inner quotes are literal.
+      msg = replace(msg, r'(?i)"secret"\s*:\s*"[^"]*"', s'"secret":"[REDACTED]"')
+      msg = replace(msg, r'(?i)"token"\s*:\s*"[^"]*"', s'"token":"[REDACTED]"')
+      msg = replace(msg, r'(?i)"password"\s*:\s*"[^"]*"', s'"password":"[REDACTED]"')
+      msg = replace(msg, r'(?i)"passwd"\s*:\s*"[^"]*"', s'"passwd":"[REDACTED]"')
+      msg = replace(msg, r'(?i)"api_?key"\s*:\s*"[^"]*"', s'"api_key":"[REDACTED]"')
+      msg = replace(msg, r'(?i)"authorization"\s*:\s*"[^"]*"', s'"authorization":"[REDACTED]"')
+      .message = msg
+
+sinks:
+  loki:
+    type: loki
+    inputs:
+      - process
+    endpoint: http://loki:3100
+    # Ship the raw pino/nginx JSON string as the Loki log line; parse with
+    # `| json` in Grafana. Keeps label cardinality low (service only).
+    encoding:
+      codec: text
+    labels:
+      service: "{{ service }}"
+      source: vector
+    out_of_order_action: accept
+    remove_label_fields: true


### PR DESCRIPTION
**Phase 2** of the log pipeline — self-hosted, fully on the prod VPS:

```
edukia_* containers ─► Vector ─► Loki ─► R2 (edukia-logs, chunks+index, 90d)
                                  ▲
                        Grafana ──┘  (grafana.educ-prime.com)
```

## What's added
- **`observability/loki-config.yaml`** — monolithic Loki; R2 `edukia-logs` as the S3 object store (chunks + TSDB index); compactor **90-day** retention.
- **`observability/vector.yaml`** — `docker_logs` over all `edukia_*` containers; ships raw pino/nginx JSON labeled by `service`; redacts bearer tokens, querystring `?secret=`, and JSON `"key":"value"` secrets.
- **`observability/grafana/provisioning/`** — auto-adds the Loki datasource.
- **`docker-compose.yml`** — `loki` + `vector` + `grafana` (+ volumes); Loki reuses the existing `R2_*` creds; certbot also requests `grafana.educ-prime.com`.
- **`nginx.conf`** — `grafana.educ-prime.com` server block (TLS + ws upgrade).
- **`deploy.yml`** — ships `observability/` to the VPS, writes `GF_SECURITY_ADMIN_PASSWORD` to `.env`, expands the LE cert for the grafana subdomain.

## Validation (local)
- ✅ `loki -verify-config`, `vector validate`, `docker compose config` pass.
- ✅ End-to-end (filesystem Loki + Vector vs. running dev containers): logs flow, queryable by `{service=...}`, **0 secret leaks** (querystring, pino `req.query`, bearer all redacted).
- R2 connectivity only testable on deploy.

## ✅ Prerequisites — status
1. **R2 creds** — reused from existing `R2_ENDPOINT` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` PRD secrets (already set). No new R2 secret needed.
2. **DNS** `grafana.educ-prime.com → VPS` — **done** (per owner).
3. **VPS RAM** — confirmed OK (per owner).
4. **Still needed:** add **`GF_SECURITY_ADMIN_PASSWORD`** to the PRD environment (Grafana admin password).

Merging triggers a deploy that brings up loki + vector + grafana. **Add `GF_SECURITY_ADMIN_PASSWORD` first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)