### PR TITLE
fix(kpi): compter aussi les sessions renouvelées

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,12 +40,18 @@ export class AuthService {
    * Best-effort : une écriture de statistique ne doit jamais faire échouer une
    * connexion. En cas d'erreur on journalise et on continue.
    */
-  private async recordLoginEvent(userId: number, pays: string | undefined, appareil?: string) {
+  private async recordLoginEvent(
+    userId: number,
+    pays: string | undefined,
+    appareil?: string,
+    type: 'connexion' | 'refresh' = 'connexion',
+  ) {
     try {
       await this.loginEventRepository.insert({
         utilisateur_id: userId,
         pays: pays || 'benin',
         appareil: appareil ?? null,
+        type,
       });
     } catch (error) {
       this.logger.error(`Journalisation de la connexion échouée (utilisateur ${userId}): ${error.message}`);
@@ -196,6 +202,11 @@ export class AuthService {
     // Generate new access token (cross-country, see login())
     const payload = { sub: user.id, email: user.email, role: user.role };
     const accessToken = this.jwtService.sign(payload);
+
+    // Une session renouvelée est une session active : sans cette ligne, seules
+    // les ré-authentifications seraient comptées et les utilisateurs les plus
+    // assidus — ceux qui ne se déconnectent jamais — seraient invisibles.
+    await this.recordLoginEvent(user.id, (user as any).pays, validToken.appareil, 'refresh');
 
     this.logger.log(`Access token rafraîchi pour utilisateur: ${user.email} (ID: ${user.id})`);
     return { access_token: accessToken };

--- a/backend/src/auth/entities/login-event.entity.ts
+++ b/backend/src/auth/entities/login-event.entity.ts
@@ -25,6 +25,15 @@ export class LoginEvent {
     @Column({ type: 'varchar', length: 20, nullable: true })
     appareil?: string | null;
 
+    /**
+     * 'connexion' — identifiants saisis ; 'refresh' — session renouvelée sans
+     * ressaisie. Le jeton d'accès dure 1 jour et celui de rafraîchissement 30 :
+     * sans le second cas, une personne qui garde sa session ouverte n'aurait
+     * produit aucune ligne, et les plus actifs auraient été les moins comptés.
+     */
+    @Column({ type: 'varchar', length: 20, default: 'connexion' })
+    type: string;
+
     @CreateDateColumn({ name: 'date_creation', type: 'timestamptz' })
     date_creation: Date;
 }


### PR DESCRIPTION
Suite de **#221**. Le journal introduit là n'enregistrait que `POST /auth/connexion`.

## Le manque

| | |
|---|---|
| Jeton d'accès | **1 jour** |
| Jeton de rafraîchissement | **30 jours** |

Une personne qui garde sa session ouverte passe par `/auth/refresh` et ne repasse par `/auth/connexion` qu'après une réinstallation, une déconnexion explicite ou 30 jours d'inactivité.

Le journal ne captait donc que les **ré-authentifications** : les utilisateurs les plus assidus — ceux qui ne se déconnectent jamais — n'auraient produit aucune ligne. C'est le défaut que #221 corrigeait, déplacé plutôt que supprimé.

## Le correctif

`refreshAccessToken()` écrit son propre événement, marqué `refresh`, à côté de `connexion`. L'écriture reste **best-effort** : une erreur de statistique est journalisée, jamais levée — un rafraîchissement ne peut pas échouer à cause du compteur.

La requête KPI ne change pas : elle compte déjà les personnes distinctes sur la table. Toutes natures confondues, c'est l'activité réelle ; la colonne `type` permet la ventilation si l'on veut plus tard séparer nouvelles connexions et sessions actives.

## Vérifié sur dev

Un compte, une connexion puis trois renouvellements :

```
id | type      | appareil | date
 4 | connexion | web      | 18:17:20
 5 | refresh   | web      | 18:17:20
 6 | refresh   | web      | 18:17:21
 7 | refresh   | web      | 18:17:22

KPI utilisateurs.connectes          = 1
    engagement.apprenants_connectes = 1
```

Quatre événements, une personne. Compte et lignes de test supprimés ensuite.

`tsc --noEmit` propre, `npm run build` sans erreur.

## Ordre de livraison

Migration **074** (`edukia-db` PR #29) d'abord — elle ajoute la colonne `type`. Elle est additive avec valeur par défaut, donc le code actuellement en production continue de fonctionner entre les deux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)