### PR TITLE
fix(logging): don't crash in dev when pino-pretty isn't installed

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -73,6 +73,20 @@ import { BullModule } from '@nestjs/bullmq';
 import { CountryConfigModule } from './config/country-config.module';
 import { CountryMiddleware } from './config/country.middleware';
 
+// pino-pretty is a devDependency, so it's absent from the prod-only Docker
+// runtime image (`npm install --only=production`). Only use the pretty
+// transport when it's actually resolvable — otherwise a docker dev stack
+// (NODE_ENV=development on that image) would crash with
+// "unable to determine transport target for pino-pretty". Falls back to JSON.
+const prettyLogsAvailable = (() => {
+  try {
+    require.resolve('pino-pretty');
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
 @Module({
   imports: [
     // Structured JSON logging (pino). In prod every log line is one JSON
@@ -84,9 +98,9 @@ import { CountryMiddleware } from './config/country.middleware';
     LoggerModule.forRoot({
       pinoHttp: {
         level: process.env.LOG_LEVEL || 'info',
-        // JSON in prod; pretty single-line in dev.
+        // Pretty single-line in dev when pino-pretty is installed; JSON otherwise.
         transport:
-          process.env.NODE_ENV !== 'production'
+          process.env.NODE_ENV !== 'production' && prettyLogsAvailable
             ? { target: 'pino-pretty', options: { singleLine: true } }
             : undefined,
         // Emit level as a string ("info") instead of a number — friendlier in Loki.


### PR DESCRIPTION
## Bug
The backend crash-loops when the Docker stack runs with `NODE_ENV=development` (the `docker-compose.dev.yml` default). The prod image is built with `npm install --only=production`, so the **devDependency `pino-pretty` is missing**, and pino's dev transport fails at startup:
```
Error: unable to determine transport target for "pino-pretty"
```
Introduced in #191. **Prod is unaffected** (`NODE_ENV=production` never loads pino-pretty).

## Fix
Guard the pretty transport behind `require.resolve('pino-pretty')` — use it only when actually installed (local `npm run start` with devDeps), otherwise fall back to JSON. No crash either way.

| Context | Before | After |
|---|---|---|
| Local `npm run start` (devDeps) | pretty | pretty |
| Docker dev stack (prod-only image) | **crash** | JSON (no crash) |
| Prod (`NODE_ENV=production`) | JSON | JSON |

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)