### PR TITLE
fix(kpi): compter les vraies connexions, pas la dernière de chacun

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { RoleGuard } from './guards/role.guard';
 import { UtilisateursModule } from '../utilisateurs/utilisateurs.module';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { BlacklistedToken } from './entities/blacklisted-token.entity';
+import { LoginEvent } from './entities/login-event.entity';
 import { MailModule } from '../mail/mail.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 
@@ -26,7 +27,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       }),
       inject: [ConfigService],
     }),
-    TypeOrmModule.forFeature([RefreshToken, BlacklistedToken]),
+    TypeOrmModule.forFeature([RefreshToken, BlacklistedToken, LoginEvent]),
     MailModule,
   ],
   controllers: [AuthController],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { RegisterDto } from './dto/register.dto';
 import { Utilisateur } from '../utilisateurs/entities/utilisateur.entity';
 import { RefreshToken, AppareilType } from './entities/refresh-token.entity';
 import { BlacklistedToken } from './entities/blacklisted-token.entity';
+import { LoginEvent } from './entities/login-event.entity';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 import { MailService } from '../mail/mail.service';
@@ -26,6 +27,29 @@ export class AuthService {
 
   private get refreshTokenRepository(): Repository<RefreshToken> {
     return this.resolver.getRepository(RefreshToken);
+  }
+
+  private get loginEventRepository(): Repository<LoginEvent> {
+    return this.resolver.getRepository(LoginEvent);
+  }
+
+  /**
+   * Trace la connexion pour les KPI. En AJOUT SEUL, contrairement à
+   * refresh_tokens dont la ligne est remplacée à chaque connexion.
+   *
+   * Best-effort : une écriture de statistique ne doit jamais faire échouer une
+   * connexion. En cas d'erreur on journalise et on continue.
+   */
+  private async recordLoginEvent(userId: number, pays: string | undefined, appareil?: string) {
+    try {
+      await this.loginEventRepository.insert({
+        utilisateur_id: userId,
+        pays: pays || 'benin',
+        appareil: appareil ?? null,
+      });
+    } catch (error) {
+      this.logger.error(`Journalisation de la connexion échouée (utilisateur ${userId}): ${error.message}`);
+    }
   }
 
   private get blacklistedTokenRepository(): Repository<BlacklistedToken> {
@@ -84,6 +108,8 @@ export class AuthService {
 
     // Generate refresh token (30 days)
     const refreshToken = await this.createRefreshToken(user.id, appareil || AppareilType.WEB);
+
+    await this.recordLoginEvent(user.id, (user as any).pays, appareil || AppareilType.WEB);
 
     this.logger.log(`Connexion réussie: ${user.email} (ID: ${user.id}, Rôle: ${user.role})`);
     return {

--- a/backend/src/auth/entities/login-event.entity.ts
+++ b/backend/src/auth/entities/login-event.entity.ts
@@ -1,0 +1,30 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Une ligne par connexion réussie. Table en AJOUT SEUL : rien n'y est mis à
+ * jour ni supprimé.
+ *
+ * refresh_tokens ne peut pas servir à mesurer les connexions : createRefreshToken
+ * supprime la ligne précédente de l'appareil avant d'en insérer une nouvelle, si
+ * bien qu'il ne reste que la DERNIÈRE connexion de chaque utilisateur. Une
+ * personne qui revient chaque semaine n'apparaît alors que dans la dernière
+ * période, et un même rapport rejoué plus tard donne un chiffre différent.
+ */
+@Entity('login_events')
+export class LoginEvent {
+    @PrimaryGeneratedColumn({ type: 'bigint' })
+    id: string;
+
+    @Column({ name: 'utilisateur_id', type: 'int' })
+    utilisateur_id: number;
+
+    /** Pays du compte au moment de la connexion : les KPI sont scopés par pays. */
+    @Column({ type: 'varchar', length: 50, default: 'benin' })
+    pays: string;
+
+    @Column({ type: 'varchar', length: 20, nullable: true })
+    appareil?: string | null;
+
+    @CreateDateColumn({ name: 'date_creation', type: 'timestamptz' })
+    date_creation: Date;
+}

--- a/backend/src/kpi/kpi.service.ts
+++ b/backend/src/kpi/kpi.service.ts
@@ -22,8 +22,14 @@ import { CountryConfigService } from '../config/country-config.service';
  *    NULL age_group is excluded automatically (not counted). Replaces the former
  *    date_naissance-based computation.
  *  - disability: situation_handicap IS TRUE (booléen).
- *  - logins (KPI 8 / 15): distinct refresh_tokens.utilisateur_id in the period
- *    (refresh_tokens has no pays, so we join utilisateurs for the country scope).
+ *  - logins (KPI 8 / 15): distinct login_events.utilisateur_id in the period.
+ *    login_events is append-only, one row per successful login (migration 073).
+ *    It replaced refresh_tokens, which could not measure this: createRefreshToken
+ *    DELETES the device's previous row before inserting a new one, so only the
+ *    LAST login of each user survived. A user returning every week appeared only
+ *    in the period of their most recent visit, and re-running a report for a past
+ *    period returned a different figure each time. Journal starts 2026-08-11:
+ *    earlier periods legitimately read 0.
  *  - KPI 16: distinct learners with a resource_access row (épreuve|concours) in
  *    the trailing week / 2 weeks / month windows, all anchored on endDate.
  */
@@ -78,7 +84,7 @@ export class KpiService {
       SELECT
         COUNT(DISTINCT rt.utilisateur_id)                                       AS users_logged_in,
         COUNT(DISTINCT rt.utilisateur_id) FILTER (WHERE u.role = 'étudiant')    AS learners_logged_in
-      FROM refresh_tokens rt
+      FROM login_events rt
       JOIN utilisateurs u ON u.id = rt.utilisateur_id
       WHERE u.pays = $1
         AND rt.date_creation >= ${lo}


### PR DESCRIPTION
Les KPI **« utilisateurs connectés »** et **« apprenants connectés »** ne mesuraient pas ce qu'ils annoncent.

## Le défaut

Ils lisaient `refresh_tokens`. Ce n'est pas un journal de connexions : `createRefreshToken()` **supprime** la ligne précédente de l'appareil avant d'en insérer une nouvelle.

En production :

```
18 252 lignes pour 18 249 personnes  →  18 246 personnes n'ont qu'UNE ligne
```

Le champ ne porte donc que la **dernière** connexion de chaque compte :

- une personne qui revient chaque semaine n'est comptée que dans la période de sa dernière visite — l'activité récurrente est invisible ;
- le même rapport rejoué plus tard donne un chiffre **différent** pour un mois passé, la ligne s'étant déplacée entre-temps.

## Le correctif

- `login_events` (migration **073**, PR edukia-db #28) : une ligne par connexion réussie, table en ajout seul.
- `auth.service.login()` y écrit, avec le pays et l'appareil. L'écriture est **best-effort** : une erreur de statistique est journalisée mais ne fait jamais échouer une connexion.
- `kpi.service` compte les personnes distinctes de ce journal sur la période.

## Vérification sur dev

Compte de test, trois connexions successives :

```
login_events : 3 lignes   (refresh_tokens n'en aurait gardé qu'une)
KPI utilisateurs.connectes          = 1
KPI engagement.apprenants_connectes = 1
```

Trois connexions, une personne comptée une fois. Compte et lignes de test supprimés ensuite.

## À savoir avant de déployer

**Le journal démarre vide** : les périodes antérieures au déploiement afficheront 0, légitimement. L'historique n'est pas reconstituable — `refresh_tokens` n'a conservé que la dernière connexion de chaque compte, jamais les précédentes.

Ordre : appliquer 073 et fusionner edukia-db #28 **avant** cette PR, sinon la requête KPI échoue sur une table absente.

## Trouvé pendant l'audit, hors périmètre ici

Trois autres indicateurs sont exacts mais vides, faute de collecte : **zone rurale** (0 « rural », une seule valeur « urbain » sur 32 594 comptes), **situation de handicap** (1 seul `true`), **tranche d'âge** (renseignée pour 1,1 % des comptes). Ils ne sont pas cassés, mais les présenter comme des constats sur la population serait trompeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)