### PR TITLE
fix(observability): ship the frontend nginx logs and stop dropping non-JSON lines

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,8 +1,32 @@
+# This file is mounted as conf.d/default.conf, i.e. inside the image's http{}
+# block, so log_format is valid here. Same shape as the edge proxy's
+# (nginx/nginx.conf) so both nginx layers parse identically under `| json` in
+# Grafana — upstream_response_time is omitted, nothing is proxied from here.
+log_format json_access escape=json
+  '{'
+    '"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"method":"$request_method",'
+    '"uri":"$request_uri",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"referer":"$http_referer",'
+    '"user_agent":"$http_user_agent",'
+    '"x_forwarded_for":"$http_x_forwarded_for",'
+    '"host":"$host",'
+    '"server_name":"$server_name",'
+    '"scheme":"$scheme"'
+  '}';
+
 server {
     listen 80;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Override the image default (`main`, plain text) — see log_format above.
+    access_log /var/log/nginx/access.log json_access;
 
     # Gzip compression
     gzip on;

--- a/observability/vector.yaml
+++ b/observability/vector.yaml
@@ -16,6 +16,13 @@ sources:
     include_containers:
       - edukia_backend
       - edukia_nginx
+      # The SPA container is a SECOND nginx (frontend/Dockerfile is FROM
+      # nginx:alpine) — its access/error logs were invisible in Grafana until
+      # it was allowlisted here.
+      - edukia_frontend
+      # Renewal failures are a site outage waiting to happen; they only ever
+      # showed up in `docker logs`.
+      - edukia_certbot
 
 transforms:
   process:
@@ -43,6 +50,18 @@ transforms:
       msg = replace(msg, r'(?i)"passwd"\s*:\s*"[^"]*"', s'"passwd":"[REDACTED]"')
       msg = replace(msg, r'(?i)"api_?key"\s*:\s*"[^"]*"', s'"api_key":"[REDACTED]"')
       msg = replace(msg, r'(?i)"authorization"\s*:\s*"[^"]*"', s'"authorization":"[REDACTED]"')
+
+      # nginx's error_log format is FIXED — nginx cannot emit JSON there — and
+      # container startup notices are plain text too. Every dashboard and alert
+      # filters with `| json | __error__=""`, so those lines reached Loki and
+      # were then silently dropped at query time. Wrap whatever isn't already a
+      # JSON object so one `| json` pipeline sees every line. Access logs (both
+      # nginx layers) and pino output are already objects and pass through
+      # untouched.
+      parsed, parse_err = parse_json(msg)
+      if parse_err != null || !is_object(parsed) {
+        msg = encode_json({"level": "raw", "service": .service, "message": msg})
+      }
       .message = msg
 
 sinks:


### PR DESCRIPTION
Two blind spots in the `container stdout → Vector → Loki → Grafana` pipeline.

## 1. The frontend container is a second nginx, and it was never shipped

`frontend/Dockerfile` is `FROM nginx:alpine` and serves the SPA, but Vector's allowlist only had `edukia_backend` and `edukia_nginx` — so **none** of its access or error logs ever reached Loki.

`frontend/nginx.conf` also declared no `log_format`, `access_log` or `error_log` at all, so it ran on the image default `main` (plain text). Allowlisting the container alone would have shipped lines that every dashboard immediately drops. It now emits the same `json_access` shape as the edge proxy.

`edukia_certbot` is allowlisted too — a silent renewal failure is a site outage that currently only shows up in `docker logs`.

## 2. Non-JSON lines were shipped, then silently dropped at query time

nginx **cannot** format `error_log` as JSON (the format is fixed), and container startup notices are plain text. Every dashboard and alert filters with `| json | __error__=""`, so those lines sat in Loki and vanished in Grafana.

Vector now wraps anything that isn't already a JSON object:

```json
{"level":"raw","service":"edukia_frontend","message":"<original line>"}
```

Access logs (both nginx layers) and pino output are objects already and pass through untouched.

## Verification

- `vector validate` → passes
- The **real** VRL program, extracted from this config, run against a JSON access log, an nginx `error_log` line, a pino line carrying a `Bearer` token, an nginx `[emerg]` line and a `?secret=` URI: wrapping is correct and both redaction paths still fire
- `nginx -t` passes on the new conf; a live `nginx:alpine` with it logs JSON for a 200 **and** for the asset 404 that used to be invisible

## Deploy notes

- `observability/` is tarred to the VPS by `deploy.yml`, and Vector runs `--watch-config`, so the transform applies without a container recreate
- `frontend/nginx.conf` is baked into the image, so it takes effect once `docker-build.yml` rebuilds the frontend
- No dashboard or alert rule was modified — existing `| json` panels simply start seeing more

🤖 Generated with [Claude Code](https://claude.com/claude-code)