### PR TITLE
ci(deploy): laisser 10 minutes au port 22 au lieu de 2,5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,16 +46,33 @@ jobs:
         env:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_PORT: ${{ secrets.VPS_PORT || 22 }}
+        # Le port 22 n'est filtré NI par le VPS (pas de fail2ban, ufw inactif,
+        # iptables/nftables sans règle sur 22, conntrack à 59/262144) NI par
+        # sshd : lors de l'échec du 2026-08-11, sshd n'a rien journalisé entre
+        # 16:24 (déploiement manuel réussi) et 16:42. Les paquets SYN du runner
+        # n'atteignaient pas la machine — filtrage en amont, côté hébergeur ou
+        # sur le chemin depuis les plages GitHub, et propre à l'IP du runner :
+        # un autre runner s'était connecté huit minutes plus tôt.
+        #
+        # Rien à corriger côté serveur : on attend simplement que ça passe.
+        # 2,5 minutes ne suffisaient pas (échecs des 2026-08-09 et 2026-08-11) ;
+        # 10 minutes couvrent ces deux épisodes, le job SSH qui suit ayant de
+        # toute façon son propre timeout.
         run: |
-          for i in $(seq 1 10); do
+          ATTEMPTS=40
+          DELAY=15
+          for i in $(seq 1 $ATTEMPTS); do
             if timeout 10 bash -c "cat < /dev/null > /dev/tcp/$VPS_HOST/$VPS_PORT" 2>/dev/null; then
               echo "VPS $VPS_HOST:$VPS_PORT reachable (attempt $i)."
               exit 0
             fi
-            echo "Attempt $i: $VPS_HOST:$VPS_PORT not reachable yet, retrying in 15s…"
-            sleep 15
+            # Une ligne toutes les minutes : le journal reste lisible.
+            if [ $((i % 4)) -eq 1 ]; then
+              echo "Attempt $i/$ATTEMPTS: $VPS_HOST:$VPS_PORT not reachable yet, still retrying…"
+            fi
+            sleep $DELAY
           done
-          echo "::error::VPS $VPS_HOST:$VPS_PORT unreachable after 10 attempts (~2.5 min)."
+          echo "::error::VPS $VPS_HOST:$VPS_PORT unreachable after $ATTEMPTS attempts (~10 min). Le VPS répond-il en HTTPS ? Si oui, le filtrage est en amont (hébergeur / chemin réseau) : relancer le job suffit en général."
           exit 1
 
       - name: Déployer sur le VPS


### PR DESCRIPTION
Le déploiement a échoué **deux fois cette semaine** (09/08 et 11/08) sur l'étape `Wait for VPS SSH to be reachable`, alors que le VPS servait normalement en HTTPS. Dans les deux cas, relancer le job a suffi.

## Ce n'est pas le serveur

Vérifié sur la machine :

| Contrôle | Résultat |
|---|---|
| `fail2ban` | **pas installé** |
| `ufw` | inactif |
| `iptables` / `nftables` | règles Docker uniquement, **rien sur le port 22** |
| conntrack | 59 / 262 144 |
| `sshd` | valeurs par défaut |

Et surtout : **`sshd` n'a rien journalisé entre 16:24 et 16:42**, alors que le job a retenté dix fois entre 16:33 et 16:37. Les paquets SYN n'atteignaient pas la machine.

Le 16:24 est parlant : c'est un déploiement manuel, depuis un autre runner, **réussi** — et mon poste joignait le port 22 à 16:41. Le filtrage est donc en amont (hébergeur ou chemin réseau depuis les plages GitHub) et lié à l'IP du runner, pas au serveur ni à une plage horaire (l'historique montre des succès à 03:26, 07:09, 10:23, 16:22, 16:36, 19:45).

## Le correctif

Il n'y a rien à corriger côté serveur : on attend simplement que ça passe.

- **40 tentatives de 15 s (~10 min)** au lieu de 10 (~2,5 min) — couvre les deux épisodes observés
- Journal allégé : une ligne par minute au lieu d'une par tentative
- Message d'erreur final qui oriente le diagnostic (« le VPS répond-il en HTTPS ? alors le filtrage est en amont, relancer suffit en général »)

Le job SSH qui suit garde son propre timeout, donc un VPS réellement mort échoue toujours, simplement 7,5 minutes plus tard.

## Vérification

La sonde `/dev/tcp` a été testée dans les deux sens : port ouvert → succès, port fermé → échec.

Note : mes premiers essais locaux ont échoué à tort, `timeout` n'existant pas sur macOS — il est bien présent sur les runners Ubuntu, où tourne cette étape.

## À part

Le 11/08, GitHub a aussi mis **40 minutes** à marquer le run de build « terminé » (jobs finis à 15:52, run clos à 16:32), ce qui a retardé d'autant le déclenchement du déploiement. Cette PR n'y change rien : un merge vert ne garantit toujours pas un déploiement, et `gh workflow run deploy.yml --ref main` reste le recours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)