### PR TITLE
feat(mail): new approval email for user-contributed content

### DIFF
--- a/backend/src/mail/mail.service.ts
+++ b/backend/src/mail/mail.service.ts
@@ -3,6 +3,19 @@ import * as nodemailer from 'nodemailer';
 import { ConfigService } from '@nestjs/config';
 import { CountryConfigService } from '../config/country-config.service';
 
+/**
+ * Les titres et noms viennent de données utilisateur (titre d'une soumission,
+ * nom du compte) : ne jamais les injecter bruts dans le HTML d'un mail.
+ */
+function escapeHtml(value: string): string {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 @Injectable()
 export class MailService {
     private transporter: nodemailer.Transporter;
@@ -215,26 +228,48 @@ export class MailService {
 
         let statusText = '';
         let messageHtml = '';
+        // Contenus déposés par les utilisateurs : leur approbation crédite le
+        // wallet, donc le mail parle de gains. Les autres entités qui passent
+        // par cette méthode (offres JobKia…) ne rapportent rien — elles gardent
+        // le message neutre plus bas.
+        const CONTENUS_RECOMPENSES: Record<string, { approuve: string }> = {
+            'épreuve': { approuve: 'approuvée' },   // féminin
+            'examen national': { approuve: 'approuvé' },
+            'concours': { approuve: 'approuvé' },
+        };
 
-        if (status === 'active' || status === 'approved') {
+        if ((status === 'active' || status === 'approved') && CONTENUS_RECOMPENSES[entityType]) {
+            const accord = CONTENUS_RECOMPENSES[entityType].approuve;
+            statusText = accord;
+            messageHtml = `
+        <p>Excellente nouvelle ! 🎉</p>
+        <p>Votre ${entityType} «&nbsp;<strong>${escapeHtml(serviceTitle)}</strong>&nbsp;» a été <strong>${accord}</strong> et est désormais visible par tous les utilisateurs sur EDUKIA.</p>
+        <p>Les revenus générés grâce à vos contenus sont disponibles dans votre <strong>Wallet EDUKIA</strong>.</p>
+        <p>Le retrait de vos gains via Mobile Money sera disponible dès la semaine prochaine. Vous recevrez directement une notification dans l'application vous invitant à renseigner votre numéro Mobile Money afin que nous puissions effectuer le transfert.</p>
+        <p>Merci pour votre confiance et votre contribution à la communauté EDUKIA.</p>`;
+        } else if (status === 'active' || status === 'approved') {
+            // Entités sans récompense (offres JobKia…) : message neutre inchangé.
             statusText = 'approuvé';
-            messageHtml = `<p>Excellente nouvelle ! Votre ${entityType} <strong>"${serviceTitle}"</strong> a été <strong>approuvé</strong> et est maintenant visible par tous les utilisateurs.</p>`;
+            messageHtml = `<p>Excellente nouvelle ! Votre ${entityType} <strong>"${escapeHtml(serviceTitle)}"</strong> a été <strong>approuvé</strong> et est maintenant visible par tous les utilisateurs.</p>`;
         } else if (status === 'declined') {
             statusText = 'refusé';
             const reasonHtml = reason && reason.trim()
-                ? `<p><strong>Motif :</strong> ${reason.trim()}</p>`
+                ? `<p><strong>Motif :</strong> ${escapeHtml(reason.trim())}</p>`
                 : '';
-            messageHtml = `<p>Nous sommes au regret de vous informer que votre ${entityType} <strong>"${serviceTitle}"</strong> a été <strong>refusé</strong>.</p>${reasonHtml}`;
+            messageHtml = `<p>Nous sommes au regret de vous informer que votre ${entityType} <strong>"${escapeHtml(serviceTitle)}"</strong> a été <strong>refusé</strong>.</p>${reasonHtml}`;
         } else {
             // Optional: don't send emails for other status changes
             return;
         }
 
+        const remerciement = CONTENUS_RECOMPENSES[entityType] && (status === 'active' || status === 'approved')
+            ? ''                                    // déjà dit dans le message ci-dessus
+            : `<br/><p>Merci pour votre confiance,</p>`;
+
         const innerContent = `
-        <h2 style="color: #0f172a; margin-top: 0;">Bonjour ${userName},</h2>
+        <h2 style="color: #0f172a; margin-top: 0;">Bonjour ${escapeHtml(userName)},</h2>
         ${messageHtml}
-        <br/>
-        <p>Merci pour votre confiance,</p>
+        ${remerciement}
         <p>L'équipe Edukia</p>
         `;
 


### PR DESCRIPTION
Applies the requested wording to the approval email for **épreuves, examens nationaux et concours** deposited by users.

## The email

> Bonjour {prénom NOM},
>
> Excellente nouvelle ! 🎉
>
> Votre {épreuve|examen national|concours} « {titre} » a été approuvé(e) et est désormais visible par tous les utilisateurs sur EDUKIA.
>
> Les revenus générés grâce à vos contenus sont disponibles dans votre **Wallet EDUKIA**.
>
> Le retrait de vos gains via Mobile Money sera disponible dès la semaine prochaine. Vous recevrez directement une notification dans l'application vous invitant à renseigner votre numéro Mobile Money afin que nous puissions effectuer le transfert.
>
> Merci pour votre confiance et votre contribution à la communauté EDUKIA.

## Scoping — why it keys on entity type

`sendServiceStatusUpdateEmail` is shared with **offres JobKia**, which earn nothing. Rather than change three call sites, the new body is selected by entity type, so:

| | |
|---|---|
| épreuve / examen national / concours, approuvé | new wallet message |
| offre, approuvé | neutral text, unchanged |
| n'importe quoi, refusé | unchanged, motif included |

French agreement follows gender: *votre épreuve a été **approuvée***, *votre concours a été **approuvé***.

## Also fixed here

Titles and names are now **HTML-escaped**. They come from user data (submission title, account name) and were interpolated raw — a title containing `<` or `"` broke the markup. Visible in the sample: an apostrophe in a real concours title now renders as an entity instead of leaking into the HTML.

## Verification

I rendered the five real emails through the compiled service with the transporter intercepted — the three content types, a decline, and an offre. All five correct.

This caught a genuine bug mid-work: my first edit accidentally attached the *refusé* body to the approved branch, so approved offres would have been told they were rejected and declines would have sent nothing at all. The render surfaced it (4 mails for 5 cases); the branch is repaired and re-verified.

## One thing to decide

The copy says withdrawal will be available **« dès la semaine prochaine »**. That's fixed text in a template that ships indefinitely — it will still promise "next week" months from now. Worth replacing with something dateless ("prochainement") or tracking a date to remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)