### PR TITLE
fix(concours+auth): creation date, country-on-create, login error masking

### DIFF
--- a/backend/src/concours/concours.controller.ts
+++ b/backend/src/concours/concours.controller.ts
@@ -26,8 +26,8 @@ export class ConcoursController {
   @UseGuards(JwtAuthGuard, RoleGuard)
   @Roles(RoleType.ADMIN)
   @Post()
-  create(@Body() createConcoursDto: CreateConcoursDto) {
-    return this.concoursService.create(createConcoursDto);
+  create(@CurrentCountry() pays: string, @Body() createConcoursDto: CreateConcoursDto) {
+    return this.concoursService.create(pays, createConcoursDto);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/concours/concours.service.ts
+++ b/backend/src/concours/concours.service.ts
@@ -58,14 +58,14 @@ export class ConcoursService {
     return `${structure.nom} - ${titreRef.nom}`;
   }
 
-  async create(createConcoursDto: CreateConcoursDto) {
-    this.logger.log(`Création d'un concours (structure ${createConcoursDto.structure_id}, titre ${createConcoursDto.titre_id})`);
-    const newConcours = this.concoursRepository.create(createConcoursDto);
+  async create(pays: string, createConcoursDto: CreateConcoursDto) {
+    this.logger.log(`Création d'un concours (pays=${pays}, structure ${createConcoursDto.structure_id}, titre ${createConcoursDto.titre_id})`);
+    const newConcours = this.concoursRepository.create({ ...createConcoursDto, pays });
     // structure_id + titre_id are required at create; the legacy titre column
     // is always server-composed (never the manually-typed value).
     newConcours.titre = await this.composeTitre(createConcoursDto.structure_id, createConcoursDto.titre_id);
     const saved = await this.concoursRepository.save(newConcours);
-    this.logger.log(`Concours créé: ${saved.titre} (ID: ${saved.id})`);
+    this.logger.log(`Concours créé: ${saved.titre} (ID: ${saved.id}, pays: ${saved.pays})`);
     return saved;
   }
 

--- a/backend/src/concours/entities/concours.entity.ts
+++ b/backend/src/concours/entities/concours.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Structure } from '../../structure/entities/structure.entity';
 import { Titre } from '../../titre/entities/titre.entity';
@@ -61,4 +61,8 @@ export class Concours {
     @ManyToOne(() => Titre, { nullable: true })
     @JoinColumn({ name: 'titre_id' })
     titre_ref?: Titre;
+
+    @ApiProperty({ description: 'Date de création de la ressource' })
+    @CreateDateColumn({ name: 'date_creation', type: 'timestamptz' })
+    date_creation: Date;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -91,7 +91,9 @@ class ApiClient {
 
     const data = await response.json();
     this.setToken(data.access_token);
-    localStorage.setItem('refresh_token', data.refresh_token);
+    // /auth/refresh returns only access_token — guard so we don't overwrite the
+    // valid stored refresh token with `undefined` (which corrupts the session).
+    if (data.refresh_token) localStorage.setItem('refresh_token', data.refresh_token);
     console.log('[Auth] ✓ Token rafraîchi');
     return data.access_token;
   }
@@ -134,8 +136,13 @@ class ApiClient {
       });
 
       if (!response.ok) {
-        // Handle 401 Unauthorized - token expired
-        if (response.status === 401 && !isRetry && endpoint !== '/auth/refresh') {
+        // Handle 401 Unauthorized - token expired.
+        // Public auth endpoints return 401 for bad credentials / invalid input,
+        // NOT for an expired access token — skip the refresh flow for them, else
+        // it masks the real error (e.g. "Identifiants invalides") with
+        // "No refresh token available" on a fresh login.
+        const skipRefreshOn401 = ['/auth/connexion', '/auth/register', '/auth/refresh', '/auth/forgot-password', '/auth/reset-password'];
+        if (response.status === 401 && !isRetry && !skipRefreshOn401.includes(endpoint)) {
           if (this.isRefreshing) {
             // Wait for token refresh to complete
             return new Promise((resolve, reject) => {

--- a/frontend/src/lib/services/concours.service.ts
+++ b/frontend/src/lib/services/concours.service.ts
@@ -19,6 +19,8 @@ export interface Concours {
     lieu?: string;
     nombre_page: number;
     nombre_telechargements: number;
+    /** Row creation timestamp (ISO). */
+    date_creation?: string;
     /** Optional reference to the organizing structure (lookup entity). */
     structure_id?: number;
     structure?: Structure;

--- a/frontend/src/pages/Concours.tsx
+++ b/frontend/src/pages/Concours.tsx
@@ -348,7 +348,7 @@ export default function Concours() {
                                             <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                                 <Command shouldFilter={false}>
                                                     <CommandInput placeholder="Rechercher une structure..." value={structureSearch} onValueChange={setStructureSearch} />
-                                                    <CommandList>
+                                                    <CommandList style={{ maxHeight: "min(18rem, calc(var(--radix-popover-content-available-height) - 3.5rem))" }}>
                                                         <CommandEmpty>Aucune structure trouvée.</CommandEmpty>
                                                         <CommandGroup>
                                                             {structuresList.map((s) => (
@@ -379,7 +379,7 @@ export default function Concours() {
                                             <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                                 <Command shouldFilter={false}>
                                                     <CommandInput placeholder="Rechercher un titre..." value={titreSearch} onValueChange={setTitreSearch} />
-                                                    <CommandList>
+                                                    <CommandList style={{ maxHeight: "min(18rem, calc(var(--radix-popover-content-available-height) - 3.5rem))" }}>
                                                         <CommandEmpty>Aucun titre trouvé.</CommandEmpty>
                                                         <CommandGroup>
                                                             {titresList.map((t) => (
@@ -569,7 +569,7 @@ export default function Concours() {
                                         <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                             <Command shouldFilter={false}>
                                                 <CommandInput placeholder="Rechercher une structure..." value={structureSearch} onValueChange={setStructureSearch} />
-                                                <CommandList>
+                                                <CommandList style={{ maxHeight: "min(18rem, calc(var(--radix-popover-content-available-height) - 3.5rem))" }}>
                                                     <CommandEmpty>Aucune structure trouvée.</CommandEmpty>
                                                     <CommandGroup>
                                                         {structuresList.map((s) => (
@@ -599,7 +599,7 @@ export default function Concours() {
                                         <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                             <Command shouldFilter={false}>
                                                 <CommandInput placeholder="Rechercher un titre..." value={titreSearch} onValueChange={setTitreSearch} />
-                                                <CommandList>
+                                                <CommandList style={{ maxHeight: "min(18rem, calc(var(--radix-popover-content-available-height) - 3.5rem))" }}>
                                                     <CommandEmpty>Aucun titre trouvé.</CommandEmpty>
                                                     <CommandGroup>
                                                         {titresList.map((t) => (

--- a/frontend/src/pages/Concours.tsx
+++ b/frontend/src/pages/Concours.tsx
@@ -341,24 +341,24 @@ export default function Concours() {
                                         <Popover open={openStructureCombobox} onOpenChange={setOpenStructureCombobox}>
                                             <PopoverTrigger asChild>
                                                 <Button type="button" variant="outline" role="combobox" aria-expanded={openStructureCombobox} className="w-full justify-between font-normal">
-                                                    <span className="truncate">{selectedStructure ? selectedStructure.nom : "Sélectionner une structure"}</span>
+                                                    <span className="truncate min-w-0 text-left">{selectedStructure ? selectedStructure.nom : "Sélectionner une structure"}</span>
                                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                                 </Button>
                                             </PopoverTrigger>
-                                            <PopoverContent className="w-[300px] p-0">
+                                            <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                                 <Command shouldFilter={false}>
                                                     <CommandInput placeholder="Rechercher une structure..." value={structureSearch} onValueChange={setStructureSearch} />
                                                     <CommandList>
                                                         <CommandEmpty>Aucune structure trouvée.</CommandEmpty>
                                                         <CommandGroup>
                                                             {structuresList.map((s) => (
-                                                                <CommandItem key={s.id} value={s.nom} onSelect={() => {
+                                                                <CommandItem key={s.id} value={s.nom} className="items-start" onSelect={() => {
                                                                     setFormData({ ...formData, structure_id: s.id });
                                                                     setSelectedStructure({ id: s.id, nom: s.nom });
                                                                     setOpenStructureCombobox(false);
                                                                 }}>
-                                                                    <Check className={cn("mr-2 h-4 w-4", formData.structure_id === s.id ? "opacity-100" : "opacity-0")} />
-                                                                    {s.nom}
+                                                                    <Check className={cn("mr-2 mt-0.5 h-4 w-4 shrink-0", formData.structure_id === s.id ? "opacity-100" : "opacity-0")} />
+                                                                    <span className="whitespace-normal break-words">{s.nom}</span>
                                                                 </CommandItem>
                                                             ))}
                                                         </CommandGroup>
@@ -372,24 +372,24 @@ export default function Concours() {
                                         <Popover open={openTitreCombobox} onOpenChange={setOpenTitreCombobox}>
                                             <PopoverTrigger asChild>
                                                 <Button type="button" variant="outline" role="combobox" aria-expanded={openTitreCombobox} className="w-full justify-between font-normal">
-                                                    <span className="truncate">{selectedTitre ? selectedTitre.nom : "Sélectionner un titre"}</span>
+                                                    <span className="truncate min-w-0 text-left">{selectedTitre ? selectedTitre.nom : "Sélectionner un titre"}</span>
                                                     <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                                 </Button>
                                             </PopoverTrigger>
-                                            <PopoverContent className="w-[300px] p-0">
+                                            <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                                 <Command shouldFilter={false}>
                                                     <CommandInput placeholder="Rechercher un titre..." value={titreSearch} onValueChange={setTitreSearch} />
                                                     <CommandList>
                                                         <CommandEmpty>Aucun titre trouvé.</CommandEmpty>
                                                         <CommandGroup>
                                                             {titresList.map((t) => (
-                                                                <CommandItem key={t.id} value={t.nom} onSelect={() => {
+                                                                <CommandItem key={t.id} value={t.nom} className="items-start" onSelect={() => {
                                                                     setFormData({ ...formData, titre_id: t.id });
                                                                     setSelectedTitre({ id: t.id, nom: t.nom });
                                                                     setOpenTitreCombobox(false);
                                                                 }}>
-                                                                    <Check className={cn("mr-2 h-4 w-4", formData.titre_id === t.id ? "opacity-100" : "opacity-0")} />
-                                                                    {t.nom}
+                                                                    <Check className={cn("mr-2 mt-0.5 h-4 w-4 shrink-0", formData.titre_id === t.id ? "opacity-100" : "opacity-0")} />
+                                                                    <span className="whitespace-normal break-words">{t.nom}</span>
                                                                 </CommandItem>
                                                             ))}
                                                         </CommandGroup>
@@ -562,23 +562,23 @@ export default function Concours() {
                                     <Popover open={openStructureCombobox} onOpenChange={setOpenStructureCombobox}>
                                         <PopoverTrigger asChild>
                                             <Button type="button" variant="outline" role="combobox" aria-expanded={openStructureCombobox} className="w-full justify-between font-normal">
-                                                <span className="truncate">{editingItem?.structure ? editingItem.structure.nom : "Sélectionner une structure"}</span>
+                                                <span className="truncate min-w-0 text-left">{editingItem?.structure ? editingItem.structure.nom : "Sélectionner une structure"}</span>
                                                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                             </Button>
                                         </PopoverTrigger>
-                                        <PopoverContent className="w-[300px] p-0">
+                                        <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                             <Command shouldFilter={false}>
                                                 <CommandInput placeholder="Rechercher une structure..." value={structureSearch} onValueChange={setStructureSearch} />
                                                 <CommandList>
                                                     <CommandEmpty>Aucune structure trouvée.</CommandEmpty>
                                                     <CommandGroup>
                                                         {structuresList.map((s) => (
-                                                            <CommandItem key={s.id} value={s.nom} onSelect={() => {
+                                                            <CommandItem key={s.id} value={s.nom} className="items-start" onSelect={() => {
                                                                 setEditingItem(editingItem ? { ...editingItem, structure_id: s.id, structure: { id: s.id, nom: s.nom } } : null);
                                                                 setOpenStructureCombobox(false);
                                                             }}>
-                                                                <Check className={cn("mr-2 h-4 w-4", editingItem?.structure_id === s.id ? "opacity-100" : "opacity-0")} />
-                                                                {s.nom}
+                                                                <Check className={cn("mr-2 mt-0.5 h-4 w-4 shrink-0", editingItem?.structure_id === s.id ? "opacity-100" : "opacity-0")} />
+                                                                <span className="whitespace-normal break-words">{s.nom}</span>
                                                             </CommandItem>
                                                         ))}
                                                     </CommandGroup>
@@ -592,23 +592,23 @@ export default function Concours() {
                                     <Popover open={openTitreCombobox} onOpenChange={setOpenTitreCombobox}>
                                         <PopoverTrigger asChild>
                                             <Button type="button" variant="outline" role="combobox" aria-expanded={openTitreCombobox} className="w-full justify-between font-normal">
-                                                <span className="truncate">{editingItem?.titre_ref ? editingItem.titre_ref.nom : "Sélectionner un titre"}</span>
+                                                <span className="truncate min-w-0 text-left">{editingItem?.titre_ref ? editingItem.titre_ref.nom : "Sélectionner un titre"}</span>
                                                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                                             </Button>
                                         </PopoverTrigger>
-                                        <PopoverContent className="w-[300px] p-0">
+                                        <PopoverContent align="start" className="w-[--radix-popover-trigger-width] min-w-[16rem] p-0">
                                             <Command shouldFilter={false}>
                                                 <CommandInput placeholder="Rechercher un titre..." value={titreSearch} onValueChange={setTitreSearch} />
                                                 <CommandList>
                                                     <CommandEmpty>Aucun titre trouvé.</CommandEmpty>
                                                     <CommandGroup>
                                                         {titresList.map((t) => (
-                                                            <CommandItem key={t.id} value={t.nom} onSelect={() => {
+                                                            <CommandItem key={t.id} value={t.nom} className="items-start" onSelect={() => {
                                                                 setEditingItem(editingItem ? { ...editingItem, titre_id: t.id, titre_ref: { id: t.id, nom: t.nom } } : null);
                                                                 setOpenTitreCombobox(false);
                                                             }}>
-                                                                <Check className={cn("mr-2 h-4 w-4", editingItem?.titre_id === t.id ? "opacity-100" : "opacity-0")} />
-                                                                {t.nom}
+                                                                <Check className={cn("mr-2 mt-0.5 h-4 w-4 shrink-0", editingItem?.titre_id === t.id ? "opacity-100" : "opacity-0")} />
+                                                                <span className="whitespace-normal break-words">{t.nom}</span>
                                                             </CommandItem>
                                                         ))}
                                                     </CommandGroup>


### PR DESCRIPTION
Fixes three dashboard bugs (investigated by a parallel agent team, implemented + verified on the dev stack).

## 1. Concours had no creation date
`concours` entity/table carried no timestamp. Adds `date_creation` (`@CreateDateColumn`, matching `concours_submissions`/`utilisateurs`). Responses (`GET /concours`, grouped `/v1/concours`) return the full entity with no serializer stripping, so it's exposed automatically; frontend `Concours` type updated.
**Requires edukia-db migration 067** (separate PR) — apply to prod first.

## 2. Concours created under Senegal saved as Benin
`POST /concours` never read `@CurrentCountry()` and the service never set `pays`, so the row fell back to the column default `'benin'`. Now the controller passes `@CurrentCountry() pays` and `create(pays, dto)` sets `{ ...dto, pays }`. (Frontend + middleware were already correct — JSON POST carries `pays` in the body.)

## 3. "No refresh token" on login
The 401 interceptor (`api.ts`) ran the token-refresh flow on the **login call's own 401** (bad credentials), throwing `"No refresh token available"` and hiding the real message. Now public `/auth/*` endpoints skip refresh-on-401, so `"Identifiants invalides"` reaches the UI. Also stops overwriting the stored `refresh_token` with `undefined` (the refresh endpoint returns only `access_token`) — which was silently corrupting long sessions.

## Verification (dev stack)
- Create concours with `country=senegal` → row persists `pays='senegal'` **and** `date_creation`.
- All existing concours rows backfilled with `date_creation`.
- Bad-cred login → HTTP 401 `"Identifiants invalides"`.
- `tsc --noEmit` clean (backend + frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)