### PR TITLE
feat(observability): Phase 3b — Grafana alerting to Slack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,7 @@ jobs:
             INFOBIP_DELIVERY_REPORT_NOTIFY_URL=
             INFOBIP_NOTIFY_CONTENT_TYPE=application/json
             GF_SECURITY_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}
+            SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}
             ENV_EOF
 
             # Créer le fichier docker-compose.yml depuis le contenu du repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,8 @@ services:
       GF_SERVER_DOMAIN: grafana.educ-prime.com
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_ANALYTICS_REPORTING_ENABLED: "false"
+      # Referenced by the Slack contact point provisioning ($__env{SLACK_WEBHOOK_URL}).
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/observability/grafana/provisioning/alerting/contactpoints.yml
+++ b/observability/grafana/provisioning/alerting/contactpoints.yml
@@ -1,0 +1,18 @@
+# Slack contact point. The webhook URL is injected from the SLACK_WEBHOOK_URL
+# env var (set in the Grafana container from the PRD secret) — never hard-coded.
+apiVersion: 1
+contactPoints:
+  - orgId: 1
+    name: slack
+    receivers:
+      - uid: slack-webhook
+        type: slack
+        settings:
+          url: $__env{SLACK_WEBHOOK_URL}
+          title: |
+            {{ if eq .Status "firing" }}🔴{{ else }}✅{{ end }} [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
+          text: |
+            {{ range .Alerts }}*{{ .Labels.alertname }}* ({{ .Labels.severity }})
+            {{ .Annotations.summary }}
+            {{ end }}
+        disableResolveMessage: false

--- a/observability/grafana/provisioning/alerting/policies.yml
+++ b/observability/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,9 @@
+# Route all alerts to Slack. Provisioning the root policy replaces the default.
+apiVersion: 1
+policies:
+  - orgId: 1
+    receiver: slack
+    group_by: ['alertname']
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/observability/grafana/provisioning/alerting/rules.yml
+++ b/observability/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,108 @@
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: edukia-logs
+    folder: Edukia Alerts
+    interval: 1m
+    rules:
+      # Backend logged more than 5 ERROR lines in the last 5 minutes.
+      - uid: edukia-backend-errors
+        title: Backend error surge
+        condition: C
+        for: 0m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: warning
+        annotations:
+          summary: '{{ $values.A.Value }} backend ERROR log lines in the last 5m (threshold 5)'
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: loki
+            model:
+              refId: A
+              datasource: { type: loki, uid: loki }
+              editorMode: code
+              queryType: instant
+              expr: 'sum(count_over_time({service="edukia_backend"} | json | __error__="" | level="error" [5m]))'
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator: { type: gt, params: [5] }
+
+      # nginx served more than 10 5xx responses in the last 5 minutes.
+      - uid: edukia-nginx-5xx
+        title: nginx 5xx spike
+        condition: C
+        for: 0m
+        noDataState: OK
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: '{{ $values.A.Value }} nginx 5xx responses in the last 5m (threshold 10)'
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: loki
+            model:
+              refId: A
+              datasource: { type: loki, uid: loki }
+              editorMode: code
+              queryType: instant
+              expr: 'sum(count_over_time({service="edukia_nginx"} | json | __error__="" | status>=500 [5m]))'
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator: { type: gt, params: [10] }
+
+      # Backend produced no logs for 10 minutes (silent / down). noData -> Alerting.
+      - uid: edukia-backend-silent
+        title: Backend has gone silent
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Error
+        labels:
+          severity: critical
+        annotations:
+          summary: 'No backend logs for ~10m — the backend may be down'
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: loki
+            model:
+              refId: A
+              datasource: { type: loki, uid: loki }
+              editorMode: code
+              queryType: instant
+              expr: 'sum(count_over_time({service="edukia_backend"} [10m]))'
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: C
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - type: query
+                  evaluator: { type: lt, params: [1] }


### PR DESCRIPTION
**Phase 3b** — alerting on the logs, delivered to **Slack**.

## What's added (all provisioned)
- **Contact point** (`contactpoints.yml`): Slack, webhook from `$__env{SLACK_WEBHOOK_URL}` (never hard-coded), with a firing/resolved-templated title + text.
- **Notification policy** (`policies.yml`): routes all alerts to Slack (group 30s / repeat 4h).
- **Alert rules** (`rules.yml`), evaluated every 1m:
  | Rule | Condition | Severity |
  |---|---|---|
  | Backend error surge | >5 backend `ERROR` lines / 5m | warning |
  | nginx 5xx spike | >10 nginx 5xx / 5m | critical |
  | Backend has gone silent | no backend logs ~10m (noData→Alerting), `for: 5m` | critical |

## Wiring
- `docker-compose.yml`: pass `SLACK_WEBHOOK_URL` into the Grafana container.
- `deploy.yml`: write `SLACK_WEBHOOK_URL` to the VPS `.env` from the PRD secret (already set).

## Validation — end-to-end, locally
- ✅ Grafana provisions all 3 rules + the Slack contact point + policy with **no errors** (`finished to provision alerting`).
- ✅ Pushed 12 backend errors → **"Backend error surge" fired** and delivered to a mock Slack webhook:
  > 🔴 [FIRING] Backend error surge — *12 backend ERROR log lines in the last 5m (threshold 5)*
- `$values.A.Value` templating renders correctly; red color; resolve notifications enabled.

Deploy: touches `deploy.yml` so it auto-deploys on merge; Grafana recreates and re-provisions the alert rules.

**Deferred to Phase 4:** cert-expiry / endpoint-down alerting needs active probing (Prometheus + blackbox exporter) — that comes with the metrics phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)