### PR TITLE
fix(wallet): register missing GetMyWalletOverviewUseCase provider (backend boot crash / prod 502)

### DIFF
--- a/backend/src/wallet/wallet.module.ts
+++ b/backend/src/wallet/wallet.module.ts
@@ -33,6 +33,7 @@ import { CreditWalletFromValidatedExamUseCase } from './wallet-balance/use-cases
 import { GetMyWalletUseCase } from './wallet-balance/use-cases/get-my-wallet.use-case';
 import { GetMyWalletTransactionsUseCase } from './wallet-balance/use-cases/get-my-wallet-transactions.use-case';
 import { GetMyWalletOverviewUseCase } from './wallet-balance/use-cases/get-my-wallet-overview.use-case';
+import { GetCurrentWithdrawalUseCase } from './wallet-balance/use-cases/get-current-withdrawal.use-case';
 import { RequestWithdrawalUseCase } from './wallet-balance/use-cases/request-withdrawal.use-case';
 import { VerifyWithdrawalOtpUseCase } from './otp/use-cases/verify-withdrawal-otp.use-case';
 import { ResendWithdrawalOtpUseCase } from './otp/use-cases/resend-withdrawal-otp.use-case';
@@ -96,6 +97,7 @@ import { InfobipOtpSmsAdapter } from './otp/infobip-otp-sms.adapter';
     GetMyWalletUseCase,
     GetMyWalletTransactionsUseCase,
     GetMyWalletOverviewUseCase,
+    GetCurrentWithdrawalUseCase,
     RequestWithdrawalUseCase,
     VerifyWithdrawalOtpUseCase,
     ResendWithdrawalOtpUseCase,

--- a/backend/src/wallet/wallet.module.ts
+++ b/backend/src/wallet/wallet.module.ts
@@ -32,6 +32,7 @@ import { CreateWalletForUserUseCase } from './wallet-balance/use-cases/create-wa
 import { CreditWalletFromValidatedExamUseCase } from './wallet-balance/use-cases/credit-wallet-from-validated-exam.use-case';
 import { GetMyWalletUseCase } from './wallet-balance/use-cases/get-my-wallet.use-case';
 import { GetMyWalletTransactionsUseCase } from './wallet-balance/use-cases/get-my-wallet-transactions.use-case';
+import { GetMyWalletOverviewUseCase } from './wallet-balance/use-cases/get-my-wallet-overview.use-case';
 import { RequestWithdrawalUseCase } from './wallet-balance/use-cases/request-withdrawal.use-case';
 import { VerifyWithdrawalOtpUseCase } from './otp/use-cases/verify-withdrawal-otp.use-case';
 import { ResendWithdrawalOtpUseCase } from './otp/use-cases/resend-withdrawal-otp.use-case';
@@ -94,6 +95,7 @@ import { InfobipOtpSmsAdapter } from './otp/infobip-otp-sms.adapter';
     CreditWalletFromValidatedExamUseCase,
     GetMyWalletUseCase,
     GetMyWalletTransactionsUseCase,
+    GetMyWalletOverviewUseCase,
     RequestWithdrawalUseCase,
     VerifyWithdrawalOtpUseCase,
     ResendWithdrawalOtpUseCase,


### PR DESCRIPTION
## Urgent — prod down
After #204 unblocked the backend build, deploying `15c6010` crash-loops the backend (prod **502**):

```
Nest can't resolve dependencies of the WalletController (…, ? at index [2], …).
GetMyWalletOverviewUseCase is not available in the WalletModule context.
```

## Cause
#202/#203 added `GetMyWalletOverviewUseCase` and injected it into `WalletController`, but never registered it in `WalletModule.providers`. DI is a runtime check, so `tsc`/CI build passes — the app only crashes on boot.

## Fix
Import `GetMyWalletOverviewUseCase` and add it to `providers`. Its two deps (`CreateWalletForUserUseCase`, `WITHDRAWAL_REQUEST_REPOSITORY`) are already provided — no other change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)