### PR TITLE
feat(observability): ship only backend + nginx logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,9 @@ services:
     image: timberio/vector:0.44.0-debian
     container_name: edukia_vector
     restart: unless-stopped
+    # --watch-config so edits to vector.yaml auto-reload on deploy (compose does
+    # not recreate a container when only a bind-mounted file's contents change).
+    command: --watch-config --config-yaml /etc/vector/vector.yaml
     volumes:
       - ./observability/vector.yaml:/etc/vector/vector.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/observability/vector.yaml
+++ b/observability/vector.yaml
@@ -10,13 +10,12 @@ api:
 sources:
   containers:
     type: docker_logs
+    # Allowlist — only the services we care about right now. Add container
+    # names here (e.g. edukia_redis) to start shipping more. An explicit list
+    # also naturally excludes the logging stack itself (loki/vector/grafana).
     include_containers:
-      - edukia_
-    # Never tail the logging stack itself (avoids a feedback loop).
-    exclude_containers:
-      - edukia_vector
-      - edukia_loki
-      - edukia_grafana
+      - edukia_backend
+      - edukia_nginx
 
 transforms:
   process:


### PR DESCRIPTION
Restricts the log pipeline to the two services that matter right now.

- **`vector.yaml`** — swap the broad `include_containers: [edukia_]` for an explicit allowlist **`[edukia_backend, edukia_nginx]`**. Frontend, redis, and certbot are no longer shipped to Loki. Extend the list to add more later.
- **`docker-compose.yml`** — add `--watch-config` to Vector so `vector.yaml` edits auto-reload (compose won't recreate a container for a bind-mounted-file change alone). This command change also forces the recreate that applies the new filter on this deploy.

Verified locally (filesystem Loki + Vector vs. running dev containers): after the change, `GET /loki/.../label/service/values` returns **only** `["edukia_backend","edukia_nginx"]`. `vector validate` + `docker compose config` pass; `--watch-config` confirmed a valid flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)