### PR TITLE
fix(nginx): enable HTTP/2 and restrict TLS 1.2 to AEAD ciphers

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,6 +28,40 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+# --- TLS (http context, applies to every server below) ----------------------
+# Nothing here touches ssl_certificate/ssl_certificate_key: the mobile app pins
+# the certificate (see the grafana block below for what re-keying cost us).
+#
+# Pinning the floor explicitly. This matches what nginx 1.29 already does by
+# default — it is here so an image bump can never silently lower it. TLSv1.2 is
+# the floor: Android 5+ negotiates it, and Android 4.x can't validate this
+# ECDSA-only certificate anyway, so no working client is dropped.
+ssl_protocols TLSv1.2 TLSv1.3;
+
+# THIS one changes behaviour. nginx's default (HIGH:!aNULL:!MD5) still accepts
+# CBC + SHA-1 suites — ECDHE-ECDSA-AES128-SHA and -AES256-SHA both negotiated
+# against prod before this. Restricting to AEAD (GCM / ChaCha20-Poly1305) drops
+# the padding-oracle-prone CBC family. Server preference stays OFF so a client
+# without AES hardware — most mid-range Android in our markets — can choose
+# ChaCha20, which is markedly faster there.
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_prefer_server_ciphers off;
+
+# Session tickets are on by default and TLSv1.2 resumption already works
+# (verified against prod: repeated handshakes come back Reused). The shared
+# cache only adds the session-id path for clients that decline a ticket, and
+# shares it across workers. 10m holds roughly 40k sessions.
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 1d;
+
+# Default is 16k: nginx waits for a full record before the first byte can go
+# out. 4k fits a small JSON response in one TCP segment, which matters on the
+# high-latency mobile links our app actually runs on.
+ssl_buffer_size 4k;
+
+# No ssl_stapling: Let's Encrypt retired OCSP and this certificate carries no
+# OCSP URI at all, so enabling it would only log failures.
+
 # HTTP for Frontend, Backend & Grafana : educ-prime.com, api., grafana.
 server {
     listen 80;
@@ -46,6 +80,7 @@ server {
 # HTTPS for Frontend : educ-prime.com
 server {
     listen 443 ssl;
+    http2 on;
     server_name educ-prime.com;
     access_log /var/log/nginx/access.log json_access;
 
@@ -64,6 +99,7 @@ server {
 # HTTPS for Backend : api.educ-prime.com
 server {
     listen 443 ssl;
+    http2 on;
     server_name api.educ-prime.com;
     access_log /var/log/nginx/access.log json_access;
 
@@ -97,6 +133,7 @@ server {
 # certificate pinning).
 server {
     listen 443 ssl;
+    http2 on;
     server_name grafana.educ-prime.com;
     access_log /var/log/nginx/access.log json_access;
 


### PR DESCRIPTION
Measured against production before changing anything, which corrected two assumptions I started with:

| Assumption | Reality |
|---|---|
| TLS 1.0/1.1 still accepted | **Already refused** — nginx 1.29 defaults to 1.2+ |
| No session resumption | **Already works** — TLS 1.2 resumes via tickets (repeated handshakes come back `Reused`) |

So neither needed fixing. Two things genuinely did.

## 1. No HTTP/2

ALPN offered only `http/1.1`, so the admin dashboard opens a fresh connection per parallel request. Enabled `http2 on` on the three TLS servers (the 1.25.1+ directive — `listen … http2` has been deprecated since then).

**Scope note:** the Flutter app will *not* benefit — `dart:io`'s `HttpClient` doesn't speak HTTP/2. This is a dashboard/browser win.

## 2. CBC + SHA-1 suites still negotiated

nginx's default list (`HIGH:!aNULL:!MD5`) accepts legacy CBC suites. Verified against prod:

| Cipher | prod today | with this PR |
|---|---|---|
| `ECDHE-ECDSA-AES128-SHA` | ACCEPTED | refused |
| `ECDHE-ECDSA-AES256-SHA` | ACCEPTED | refused |
| `AES128-GCM` / ChaCha20 | accepted | accepted |

Restricted to the Mozilla intermediate list, leaving only AEAD (GCM / ChaCha20-Poly1305) and dropping the padding-oracle-prone CBC family. `ssl_prefer_server_ciphers` stays **off** so mid-range Android without AES hardware can still choose ChaCha20, which is much faster there.

## Also included

- `ssl_protocols TLSv1.2 TLSv1.3` — no behaviour change today, pinned so an image bump can't silently lower the floor
- `ssl_session_cache shared:SSL:10m` + `ssl_session_timeout 1d` — adds the session-id path alongside the tickets that already work
- `ssl_buffer_size 4k` — a small JSON response leaves in one TCP segment instead of waiting on a 16k record; aimed at the high-latency mobile links in our markets

**Not** included: `ssl_stapling` — Let's Encrypt retired OCSP and this certificate carries no OCSP URI, so it would only log failures.

## Safety

**No certificate or key is touched.** The mobile app pins the certificate — that's why grafana has its own lineage, per the existing comment in this file.

## Verification

Ran `nginx:alpine` with this exact config (dummy certs, upstreams stubbed):

- TLS 1.0 / 1.1 refused, 1.2 / 1.3 accepted
- ALPN negotiates `h2`
- TLS 1.2 resumption still `Reused`
- The CBC suites above now refused
- `nginx -t` passes

## Context

Came out of the `connectionTimeout` investigation on `GET /app/version/check` from Benin. To be clear: **this is hardening, not a fix for that timeout** — the timeout is connection-phase and still undiagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)