### PR TITLE
chore(deploy): add OTP_LOCK_DURATION_MINUTES=1440 to VPS .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,7 @@ jobs:
             OTP_MAX_ATTEMPTS=3
             OTP_RESEND_COOLDOWN_SECONDS=60
             OTP_MAX_RESENDS=2
+            OTP_LOCK_DURATION_MINUTES=1440
             OTP_ANDROID_SMS_HASH=omRcRPVzgWL
             INFOBIP_SMS_ENDPOINT=/sms/2/text/advanced
             INFOBIP_TIMEOUT_MS=10000


### PR DESCRIPTION
Adds `OTP_LOCK_DURATION_MINUTES=1440` to the backend `.env` written by `deploy.yml`.

## Why
It's the one non-sensitive OTP setting that lives in `backend/.env` but was missing from the deploy pipeline's `.env` heredoc. This completes the OTP config block so prod matches local dev.

## Value & scope
- `1440` min (24 h) = the same value already carried locally and the `payment_configuration.otp_lock_duration_minutes` **DB column default**.
- Non-sensitive → set as a plain literal alongside `OTP_MAX_RESENDS`, not a GitHub secret.
- **Note:** the backend currently sources the OTP lock duration from the `payment_configuration` DB row (default 1440), not from `process.env` — so this var is for pipeline/parity completeness and is behaviourally inert until/unless the code adds an env fallback (as the other OTP settings have). Zero behavioural risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)