### PR TITLE
fix(epreuves): stop presenting the uploading student as the professeur

### DIFF
--- a/backend/src/epreuves/dto/epreuve-response.dto.ts
+++ b/backend/src/epreuves/dto/epreuve-response.dto.ts
@@ -131,7 +131,8 @@ export class RessourceResponseDto {
     nombre_telechargements: number;
 
     @ApiPropertyRessource({ type: () => ProfesseurInRessourceDto })
-    professeur: ProfesseurInRessourceDto;
+    /** `null` si l'auteur du dépôt n'est pas un professeur (cas des dépôts étudiants). */
+    professeur: ProfesseurInRessourceDto | null;
 
     @ApiPropertyRessource({ type: () => MatiereInRessourceDto })
     matiere: MatiereInRessourceDto;
@@ -172,7 +173,8 @@ export class EpreuveResponseDto {
     section: EpreuveSection;
 
     @ApiProperty({ type: () => ProfesseurInEpreuveDto })
-    professeur: ProfesseurInEpreuveDto;
+    /** `null` si l'auteur du dépôt n'est pas un professeur (cas des dépôts étudiants). */
+    professeur: ProfesseurInEpreuveDto | null;
 
     @ApiProperty({ type: () => MatiereInEpreuveDto })
     matiere: MatiereInEpreuveDto;

--- a/backend/src/epreuves/epreuves.service.ts
+++ b/backend/src/epreuves/epreuves.service.ts
@@ -10,6 +10,7 @@ import { FilterEpreuveDto } from './dto/filter-epreuve.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { PaginationResponse } from '../common/interfaces/pagination-response.interface';
 import { EpreuveResponseDto } from './dto/epreuve-response.dto';
+import { professeurPublic } from './professeur-public.util';
 
 @Injectable()
 export class EpreuvesService {
@@ -46,11 +47,7 @@ export class EpreuvesService {
       type: epreuve.type,
       annee: epreuve.annee,
       section: epreuve.section,
-      professeur: {
-        nom: epreuve.professeur.nom,
-        prenom: epreuve.professeur.prenom,
-        telephone: epreuve.professeur.telephone,
-      },
+      professeur: professeurPublic(epreuve.professeur),
       matiere: {
         id: epreuve.matiere.id,
         nom: epreuve.matiere.nom,

--- a/backend/src/epreuves/professeur-public.util.ts
+++ b/backend/src/epreuves/professeur-public.util.ts
@@ -1,0 +1,24 @@
+import { RoleType, Utilisateur } from '../utilisateurs/entities/utilisateur.entity';
+
+/**
+ * `epreuves.professeur_id` est NOT NULL et reçoit l'AUTEUR du dépôt : à
+ * l'approbation d'une soumission c'est l'ÉTUDIANT qui a chargé le PDF
+ * (epreuve-submissions.service.ts). En production ce champ contient 2 705
+ * admins, 387 étudiants, 20 « autre » — et 1 seul vrai professeur ; la réponse
+ * publiait leur `telephone` sur chaque liste d'épreuves.
+ *
+ * Le lien reste en base (audit du dépôt, récompense wallet) mais n'est exposé
+ * que s'il s'agit réellement d'un professeur. La clé `professeur` est conservée
+ * dans la réponse, à `null` sinon : les clients qui l'affichent n'ont rien à
+ * changer, ils cessent simplement de montrer un élève comme enseignant.
+ */
+export function professeurPublic(
+  utilisateur?: Utilisateur | null,
+): { nom: string; prenom: string; telephone: string } | null {
+  if (!utilisateur || utilisateur.role !== RoleType.PROFESSEUR) return null;
+  return {
+    nom: utilisateur.nom,
+    prenom: utilisateur.prenom,
+    telephone: utilisateur.telephone,
+  };
+}

--- a/backend/src/etablissements/etablissements.service.ts
+++ b/backend/src/etablissements/etablissements.service.ts
@@ -17,6 +17,7 @@ import { FilterMatiereDto } from '../matieres/dto/filter-matiere.dto';
 import { FilterEpreuveDto } from '../epreuves/dto/filter-epreuve.dto';
 import { FiliereResponseDto } from '../filieres/dto/filiere-response.dto';
 import { FichiersService } from '../fichiers/fichiers.service';
+import { professeurPublic } from '../epreuves/professeur-public.util';
 
 // Countries whose academic hierarchy is always returned in full, regardless of
 // the `all` query flag. The default lists hide établissements / filières /
@@ -422,11 +423,7 @@ export class EtablissementsService {
         nombre_pages: epreuve.nombre_pages,
         nombre_telechargements: epreuve.nombre_telechargements,
         type: epreuve.type,
-        professeur: {
-          nom: epreuve.professeur.nom,
-          prenom: epreuve.professeur.prenom,
-          telephone: epreuve.professeur.telephone,
-        },
+        professeur: professeurPublic(epreuve.professeur),
         matiere: {
           id: epreuve.matiere.id,
           nom: epreuve.matiere.nom,


### PR DESCRIPTION
## The bug

Approving an épreuve submission sets `epreuves.professeur_id` to the uploader — a **student** — because the column is `NOT NULL` and has no way to express "no teacher" (`epreuve-submissions.service.ts:492`).

The response then publishes that person as the épreuve's *professeur*, **phone number included** (`epreuves.service.ts:49`).

What that field actually holds in production:

| Role of the "professeur" | Épreuves |
|---|---|
| admin | 2 705 |
| **étudiant** | **387** |
| autre | 20 |
| **professeur** | **1** |

So on every épreuve list and detail response, **387 students' phone numbers** were exposed to any API consumer, labelled as the teacher. That's a privacy leak, not only a wrong label.

Concours and examens nationaux have no such column and are unaffected — if it looks present there, those are épreuves with `type = Examens Nationaux`, the same table.

## The fix

`professeur` is populated **only when the linked user actually has `role = professeur`**; otherwise the key is present and `null`.

- **No migration.** The DB link is untouched — it's the audit trail of who uploaded, and what the wallet reward keys on. Only the published payload changes.
- **No breaking rename.** The key stays; clients that render it simply stop showing a student as a teacher.
- Both response sites go through **one shared helper** (`professeur-public.util.ts`) so the rule can't drift: `epreuves.service` (list + detail) and the épreuves nested under `etablissements.service`.

## Verification (dev, both directions)

| Case | Result |
|---|---|
| Épreuve attributed to a real `professeur` | `{"nom":"SOGBOSSI","prenom":"Animic",…}` — still exposed |
| Student-uploaded épreuve | `professeur: null` |
| 20-row listing | 0 professeurs exposed, **no phone in any row** |

I temporarily re-pointed one dev épreuve at a `professeur`-role user to exercise the positive path, then restored it.

## Follow-up, deliberately not here

Showing the uploader honestly as `soumis_par` (rather than hiding them) is the better end state, but it changes the response shape and needs a mobile release. This hotfix stops the leak today without touching clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)