### PR TITLE
fix(wallet): renvoyer le demandeur et son compte Mobile Money sur les retraits admin

### DIFF
--- a/backend/src/wallet/infrastructure/typeorm-payment.repositories.ts
+++ b/backend/src/wallet/infrastructure/typeorm-payment.repositories.ts
@@ -28,6 +28,7 @@ import {
 } from '../shared/payment.ports';
 import { OtpDeliveryStatus, RewardSourceTypeCode, WalletStatus, WalletTransactionStatus, WalletTransactionType, WithdrawalSecurityStatus, WithdrawalStatus } from '../shared/payment.enums';
 import { WithdrawalOtpStatus } from '../otp/entities/withdrawal-otp.entity';
+import { Utilisateur } from 'src/utilisateurs/entities/utilisateur.entity';
 import { WalletEntity } from '../wallet-balance/entities/wallet.entity';
 import { WalletTransactionEntity } from '../wallet-balance/entities/wallet-transaction.entity';
 import { WalletRestrictionEntity } from '../wallet-balance/entities/wallet-restriction.entity';
@@ -227,9 +228,69 @@ export class TypeOrmWithdrawalRequestRepository implements WithdrawalRequestRepo
   }
 
   async findForAdmin(status?: WithdrawalStatus, page = 1, limit = 20) {
+    const safePage = Number.isFinite(page) && page > 0 ? page : 1;
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 100) : 20;
+
     const where = status ? { status } : {};
-    const [data, total] = await this.repo.findAndCount({ where, order: { createdAt: 'DESC' }, skip: (page - 1) * limit, take: limit });
-    return { data: data.map((row) => this.map(row)), total };
+    const [rows, total] = await this.repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (safePage - 1) * safeLimit,
+      take: safeLimit,
+    });
+    if (!rows.length) return { data: [], total };
+
+    // withdrawal_requests ne porte que le wallet : le demandeur se rejoint par
+    // wallets.user_id. Trois requêtes ciblées plutôt qu'une jointure d'entités,
+    // pour ne jamais charger les colonnes sensibles de `utilisateurs`.
+    const wallets = await this.resolver.getRepository(WalletEntity).find({
+      where: { id: In([...new Set(rows.map((row) => row.walletId))]) },
+      select: ['id', 'userId'],
+    });
+    const userIdByWallet = new Map(wallets.map((wallet) => [wallet.id, wallet.userId]));
+
+    const userIds = [...new Set([...userIdByWallet.values()].filter((id) => id != null))];
+    const users = userIds.length
+      ? await this.resolver.getRepository(Utilisateur).find({
+          where: { id: In(userIds) },
+          select: ['id', 'nom', 'prenom', 'email', 'telephone'],
+        })
+      : [];
+    const userById = new Map(users.map((user) => [user.id, user]));
+
+    const accountIds = [...new Set(rows.map((row) => row.paymentAccountId).filter(Boolean) as string[])];
+    const accounts = accountIds.length
+      ? await this.resolver.getRepository(UserPaymentAccountEntity).find({ where: { id: In(accountIds) } })
+      : [];
+    const accountById = new Map(accounts.map((account) => [account.id, account]));
+
+    const data = rows.map((row) => {
+      const user = userById.get(userIdByWallet.get(row.walletId));
+      const account = row.paymentAccountId ? accountById.get(row.paymentAccountId) : null;
+      return {
+        ...this.map(row),
+        user: user
+          ? {
+              id: user.id,
+              nom: user.nom ?? null,
+              prenom: user.prenom ?? null,
+              email: user.email ?? null,
+              telephone: user.telephone ?? null,
+            }
+          : null,
+        paymentAccount: account
+          ? {
+              id: account.id,
+              operator: account.operator,
+              phoneNumber: account.phoneNumber,
+              accountName: account.accountName ?? null,
+              verified: account.verified,
+            }
+          : null,
+      };
+    });
+
+    return { data, total };
   }
 
   async findByWalletId(walletId: string, page = 1, limit = 50) {

--- a/backend/src/wallet/shared/payment.ports.ts
+++ b/backend/src/wallet/shared/payment.ports.ts
@@ -271,6 +271,28 @@ export interface WithdrawalRequestModel {
   createdAt: Date;
 }
 
+/**
+ * Vue admin d'une demande de retrait. `withdrawal_requests` ne porte que le
+ * wallet : sans ces deux blocs, l'écran d'approbation affiche une demande sans
+ * savoir qui la fait ni vers quel numéro payer.
+ */
+export interface AdminWithdrawalRequestModel extends WithdrawalRequestModel {
+  user?: {
+    id: number;
+    nom: string | null;
+    prenom: string | null;
+    email: string | null;
+    telephone: string | null;
+  } | null;
+  paymentAccount?: {
+    id: string;
+    operator: MobileMoneyProvider;
+    phoneNumber: string;
+    accountName: string | null;
+    verified: boolean;
+  } | null;
+}
+
 export interface WithdrawalRequestRepositoryPort {
   create(data: {
     walletId: string;
@@ -284,7 +306,7 @@ export interface WithdrawalRequestRepositoryPort {
   }): Promise<WithdrawalRequestModel>;
   findById(id: string): Promise<WithdrawalRequestModel | null>;
   findOpenByWalletId(walletId: string): Promise<WithdrawalRequestModel | null>;
-  findForAdmin(status?: WithdrawalStatus, page?: number, limit?: number): Promise<{ data: WithdrawalRequestModel[]; total: number }>;
+  findForAdmin(status?: WithdrawalStatus, page?: number, limit?: number): Promise<{ data: AdminWithdrawalRequestModel[]; total: number }>;
   findByWalletId(walletId: string, page?: number, limit?: number): Promise<{ data: WithdrawalRequestModel[]; total: number }>;
   findWalletActivityHistory(walletId: string, page?: number, limit?: number): Promise<{ data: WalletActivityHistoryItemModel[]; total: number }>;
   findWithPaymentDetailsByUserId(userId: number, page?: number, limit?: number): Promise<{ data: any[]; total: number }>;


### PR DESCRIPTION
## Le symptôme

Sur **Approbations > Wallet > Retraits**, la colonne « Utilisateur » affiche `—` pour toutes les lignes. Le numéro Mobile Money affiche « non renseigné ».

## La cause

Le front lit `w.user` et `w.paymentAccount`. L'API ne les a **jamais envoyés**.

`findForAdmin` interrogeait `withdrawal_requests` seule. Cette table n'a aucune clé vers une personne — seulement `wallet_id`. Le mappage renvoyait donc les montants, le statut, l'échéance… et rien sur le demandeur.

La donnée existe : `wallets.user_id -> utilisateurs` remonte **les 12 demandes de production sans un seul trou**, et `payment_account_id` est renseigné sur les 12.

## Pourquoi c'est plus qu'un confort d'affichage

Le paiement Mobile Money est effectué **à la main** par l'administrateur, qui devait donc virer de l'argent sans voir à qui ni vers quel numéro. Le numéro manquant est le plus gênant des deux.

## Le correctif

Trois requêtes ciblées après la page — wallets, utilisateurs, comptes de paiement — plutôt qu'une jointure d'entités. Les colonnes de `utilisateurs` sont **listées explicitement** (`id`, `nom`, `prenom`, `email`, `telephone`), donc le condensat de mot de passe n'est jamais chargé, même en mémoire.

Au passage : `page` et `limit` sont bornées comme partout ailleurs dans ce fichier. `?page=abc` produisait un `skip` à `NaN`.

Aucun changement côté front : le contrat qu'il attendait est simplement honoré.

## Vérifié sur dev

7 demandes, avec et sans filtre de statut :

```
filtre ''         : total=7 sans_demandeur=0 champs_inattendus=aucun
filtre 'PENDING'  : total=3 sans_demandeur=0 champs_inattendus=aucun
filtre 'PAID'     : total=2 sans_demandeur=0 champs_inattendus=aucun

recherche de « password » / « mot_de_passe » / condensat bcrypt : 0 occurrence
```

Les deux lignes sans `paymentAccount` sur dev ont un `payment_account_id` nul en base — jeu de test, pas un défaut. En production, aucune.

Exemple de charge utile désormais renvoyée :

```json
"user": { "id": 2950, "nom": "…", "prenom": "…", "email": "…", "telephone": null },
"paymentAccount": { "operator": "MOOV_MONEY", "phoneNumber": "+229 …", "accountName": "…", "verified": true }
```

`tsc --noEmit` propre, build sans erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)