### PR TITLE
fix(tls): give grafana its own cert so the api cert is never re-keyed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,6 +186,25 @@ jobs:
               BOOTSTRAP_NEEDED=1
             fi
 
+            # Same bootstrap for grafana's OWN certificate lineage. Grafana has a
+            # separate cert (NOT a SAN on the educ-prime.com cert) so issuing/
+            # renewing it never re-keys the api cert — that re-key broke the
+            # mobile app's certificate pinning.
+            GRAFANA_CERT_DIR="$DEPLOY_DIR/certbot/conf/live/grafana.$PRIMARY_DOMAIN"
+            GRAFANA_BOOTSTRAP_NEEDED=0
+            if [ ! -s "$GRAFANA_CERT_DIR/fullchain.pem" ]; then
+              echo "=== Aucun certificat pour grafana.$PRIMARY_DOMAIN — création d'un dummy"
+              mkdir -p "$GRAFANA_CERT_DIR"
+              timeout 300 docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                --entrypoint openssl certbot/certbot \
+                req -x509 -nodes -newkey rsa:4096 -days 1 \
+                -keyout "/etc/letsencrypt/live/grafana.$PRIMARY_DOMAIN/privkey.pem" \
+                -out "/etc/letsencrypt/live/grafana.$PRIMARY_DOMAIN/fullchain.pem" \
+                -subj "/CN=grafana.$PRIMARY_DOMAIN" </dev/null
+              GRAFANA_BOOTSTRAP_NEEDED=1
+            fi
+
             # Every docker invocation below is wrapped in `timeout` and fed
             # </dev/null. Root cause of the recurring "Run Command Timeout":
             # `docker compose logs` (and occasionally pull/up) can block
@@ -219,30 +238,34 @@ jobs:
                 certbot/certbot certonly --webroot \
                   --webroot-path=/var/www/certbot \
                   --email "$CERT_EMAIL" --agree-tos --no-eff-email \
-                  --rsa-key-size 4096 \
-                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" -d "grafana.$PRIMARY_DOMAIN" </dev/null || true
+                  --rsa-key-size 4096 --reuse-key \
+                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" </dev/null || true
 
               # Recharger nginx avec le vrai certificat
               timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
             fi
 
-            # Expand an existing certificate to cover grafana.educ-prime.com when
-            # it's missing (idempotent: certbot skips if already covered & not due
-            # for renewal). Requires a DNS A record for grafana.$PRIMARY_DOMAIN.
-            # Guarded so a not-yet-propagated DNS record never fails the deploy —
-            # nginx then serves the base cert for grafana (TLS warning) until the
-            # next deploy succeeds.
-            if ! grep -q "grafana.$PRIMARY_DOMAIN" "$DEPLOY_DIR/certbot/conf/live/$PRIMARY_DOMAIN/cert.pem" 2>/dev/null \
-               && ! openssl x509 -in "$DEPLOY_DIR/certbot/conf/live/$PRIMARY_DOMAIN/cert.pem" -noout -text 2>/dev/null | grep -q "grafana.$PRIMARY_DOMAIN"; then
-              echo "=== Expansion du certificat pour grafana.$PRIMARY_DOMAIN"
+            # Issue grafana's SEPARATE certificate (own lineage, --cert-name
+            # grafana.educ-prime.com) when we just bootstrapped a dummy for it.
+            # Kept isolated from the api cert on purpose: grafana renewals must
+            # never re-key educ-prime.com/api.educ-prime.com. Requires a DNS A
+            # record for grafana.$PRIMARY_DOMAIN; guarded so a slow record never
+            # fails the deploy (nginx keeps serving the dummy until it succeeds).
+            if [ "$GRAFANA_BOOTSTRAP_NEEDED" = "1" ]; then
+              echo "=== Émission du certificat séparé pour grafana.$PRIMARY_DOMAIN"
+              timeout 60 docker run --rm \
+                -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
+                --entrypoint sh certbot/certbot \
+                -c "rm -rf /etc/letsencrypt/live/grafana.$PRIMARY_DOMAIN /etc/letsencrypt/archive/grafana.$PRIMARY_DOMAIN /etc/letsencrypt/renewal/grafana.$PRIMARY_DOMAIN.conf" </dev/null || true
               timeout 180 docker run --rm \
                 -v "$DEPLOY_DIR/certbot/conf:/etc/letsencrypt" \
                 -v "$DEPLOY_DIR/certbot/www:/var/www/certbot" \
                 certbot/certbot certonly --webroot \
                   --webroot-path=/var/www/certbot \
                   --email "$CERT_EMAIL" --agree-tos --no-eff-email \
-                  --rsa-key-size 4096 --expand \
-                  -d "$PRIMARY_DOMAIN" -d "api.$PRIMARY_DOMAIN" -d "grafana.$PRIMARY_DOMAIN" </dev/null || true
+                  --rsa-key-size 4096 --reuse-key \
+                  --cert-name "grafana.$PRIMARY_DOMAIN" \
+                  -d "grafana.$PRIMARY_DOMAIN" </dev/null || true
               timeout 30 $COMPOSE exec -T nginx nginx -s reload </dev/null >/dev/null 2>&1 || true
             fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,9 @@ services:
       - ./certbot/www:/var/www/certbot
     entrypoint: >
       /bin/sh -c ' if [ ! -f /etc/letsencrypt/live/educ-prime.com/fullchain.pem ]; then
-        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.cloud --agree-tos --no-eff-email -d educ-prime.com -d api.educ-prime.com -d grafana.educ-prime.com;
+        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.cloud --agree-tos --no-eff-email --reuse-key -d educ-prime.com -d api.educ-prime.com;
+      fi; if [ ! -f /etc/letsencrypt/live/grafana.educ-prime.com/fullchain.pem ]; then
+        certbot certonly --webroot --webroot-path=/var/www/certbot --email support@educ-prime.cloud --agree-tos --no-eff-email --reuse-key --cert-name grafana.educ-prime.com -d grafana.educ-prime.com;
       fi; trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done; '
     networks:
       - edukia_network

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -92,15 +92,16 @@ server {
 }
 
 # HTTPS for Grafana : grafana.educ-prime.com
-# Uses the same SAN cert as educ-prime.com — the deploy expands the certificate
-# to include grafana.educ-prime.com (requires a DNS A record for it first).
+# Uses its OWN certificate lineage (not a SAN on the educ-prime.com cert), so
+# grafana cert issuance/renewal never re-keys the api cert (which broke mobile
+# certificate pinning).
 server {
     listen 443 ssl;
     server_name grafana.educ-prime.com;
     access_log /var/log/nginx/access.log json_access;
 
-    ssl_certificate /etc/letsencrypt/live/educ-prime.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/educ-prime.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/grafana.educ-prime.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/grafana.educ-prime.com/privkey.pem;
 
     location / {
         proxy_pass http://grafana:3000;


### PR DESCRIPTION
## Problem
Adding `grafana.educ-prime.com` as a SAN on the `educ-prime.com` cert (#192) forced Let's Encrypt to **re-issue** the certificate, which **changed the `api.educ-prime.com` cert's key**. The mobile app pins the cert, so it broke — while Postman/browsers/curl (no pinning) kept working. Confirmed: the live api cert's `notBefore` matches the #192 deploy time.

## Fix — grafana gets its own certificate lineage
- **`nginx.conf`** — the grafana server block now serves `/etc/letsencrypt/live/grafana.educ-prime.com/`. The api + frontend blocks keep the `educ-prime.com` cert **untouched**.
- **`deploy.yml`** — remove the `--expand` step (the culprit); bootstrap a dummy grafana cert before nginx starts, then issue a standalone `--cert-name grafana.educ-prime.com` cert via HTTP-01. The main-cert issuance drops grafana from its `-d` list and gains `--reuse-key`.
- **`docker-compose.yml`** certbot — issue grafana as a separate lineage; `--reuse-key` on both so renewals don't rotate keys.

**Deploy safety:** this run does **not** re-issue the api cert (its bootstrap block is skipped because the cert already exists), so it causes no further mobile disruption. Grafana just moves onto its own cert.

## ⚠️ This does NOT auto-fix the currently-broken mobile app
The api cert's key already changed. To restore mobile now, do one of:
1. **Update the app's pin** to the current key — `SPKI SHA-256: mnIuRic66lFvFKINSDXHr2dfi1ECcq3ji32qc7Cmr60=`. Best practice: pin the Let's Encrypt **intermediate CA** (stable across renewals) or add a backup pin.
2. **Restore the previous cert** on the VPS from `/etc/letsencrypt/archive/educ-prime.com/` (old key → old pin), then point nginx back at it.

Also: to guarantee the api key never rotates on the next auto-renewal (~60d), re-issue it once on the VPS with `--reuse-key` (reuses the *current* key, sets `reuse_key` in the renewal conf). I can hand you that exact command.

Validated: `deploy.yml` + `docker-compose.yml` YAML parse, `docker compose config` OK, `--expand` fully removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)