### PR TITLE
fix(app-version): stop force-updating every Flutter build (1.0.13+48 → "required")

### DIFF
--- a/backend/src/app-version/app-version.service.spec.ts
+++ b/backend/src/app-version/app-version.service.spec.ts
@@ -1,0 +1,65 @@
+import { AppVersionService } from './app-version.service';
+
+// compareVersions / determineUpdateType are pure — the resolver is never touched.
+const service = new AppVersionService({} as any);
+
+describe('AppVersionService.compareVersions', () => {
+    it('orders the numeric components, not the strings', () => {
+        expect(service.compareVersions('1.0.10', '1.0.9')).toBe(1);
+        expect(service.compareVersions('1.0.9', '1.0.10')).toBe(-1);
+        expect(service.compareVersions('1.0.9', '1.0.9')).toBe(0);
+        expect(service.compareVersions('1.1.0', '1.0.99')).toBe(1);
+        expect(service.compareVersions('2.0.0', '1.99.99')).toBe(1);
+    });
+
+    // The regression: Flutter reports `version+build`, and `.map(Number)` made
+    // that NaN, which `|| 0` read as patch 0 — so 1.0.13+48 compared as 1.0.0.
+    it('ignores the Flutter +build suffix', () => {
+        expect(service.compareVersions('1.0.13+48', '1.0.9')).toBe(1);
+        expect(service.compareVersions('1.0.13+48', '1.0.13')).toBe(0);
+        expect(service.compareVersions('1.0.2+7', '1.0.9')).toBe(-1);
+        expect(service.compareVersions('1.0.9+1', '1.0.9+999')).toBe(0);
+    });
+
+    it('ignores a pre-release tag and a leading v', () => {
+        expect(service.compareVersions('1.0.13-beta.2', '1.0.9')).toBe(1);
+        expect(service.compareVersions('v1.0.13', '1.0.9')).toBe(1);
+        expect(service.compareVersions('1.0.13-rc1+48', '1.0.13')).toBe(0);
+    });
+
+    it('treats missing components as zero', () => {
+        expect(service.compareVersions('1.0', '1.0.0')).toBe(0);
+        expect(service.compareVersions('1', '1.0.1')).toBe(-1);
+    });
+
+    it('compares equal when a version cannot be parsed, never lower', () => {
+        // A client we cannot read must not be force-updated out of the app.
+        for (const junk of ['', '   ', 'abc', 'nightly', null as any, undefined as any]) {
+            expect(service.compareVersions(junk, '1.0.9')).toBe(0);
+            expect(service.compareVersions('1.0.9', junk)).toBe(0);
+        }
+    });
+});
+
+describe('AppVersionService.determineUpdateType', () => {
+    // The live prod row at the time of the bug: android 1.0.9 / min 1.0.9.
+    const latest = '1.0.9';
+    const min = '1.0.9';
+
+    it('does not force-update a build newer than latest', () => {
+        expect(service.determineUpdateType('1.0.13+48', latest, min)).toBe('up_to_date');
+        expect(service.determineUpdateType('1.0.9+48', latest, min)).toBe('up_to_date');
+    });
+
+    it('still requires an update below the minimum', () => {
+        expect(service.determineUpdateType('1.0.2+7', latest, min)).toBe('required');
+    });
+
+    it('offers an optional update between minimum and latest', () => {
+        expect(service.determineUpdateType('1.0.5+3', '1.0.9', '1.0.2')).toBe('optional');
+    });
+
+    it('lets an unparseable client through instead of locking it out', () => {
+        expect(service.determineUpdateType('nightly', latest, min)).toBe('up_to_date');
+    });
+});

--- a/backend/src/app-version/app-version.service.ts
+++ b/backend/src/app-version/app-version.service.ts
@@ -24,19 +24,39 @@ export class AppVersionService {
     }
 
     /**
+     * Numeric x.y.z core of a version string, or null if it can't be read.
+     * Flutter reports `1.0.13+48` (version+build) and semver allows
+     * `1.0.13-beta.2`; both suffixes are dropped — the build number and the
+     * pre-release tag never decide whether an update is required.
+     */
+    private parseVersion(version: string): number[] | null {
+        const core = (version ?? '').trim().replace(/^v/i, '').split('+')[0].split('-')[0];
+        if (!core) return null;
+        const parts = core.split('.').map((p) => Number.parseInt(p, 10));
+        return parts.some((n) => !Number.isFinite(n)) ? null : parts;
+    }
+
+    /**
      * Compare two semantic versions (x.y.z).
      * Returns:
      *  1 if v1 > v2
      * -1 if v1 < v2
      *  0 if v1 == v2
+     *
+     * An unreadable version compares EQUAL, never lower: this comparison gates
+     * `force_update`, and a client we failed to parse must not be locked out of
+     * the app. (The previous `.map(Number)` turned `1.0.13+48` into NaN, which
+     * `|| 0` then silently read as patch 0 — every Flutter build compared as
+     * x.y.0 and got force-updated.)
      */
     compareVersions(v1: string, v2: string): number {
-        const v1Parts = v1.split('.').map(Number);
-        const v2Parts = v2.split('.').map(Number);
+        const a = this.parseVersion(v1);
+        const b = this.parseVersion(v2);
+        if (a === null || b === null) return 0;
 
         for (let i = 0; i < 3; i++) {
-            const part1 = v1Parts[i] || 0;
-            const part2 = v2Parts[i] || 0;
+            const part1 = a[i] ?? 0;
+            const part2 = b[i] ?? 0;
 
             if (part1 > part2) return 1;
             if (part1 < part2) return -1;


### PR DESCRIPTION
## The bug

Flutter reports `version+build` — the alert device is `v1.0.13+48`. `compareVersions` did:

```ts
const v1Parts = v1.split('.').map(Number);   // "1.0.13+48" → [1, 0, NaN]
const part1 = v1Parts[i] || 0;               // NaN || 0 → 0   ← NaN is falsy
```

So the patch component was silently zeroed and **every Flutter build compared as `x.y.0`**.

Against the live android row (`version 1.0.9`, `minimum_required 1.0.9`, `force_update true`), `1.0.0 < 1.0.9` → `update_type: "required"`. A build **newer** than latest was told to force-update — the app locks its own users behind an update wall.

Reproduced against production before the fix:

| `X-App-Version` | `update_type` |
|---|---|
| `1.0.13+48` | **required** ← newer than latest |
| `1.0.10` | up_to_date |
| `1.1.0` | up_to_date |

The suffix is the trigger, not the numbers. iOS is affected the same way (`minimum_required 1.0.11`).

## The fix

- Parse the numeric `x.y.z` core, dropping `+build`, `-prerelease` and a leading `v`
- **An unparseable version now compares equal, never lower.** This comparison gates `force_update`; a client we failed to read must not be locked out of the app. That is exactly how the original bug did its damage
- `?? 0` rather than `|| 0` for missing components, so a legitimate `0` isn't treated as absent

## Verification

- New spec, 9 cases (the module had none): suffix handling, ordering, short versions, unparseable input. **6 fail against the old implementation**, all 9 pass on the fix
- End-to-end against a local backend on the real schema: `1.0.13+48` → `up_to_date`, `1.0.9+1` → `up_to_date`, `1.0.2+7` → still correctly `required`, `nightly` → `up_to_date`
- The 9 unrelated suites that fail in this repo fail identically with `app-version` excluded — pre-existing, not from this change

## Context

Found while investigating the `connectionTimeout` Slack alert on `GET /app/version/check` from Benin. This is **not** the cause of that timeout (that one is connection-phase, before any handler runs) — it's a separate, more serious bug the investigation surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)