### PR TITLE
feat(epreuve-submissions): type filter query param + default null type to Examens

### DIFF
--- a/backend/src/epreuves/submissions/epreuve-submissions.controller.ts
+++ b/backend/src/epreuves/submissions/epreuve-submissions.controller.ts
@@ -9,6 +9,7 @@ import { RolesGuard } from '../../auth/guards/roles.guard';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { RoleType } from '../../utilisateurs/entities/utilisateur.entity';
 import { ServiceStatusEnum } from '../../common/enums/service-status.enum';
+import { EpreuveType } from '../entities/epreuve.entity';
 import { CurrentCountry } from '../../common/decorators/current-country.decorator';
 
 // Mounted at 'epreuves/submissions'; registered BEFORE EpreuvesController so
@@ -34,17 +35,20 @@ export class EpreuveSubmissionsController {
   @Get('mine')
   @ApiOperation({ summary: 'Mes soumissions d\'épreuves — les soumissions de l\'utilisateur connecté, infos associées résolues/proposées' })
   @ApiQuery({ name: 'status', required: false, enum: ServiceStatusEnum, description: 'Filtrer par statut (défaut: tous)' })
+  @ApiQuery({ name: 'type', required: false, enum: [EpreuveType.EXAMENS, EpreuveType.EXAMEN_NATIONAL], description: "Filtrer par type d'épreuve (Examens ou Examens Nationaux)" })
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async findMine(
     @CurrentCountry() pays: string,
     @Request() req,
     @Query('status') status?: ServiceStatusEnum,
+    @Query('type') type?: EpreuveType,
     @Query('page') page?: string,
     @Query('limit') limit?: string,
   ) {
     return this.submissionsService.findMine(pays, req.user.utilisateurId, {
       status,
+      type,
       page: page ? parseInt(page) : 1,
       limit: limit ? parseInt(limit) : 10,
     });
@@ -55,16 +59,19 @@ export class EpreuveSubmissionsController {
   @Get()
   @ApiOperation({ summary: 'Lister les soumissions (Admin) — parents manquants signalés' })
   @ApiQuery({ name: 'status', required: false, enum: ServiceStatusEnum, description: 'Filtrer par statut (ex: pending_approval)' })
+  @ApiQuery({ name: 'type', required: false, enum: [EpreuveType.EXAMENS, EpreuveType.EXAMEN_NATIONAL], description: "Filtrer par type d'épreuve (Examens ou Examens Nationaux)" })
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   async findAll(
     @CurrentCountry() pays: string,
     @Query('status') status?: ServiceStatusEnum,
+    @Query('type') type?: EpreuveType,
     @Query('page') page?: string,
     @Query('limit') limit?: string,
   ) {
     return this.submissionsService.findAllForAdmin(pays, {
       status,
+      type,
       page: page ? parseInt(page) : 1,
       limit: limit ? parseInt(limit) : 10,
     });

--- a/backend/src/epreuves/submissions/epreuve-submissions.service.ts
+++ b/backend/src/epreuves/submissions/epreuve-submissions.service.ts
@@ -4,7 +4,7 @@ import { DataSourceResolver } from '../../config/data-source-resolver.service';
 import { MailService } from '../../mail/mail.service';
 import { FilesService } from '../../files/files.service';
 import { EpreuveSubmission } from './entities/epreuve-submission.entity';
-import { Epreuve, EpreuveSection, normalizeEpreuveType } from '../entities/epreuve.entity';
+import { Epreuve, EpreuveSection, EpreuveType, normalizeEpreuveType } from '../entities/epreuve.entity';
 import { Etablissement } from '../../etablissements/entities/etablissement.entity';
 import { Filiere } from '../../filieres/entities/filiere.entity';
 import { NiveauEtude } from '../../niveau-etude/entities/niveau-etude.entity';
@@ -186,7 +186,9 @@ export class EpreuveSubmissionsService {
       uuid: s.uuid,
       pays: s.pays,
       titre: s.titre,
-      type: s.type ?? null,
+      // Défaut EXAMENS à l'affichage : les anciennes soumissions (type NULL en
+      // base, avant migration 071) sont présentées comme « Examens ».
+      type: normalizeEpreuveType(s.type),
       annee: s.annee,
       section: s.section,
       status: s.status,
@@ -232,13 +234,25 @@ export class EpreuveSubmissionsService {
       .leftJoinAndSelect('m_filiere.etablissement', 'm_etab');
   }
 
-  // Admin queue: list submissions (optional status filter), with parents resolved
-  // and missing ones flagged.
+  // Type filter (Examens / Examens Nationaux). Only these two values are
+  // meaningful; anything else is ignored. « Examens » inclut aussi les anciennes
+  // soumissions à type NULL (présentées comme Examens), pour rester cohérent avec
+  // le défaut d'affichage.
+  private applyTypeFilter(qb: import('typeorm').SelectQueryBuilder<EpreuveSubmission>, type?: string) {
+    if (type === EpreuveType.EXAMEN_NATIONAL) {
+      qb.andWhere('submission.type = :ftype', { ftype: EpreuveType.EXAMEN_NATIONAL });
+    } else if (type === EpreuveType.EXAMENS) {
+      qb.andWhere('(submission.type = :ftype OR submission.type IS NULL)', { ftype: EpreuveType.EXAMENS });
+    }
+  }
+
+  // Admin queue: list submissions (optional status + type filters), with parents
+  // resolved and missing ones flagged.
   async findAllForAdmin(
     pays: string,
-    opts: { status?: ServiceStatusEnum; page?: number; limit?: number },
+    opts: { status?: ServiceStatusEnum; type?: string; page?: number; limit?: number },
   ): Promise<PaginationResponse<ReturnType<EpreuveSubmissionsService['toSubmissionResponse']>>> {
-    const { status, page = 1, limit = 10 } = opts;
+    const { status, type, page = 1, limit = 10 } = opts;
     const qb = this.baseSubmissionQuery()
       .leftJoinAndSelect('submission.soumis_par', 'soumis_par')
       .where('submission.pays = :pays', { pays })
@@ -249,6 +263,7 @@ export class EpreuveSubmissionsService {
     if (status) {
       qb.andWhere('submission.status = :status', { status });
     }
+    this.applyTypeFilter(qb, type);
 
     const [rows, total] = await qb.getManyAndCount();
     return {
@@ -269,9 +284,9 @@ export class EpreuveSubmissionsService {
   async findMine(
     pays: string,
     soumisParId: number,
-    opts: { status?: ServiceStatusEnum; page?: number; limit?: number },
+    opts: { status?: ServiceStatusEnum; type?: string; page?: number; limit?: number },
   ): Promise<PaginationResponse<ReturnType<EpreuveSubmissionsService['toSubmissionResponse']>>> {
-    const { status, page = 1, limit = 10 } = opts;
+    const { status, type, page = 1, limit = 10 } = opts;
     const qb = this.baseSubmissionQuery()
       .where('submission.pays = :pays', { pays })
       .andWhere('submission.soumis_par_id = :soumisParId', { soumisParId })
@@ -282,6 +297,7 @@ export class EpreuveSubmissionsService {
     if (status) {
       qb.andWhere('submission.status = :status', { status });
     }
+    this.applyTypeFilter(qb, type);
 
     const [rows, total] = await qb.getManyAndCount();
     return {

--- a/frontend/src/lib/services/epreuve-submissions.service.ts
+++ b/frontend/src/lib/services/epreuve-submissions.service.ts
@@ -57,9 +57,10 @@ export interface ResolveSubmissionData {
 
 export const epreuveSubmissionsService = {
   // Admin list. country is appended by the api GET layer.
-  async list(params?: { status?: string; page?: number; limit?: number }): Promise<PaginationResponse<EpreuveSubmission>> {
+  async list(params?: { status?: string; type?: EpreuveType; page?: number; limit?: number }): Promise<PaginationResponse<EpreuveSubmission>> {
     const qp = new URLSearchParams();
     if (params?.status) qp.append('status', params.status);
+    if (params?.type) qp.append('type', params.type);
     if (params?.page) qp.append('page', params.page.toString());
     if (params?.limit) qp.append('limit', params.limit.toString());
     const qs = qp.toString() ? `?${qp.toString()}` : '';

--- a/frontend/src/pages/EpreuvesApprobation.tsx
+++ b/frontend/src/pages/EpreuvesApprobation.tsx
@@ -408,6 +408,7 @@ function ResolveDialog({ submission, open, onOpenChange }: {
 
 export default function EpreuvesApprobation() {
     const [selectedStatus, setSelectedStatus] = useState<string>("pending_approval");
+    const [selectedType, setSelectedType] = useState<string>("ALL");
     const [page, setPage] = useState(1);
     const [limit, setLimit] = useState(10);
     const [resolveTarget, setResolveTarget] = useState<EpreuveSubmission | null>(null);
@@ -418,9 +419,10 @@ export default function EpreuvesApprobation() {
     const queryClient = useQueryClient();
 
     const { data: response, isLoading, error } = useQuery({
-        queryKey: ['admin-submissions', selectedStatus, page, limit],
+        queryKey: ['admin-submissions', selectedStatus, selectedType, page, limit],
         queryFn: () => epreuveSubmissionsService.list({
             status: selectedStatus === "ALL" ? undefined : selectedStatus,
+            type: selectedType === "ALL" ? undefined : (selectedType as EpreuveSubmission['type']),
             page,
             limit,
         }),
@@ -480,7 +482,7 @@ export default function EpreuvesApprobation() {
                     <CardDescription>
                         <div className="flex flex-col md:flex-row gap-4 mt-4 items-center">
                             <Select value={selectedStatus} onValueChange={(v) => { setSelectedStatus(v); setPage(1); }}>
-                                <SelectTrigger className="w-full md:w-[250px]">
+                                <SelectTrigger className="w-full md:w-[220px]">
                                     <SelectValue placeholder="Filtrer par statut" />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -488,6 +490,16 @@ export default function EpreuvesApprobation() {
                                     <SelectItem value="approved">Approuvées</SelectItem>
                                     <SelectItem value="declined">Refusées</SelectItem>
                                     <SelectItem value="ALL">Tous les statuts</SelectItem>
+                                </SelectContent>
+                            </Select>
+                            <Select value={selectedType} onValueChange={(v) => { setSelectedType(v); setPage(1); }}>
+                                <SelectTrigger className="w-full md:w-[200px]">
+                                    <SelectValue placeholder="Filtrer par type" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="ALL">Tous les types</SelectItem>
+                                    <SelectItem value="Examens">Examens</SelectItem>
+                                    <SelectItem value="Examens Nationaux">Examens Nationaux</SelectItem>
                                 </SelectContent>
                             </Select>
                             <div className="flex items-center gap-2 ml-auto">


### PR DESCRIPTION
Follow-up to #209.

## Changes
- **`?type=` filter** on `GET /epreuves/submissions` (admin) and `/epreuves/submissions/mine`. Values: `Examens`, `Examens Nationaux`. `Examens Nationaux` matches exactly; **`Examens` also includes legacy `NULL`-type rows** so the filter stays consistent with the display default.
- **Null type → `Examens` in responses**: `toSubmissionResponse` returns `normalizeEpreuveType(type)`, so pre-migration-071 submissions (DB `type = NULL`) present as `Examens`.
- **Admin UI**: a "Filtrer par type" dropdown on the approbation page; frontend `list()` forwards the `type` param.

App-only — no DB migration.

## Testing (dev)
Seeded A=`Examens Nationaux`, B=`Examens`, C=`NULL` (legacy):
- no filter → C displays as `Examens` ✅
- `?type=Examens Nationaux` → only A ✅
- `?type=Examens` → B **and** legacy-NULL C, A excluded ✅

Backend + frontend `tsc` clean; dev stack rebuilt & healthy; built bundle contains the new filter UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)