### PR TITLE
feat(observability): Phase 3a — provisioned Grafana Logs Overview dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/dashboards:/etc/grafana/dashboards:ro
     depends_on:
       - loki
     networks:

--- a/observability/grafana/dashboards/edukia-logs-overview.json
+++ b/observability/grafana/dashboards/edukia-logs-overview.json
@@ -1,0 +1,139 @@
+{
+  "uid": "edukia-logs-overview",
+  "title": "Edukia — Logs Overview",
+  "tags": ["edukia", "logs"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "backend_re",
+        "type": "constant",
+        "query": "edukia_backend",
+        "hide": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Request rate (nginx, req/s)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" [1m]))" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "5xx error rate (%)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percent", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 5 } ] } } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "area" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" | status>=500 [5m])) / (sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" [5m])) > 0) * 100" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Backend errors (last 5m)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(count_over_time({service=\"edukia_backend\"} | json | __error__=\"\" | level=\"error\" [5m]))" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "P95 latency (s)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "expr": "quantile_over_time(0.95, {service=\"edukia_nginx\"} | json rt=\"request_time\" | __error__=\"\" | unwrap rt [5m])" }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Requests by status class",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 20, "stacking": { "mode": "normal" } } } },
+      "targets": [
+        { "refId": "2xx", "legendFormat": "2xx", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" | status>=200 | status<300 [1m]))" },
+        { "refId": "3xx", "legendFormat": "3xx", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" | status>=300 | status<400 [1m]))" },
+        { "refId": "4xx", "legendFormat": "4xx", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" | status>=400 | status<500 [1m]))" },
+        { "refId": "5xx", "legendFormat": "5xx", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum(rate({service=\"edukia_nginx\"} | json | __error__=\"\" | status>=500 [1m]))" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Latency percentiles (s)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        { "refId": "p50", "legendFormat": "p50", "datasource": { "type": "loki", "uid": "loki" }, "expr": "quantile_over_time(0.50, {service=\"edukia_nginx\"} | json rt=\"request_time\" | __error__=\"\" | unwrap rt [5m])" },
+        { "refId": "p95", "legendFormat": "p95", "datasource": { "type": "loki", "uid": "loki" }, "expr": "quantile_over_time(0.95, {service=\"edukia_nginx\"} | json rt=\"request_time\" | __error__=\"\" | unwrap rt [5m])" },
+        { "refId": "p99", "legendFormat": "p99", "datasource": { "type": "loki", "uid": "loki" }, "expr": "quantile_over_time(0.99, {service=\"edukia_nginx\"} | json rt=\"request_time\" | __error__=\"\" | unwrap rt [5m])" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Backend log levels",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } } },
+      "targets": [
+        { "refId": "A", "legendFormat": "{{level}}", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum by (level) (count_over_time({service=\"edukia_backend\"} | json | __error__=\"\" [1m]))" }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Log volume per service",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+      "targets": [
+        { "refId": "A", "legendFormat": "{{service}}", "datasource": { "type": "loki", "uid": "loki" }, "expr": "sum by (service) (count_over_time({service=~\"edukia_.+\"} [1m]))" }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "Top endpoints (last 1h)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 21 },
+      "targets": [
+        { "refId": "A", "instant": true, "datasource": { "type": "loki", "uid": "loki" }, "expr": "topk(15, sum by (uri) (count_over_time({service=\"edukia_nginx\"} | json | __error__=\"\" [1h])))" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "logs",
+      "title": "Recent backend errors",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 21 },
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "loki", "uid": "loki" }, "expr": "{service=\"edukia_backend\"} | json | __error__=\"\" | level=\"error\"" }
+      ]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/provider.yml
+++ b/observability/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,13 @@
+# Load JSON dashboards from a mounted folder so they exist on first boot.
+apiVersion: 1
+providers:
+  - name: edukia
+    orgId: 1
+    folder: Edukia
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,8 +1,15 @@
 # Auto-provision the Loki datasource so Grafana is query-ready on first boot.
+# deleteDatasources first so the fixed `uid: loki` is guaranteed even on an
+# instance that previously provisioned Loki with an auto-generated uid — the
+# provisioned dashboards reference the datasource by that uid.
 apiVersion: 1
+deleteDatasources:
+  - name: Loki
+    orgId: 1
 datasources:
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
     url: http://loki:3100
     isDefault: true


### PR DESCRIPTION
**Phase 3a** (dashboards). A file-provisioned Grafana dashboard over the logs already in Loki — it shows up automatically on deploy, no click-ops.

## Dashboard — "Edukia — Logs Overview" (folder: Edukia)
- **Stats:** request rate (req/s), 5xx error rate (%), backend errors (5m), p95 latency (s)
- **Timeseries:** requests by status class (2xx/3xx/4xx/5xx), latency p50/p95/p99, backend log levels, log volume per service
- **Table:** top 15 endpoints (last 1h)
- **Logs:** live recent backend errors

## Wiring
- `provisioning/dashboards/provider.yml` loads JSON dashboards from `/etc/grafana/dashboards` (new compose mount).
- `provisioning/datasources/loki.yaml` pins the datasource to `uid: loki` (+`deleteDatasources` so an already-provisioned Grafana adopts the fixed uid the dashboard references).

## Validation (local Loki + Grafana, synthetic nginx/backend JSON logs)
- ✅ Dashboard provisions (10 panels, folder Edukia); datasource re-provisions deterministically to `uid=loki`.
- ✅ Every panel query runs (status-class rates, 5xx error-rate division, backend error count, top endpoints, per-service volume).
- ✅ Fixed p95 to a **single** series via `| json rt="request_time" | unwrap rt` (plain `| json` split it per-uri).
- ✅ End-to-end query works through Grafana's datasource proxy.

No `deploy.yml` change needed — the deploy already ships the whole `observability/` folder; the added Grafana volume mount makes compose recreate Grafana so it re-provisions.

**Next:** Phase 3b — alerting (5xx spike, backend error surge, cert-expiry/uptime). That needs a notification channel — I'll wire Grafana SMTP from the existing `SMTP_*` secrets once you give me the recipient address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)