### PR TITLE
fix(concours): drop unknown 'resource' prop breaking backend build

### DIFF
--- a/backend/src/concours/concours-submissions.service.ts
+++ b/backend/src/concours/concours-submissions.service.ts
@@ -368,7 +368,7 @@ export class ConcoursSubmissionsService {
         // EXAM_REWARD:<uuid> (re-approving does not double-credit).
         if (submission.soumis_par_id != null) {
             this.creditWalletFromExam
-                .execute({ userId: submission.soumis_par_id, examId: savedConcours.uuid, description: 'Concours validé', resource: 'concours' })
+                .execute({ userId: submission.soumis_par_id, examId: savedConcours.uuid, description: 'Concours validé' })
                 .then((res: any) => this.logger.log(`Wallet crédité (concours ${savedConcours.uuid}) pour user ${submission.soumis_par_id}${res?.duplicated ? ' [déjà crédité]' : ''}`))
                 .catch(err => this.logger.error(`Crédit wallet échoué (soumission ${id}): ${err.message}`));
         }


### PR DESCRIPTION
## Problem
`Build and Push Docker Image` → **build-and-push-backend** has been **failing** since #202/#203 (`b168260`, `2e1a7fa`):

```
src/concours/concours-submissions.service.ts:371 — TS2353:
'resource' does not exist in type 'CreditWalletFromValidatedExamCommand'
```

`npm run build` exits 1, so no new backend image is produced.

## Cause
The concours approval's wallet-credit call passed `resource: 'concours'`. That property isn't declared on `CreditWalletFromValidatedExamCommand` and the use-case never reads it (the épreuve caller omits it).

## Fix
Remove `resource: 'concours'` from the call — **no runtime change** (it was never consumed), and it aligns concours with the épreuve caller. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)